### PR TITLE
fix: handle custom timestamp types in MissingTimestamps check

### DIFF
--- a/lib/ash_credo/check/design/missing_timestamps.ex
+++ b/lib/ash_credo/check/design/missing_timestamps.ex
@@ -26,8 +26,19 @@ defmodule AshCredo.Check.Design.MissingTimestamps do
       """
     ]
 
+  # Ash is not a runtime dependency of ash_credo - users bring their own.
+  # Suppress compile-time warnings; guarded at runtime by `with_compiled_check`.
   alias AshCredo.Introspection
   alias AshCredo.Introspection.Compiled, as: CompiledIntrospection
+
+  @compile {:no_warn_undefined, [Ash.Type, Ash.Type.NewType]}
+
+  @datetime_storage_types [
+    :utc_datetime,
+    :utc_datetime_usec,
+    :naive_datetime,
+    :naive_datetime_usec
+  ]
 
   @impl true
   def run(%SourceFile{} = source_file, params) do
@@ -117,14 +128,24 @@ defmodule AshCredo.Check.Design.MissingTimestamps do
   # PK attributes produced by e.g. `uuid_primary_key :id` - which are
   # also non-writable with a default function - don't satisfy the
   # create-timestamp predicate and mask a missing `create_timestamp`.
+  #
+  # Custom types like `AshPostgres.TimestamptzUsec` override `storage_type/1`
+  # to return a DB-specific atom (e.g. `:"timestamptz(6)"`), so we cannot
+  # rely on `Ash.Type.storage_type/2` alone. Instead we resolve through
+  # `Ash.Type.NewType.subtype_of/1` to find the base Ash type and check
+  # *its* storage type against the known datetime storage atoms.
   defp datetime_attribute_type?(type) when is_atom(type) and not is_nil(type) do
     type
-    |> Atom.to_string()
-    |> String.downcase()
-    |> String.contains?("datetime")
+    |> resolve_base_type()
+    |> Ash.Type.storage_type([])
+    |> Kernel.in(@datetime_storage_types)
   end
 
   defp datetime_attribute_type?(_), do: false
+
+  defp resolve_base_type(type) do
+    if Ash.Type.NewType.new_type?(type), do: Ash.Type.NewType.subtype_of(type), else: type
+  end
 
   defp missing_timestamps_issue(module_ast, context, issue_meta) do
     attrs_ast = Introspection.find_dsl_section(module_ast, :attributes)

--- a/lib/ash_credo/check/design/missing_timestamps.ex
+++ b/lib/ash_credo/check/design/missing_timestamps.ex
@@ -26,19 +26,8 @@ defmodule AshCredo.Check.Design.MissingTimestamps do
       """
     ]
 
-  # Ash is not a runtime dependency of ash_credo - users bring their own.
-  # Suppress compile-time warnings; guarded at runtime by `with_compiled_check`.
   alias AshCredo.Introspection
   alias AshCredo.Introspection.Compiled, as: CompiledIntrospection
-
-  @compile {:no_warn_undefined, [Ash.Type, Ash.Type.NewType]}
-
-  @datetime_storage_types [
-    :utc_datetime,
-    :utc_datetime_usec,
-    :naive_datetime,
-    :naive_datetime_usec
-  ]
 
   @impl true
   def run(%SourceFile{} = source_file, params) do
@@ -128,24 +117,7 @@ defmodule AshCredo.Check.Design.MissingTimestamps do
   # PK attributes produced by e.g. `uuid_primary_key :id` - which are
   # also non-writable with a default function - don't satisfy the
   # create-timestamp predicate and mask a missing `create_timestamp`.
-  #
-  # Custom types like `AshPostgres.TimestamptzUsec` override `storage_type/1`
-  # to return a DB-specific atom (e.g. `:"timestamptz(6)"`), so we cannot
-  # rely on `Ash.Type.storage_type/2` alone. Instead we resolve through
-  # `Ash.Type.NewType.subtype_of/1` to find the base Ash type and check
-  # *its* storage type against the known datetime storage atoms.
-  defp datetime_attribute_type?(type) when is_atom(type) and not is_nil(type) do
-    type
-    |> resolve_base_type()
-    |> Ash.Type.storage_type([])
-    |> Kernel.in(@datetime_storage_types)
-  end
-
-  defp datetime_attribute_type?(_), do: false
-
-  defp resolve_base_type(type) do
-    if Ash.Type.NewType.new_type?(type), do: Ash.Type.NewType.subtype_of(type), else: type
-  end
+  defp datetime_attribute_type?(type), do: CompiledIntrospection.datetime_type?(type)
 
   defp missing_timestamps_issue(module_ast, context, issue_meta) do
     attrs_ast = Introspection.find_dsl_section(module_ast, :attributes)

--- a/lib/ash_credo/introspection/compiled.ex
+++ b/lib/ash_credo/introspection/compiled.ex
@@ -40,7 +40,14 @@ defmodule AshCredo.Introspection.Compiled do
   # Suppress compile-time warnings for the remote calls below; they are guarded
   # at runtime by `ash_available?/0`.
   @compile {:no_warn_undefined,
-            [Ash.Resource.Info, Ash.Domain.Info, Ash.Policy.Info, Ash.Policy.Authorizer]}
+            [
+              Ash.Resource.Info,
+              Ash.Domain.Info,
+              Ash.Policy.Info,
+              Ash.Policy.Authorizer,
+              Ash.Type,
+              Ash.Type.NewType
+            ]}
 
   @cache_key_tag {__MODULE__, :cache}
   @domain_refs_key_tag {__MODULE__, :domain_refs}
@@ -577,6 +584,33 @@ defmodule AshCredo.Introspection.Compiled do
     :persistent_term.erase(@ash_missing_warned_key)
     :persistent_term.erase(@not_loadable_warned_key)
     :ok
+  end
+
+  @datetime_storage_types [
+    :utc_datetime,
+    :utc_datetime_usec,
+    :naive_datetime,
+    :naive_datetime_usec
+  ]
+
+  @doc """
+  Returns `true` if `type` is a datetime attribute type, resolving through
+  `Ash.Type.NewType.subtype_of/1` for custom NewTypes (e.g.
+  `AshPostgres.TimestamptzUsec`) whose `storage_type/1` returns a DB-specific
+  atom rather than a standard Ecto datetime type.
+  """
+  @spec datetime_type?(term()) :: boolean()
+  def datetime_type?(type) when is_atom(type) and not is_nil(type) do
+    type
+    |> resolve_base_type()
+    |> Ash.Type.storage_type([])
+    |> Kernel.in(@datetime_storage_types)
+  end
+
+  def datetime_type?(_), do: false
+
+  defp resolve_base_type(type) do
+    if Ash.Type.NewType.new_type?(type), do: Ash.Type.NewType.subtype_of(type), else: type
   end
 
   # ── Private ──

--- a/lib/ash_credo/introspection/compiled.ex
+++ b/lib/ash_credo/introspection/compiled.ex
@@ -39,6 +39,8 @@ defmodule AshCredo.Introspection.Compiled do
   # Ash is not a runtime dependency of ash_credo - users bring their own.
   # Suppress compile-time warnings for the remote calls below; they are guarded
   # at runtime by `ash_available?/0`.
+  alias Ash.Type.NewType
+
   @compile {:no_warn_undefined,
             [
               Ash.Resource.Info,
@@ -602,16 +604,12 @@ defmodule AshCredo.Introspection.Compiled do
   @spec datetime_type?(term()) :: boolean()
   def datetime_type?(type) when is_atom(type) and not is_nil(type) do
     type
-    |> resolve_base_type()
+    |> NewType.subtype_of()
     |> Ash.Type.storage_type([])
     |> Kernel.in(@datetime_storage_types)
   end
 
   def datetime_type?(_), do: false
-
-  defp resolve_base_type(type) do
-    if Ash.Type.NewType.new_type?(type), do: Ash.Type.NewType.subtype_of(type), else: type
-  end
 
   # ── Private ──
 

--- a/test/ash_credo/check/design/missing_timestamps_test.exs
+++ b/test/ash_credo/check/design/missing_timestamps_test.exs
@@ -61,6 +61,18 @@ defmodule AshCredo.Check.Design.MissingTimestampsTest do
     assert [] = run_check(MissingTimestamps, source)
   end
 
+  test "no issue when timestamps use a custom type (e.g. AshPostgres.TimestamptzUsec)" do
+    source = """
+    defmodule AshCredoFixtures.Blog.CustomTimestamps do
+      use Ash.Resource,
+        domain: AshCredoFixtures.Blog,
+        data_layer: AshPostgres.DataLayer
+    end
+    """
+
+    assert [] = run_check(MissingTimestamps, source)
+  end
+
   test "ignores embedded resources (no data layer at the AST level)" do
     source = """
     defmodule AshCredoFixtures.Blog.SomeEmbedded do

--- a/test/support/fixtures/ash_fixtures.ex
+++ b/test/support/fixtures/ash_fixtures.ex
@@ -1,3 +1,18 @@
+defmodule AshCredoFixtures.CustomTimestampType do
+  @moduledoc """
+  A custom Ash NewType that is a subtype of `:utc_datetime_usec` but overrides
+  `storage_type` to return a DB-specific atom. Mimics
+  `AshPostgres.TimestamptzUsec` for testing `MissingTimestamps` with custom
+  timestamp types whose module name does not contain "datetime" and whose
+  `storage_type` is not in the standard set.
+  """
+
+  use Ash.Type.NewType, subtype_of: :utc_datetime_usec
+
+  @impl true
+  def storage_type(_), do: :"timestamptz(6)"
+end
+
 defmodule AshCredoFixtures.Blog.Post do
   @moduledoc """
   Fixture resource used by `UseCodeInterface` tests. Intentionally covers
@@ -56,6 +71,7 @@ defmodule AshCredoFixtures.Blog do
 
     resource AshCredoFixtures.Blog.Article
     resource AshCredoFixtures.Blog.PartialTimestamps
+    resource AshCredoFixtures.Blog.CustomTimestamps
     resource AshCredoFixtures.Blog.Tag
     resource AshCredoFixtures.Blog.Empty
     resource AshCredoFixtures.Blog.WithAuthorizer
@@ -203,6 +219,30 @@ defmodule AshCredoFixtures.Blog.PartialTimestamps do
     uuid_primary_key :id
     attribute :title, :string, public?: true
     update_timestamp :updated_at
+  end
+end
+
+defmodule AshCredoFixtures.Blog.CustomTimestamps do
+  @moduledoc """
+  `MissingTimestamps` happy-path fixture: uses a custom timestamp type
+  (`AshCredoFixtures.CustomTimestampType`) whose module name does not contain
+  "datetime". Exercises the `Ash.Type.storage_type/2` resolution path.
+  """
+
+  use Ash.Resource,
+    domain: AshCredoFixtures.Blog,
+    validate_domain_inclusion?: false
+
+  actions do
+    defaults [:read]
+    default_accept []
+  end
+
+  attributes do
+    uuid_primary_key :id
+    attribute :title, :string, public?: true
+    create_timestamp :inserted_at, type: AshCredoFixtures.CustomTimestampType
+    update_timestamp :updated_at, type: AshCredoFixtures.CustomTimestampType
   end
 end
 


### PR DESCRIPTION
## Summary

The `MissingTimestamps` check previously used string matching on the type module name (checking if it contained "datetime") to identify timestamp attributes. This caused false positives for custom types like `AshPostgres.TimestamptzUsec` whose module name does not contain "datetime".

This replaces that approach with proper Ash type resolution: resolving through `Ash.Type.NewType.subtype_of/1` to find the base type and checking its `storage_type/2` against known datetime storage atoms (`:utc_datetime`, `:utc_datetime_usec`, `:naive_datetime`, `:naive_datetime_usec`).

## Test plan

- [x] New test: "no issue when timestamps use a custom type" verifies the fix with a `CustomTimestampType` fixture that mimics `AshPostgres.TimestamptzUsec`
- [x] Existing tests continue to pass (standard datetime types still recognized)