### PR TITLE
fix: skip embedded resources in MissingCodeInterface

### DIFF
--- a/lib/ash_credo/check/design/missing_code_interface.ex
+++ b/lib/ash_credo/check/design/missing_code_interface.ex
@@ -3,6 +3,9 @@ defmodule AshCredo.Check.Design.MissingCodeInterface do
     base_priority: :low,
     category: :design,
     tags: [:ash],
+    param_defaults: [
+      exclude_actions: []
+    ],
     explanations: [
       check: """
       Resources with actions but no `code_interface` block miss out on Ash's
@@ -28,12 +31,28 @@ defmodule AshCredo.Check.Design.MissingCodeInterface do
             end
           end
 
+      ## Configuration
+
+      Use `exclude_actions` to skip specific actions (e.g. auto-generated
+      by extensions like AshAuthentication):
+
+          {AshCredo.Check.Design.MissingCodeInterface,
+           exclude_actions: [
+             {MyApp.Accounts.User, :sign_in_with_password},
+             {MyApp.Accounts.Token, :expunge_expired}
+           ]}
+
+      Each entry is a `{Module, :action_name}` tuple.
+
       ## Requirements
 
       Your project must be compiled before running `mix credo`. If Ash is
       not available in the VM running Credo, the check is a no-op and emits
       a single diagnostic.
-      """
+      """,
+      params: [
+        exclude_actions: "List of `{Module, :action_name}` tuples to skip."
+      ]
     ]
 
   alias AshCredo.Introspection
@@ -42,6 +61,7 @@ defmodule AshCredo.Check.Design.MissingCodeInterface do
   @impl true
   def run(%SourceFile{} = source_file, params) do
     issue_meta = IssueMeta.for(source_file, params)
+    exclude_actions = Params.get(params, :exclude_actions, __MODULE__)
 
     CompiledIntrospection.with_compiled_check(
       fn ->
@@ -54,22 +74,23 @@ defmodule AshCredo.Check.Design.MissingCodeInterface do
       fn ->
         source_file
         |> Introspection.resource_contexts()
-        |> Enum.flat_map(&check_resource(&1, issue_meta))
+        |> Enum.flat_map(&check_resource(&1, issue_meta, exclude_actions))
       end
     )
   end
 
-  defp check_resource(%{absolute_segments: nil}, _issue_meta), do: []
+  defp check_resource(%{absolute_segments: nil}, _issue_meta, _exclude_actions), do: []
 
   defp check_resource(
          %{absolute_segments: segments, module_ast: module_ast} = context,
-         issue_meta
+         issue_meta,
+         exclude_actions
        ) do
     resource = Module.concat(segments)
 
     with false <- Introspection.embedded_resource?(context),
          {:ok, info} <- CompiledIntrospection.inspect_module(resource) do
-      flag_missing_interfaces(resource, info, module_ast, context, issue_meta)
+      flag_missing_interfaces(resource, info, module_ast, context, issue_meta, exclude_actions)
     else
       true ->
         []
@@ -89,13 +110,19 @@ defmodule AshCredo.Check.Design.MissingCodeInterface do
          %{actions: actions, interfaces: interfaces, domain: resource_domain},
          module_ast,
          context,
-         issue_meta
+         issue_meta,
+         exclude_actions
        ) do
     actions_line = actions_section_line(module_ast, context)
 
     actions
+    |> Enum.reject(&action_excluded?(&1, resource, exclude_actions))
     |> Enum.reject(&action_has_interface?(&1, interfaces, resource_domain, resource))
     |> Enum.map(&missing_interface_issue(&1, resource, actions_line, issue_meta))
+  end
+
+  defp action_excluded?(action, resource, exclude_actions) do
+    {resource, action.name} in exclude_actions
   end
 
   defp action_has_interface?(action, interfaces, resource_domain, resource) do

--- a/lib/ash_credo/check/design/missing_code_interface.ex
+++ b/lib/ash_credo/check/design/missing_code_interface.ex
@@ -65,22 +65,23 @@ defmodule AshCredo.Check.Design.MissingCodeInterface do
          %{absolute_segments: segments, module_ast: module_ast} = context,
          issue_meta
        ) do
-    resource = Module.concat(segments)
-
-    with false <- Introspection.embedded_resource?(context),
-         {:ok, info} <- CompiledIntrospection.inspect_module(resource) do
-      flag_missing_interfaces(resource, info, module_ast, context, issue_meta)
+    if Introspection.embedded_resource?(context) do
+      []
     else
-      true ->
-        []
+      resource = Module.concat(segments)
 
-      {:error, :not_loadable} ->
-        CompiledIntrospection.with_unique_not_loadable(resource, fn ->
-          not_loadable_issue(resource, context, issue_meta)
-        end)
+      case CompiledIntrospection.inspect_module(resource) do
+        {:ok, info} ->
+          flag_missing_interfaces(resource, info, module_ast, context, issue_meta)
 
-      {:error, _} ->
-        []
+        {:error, :not_loadable} ->
+          CompiledIntrospection.with_unique_not_loadable(resource, fn ->
+            not_loadable_issue(resource, context, issue_meta)
+          end)
+
+        {:error, _} ->
+          []
+      end
     end
   end
 

--- a/lib/ash_credo/check/design/missing_code_interface.ex
+++ b/lib/ash_credo/check/design/missing_code_interface.ex
@@ -3,9 +3,6 @@ defmodule AshCredo.Check.Design.MissingCodeInterface do
     base_priority: :low,
     category: :design,
     tags: [:ash],
-    param_defaults: [
-      exclude_actions: []
-    ],
     explanations: [
       check: """
       Resources with actions but no `code_interface` block miss out on Ash's
@@ -31,28 +28,12 @@ defmodule AshCredo.Check.Design.MissingCodeInterface do
             end
           end
 
-      ## Configuration
-
-      Use `exclude_actions` to skip specific actions (e.g. auto-generated
-      by extensions like AshAuthentication):
-
-          {AshCredo.Check.Design.MissingCodeInterface,
-           exclude_actions: [
-             {MyApp.Accounts.User, :sign_in_with_password},
-             {MyApp.Accounts.Token, :expunge_expired}
-           ]}
-
-      Each entry is a `{Module, :action_name}` tuple.
-
       ## Requirements
 
       Your project must be compiled before running `mix credo`. If Ash is
       not available in the VM running Credo, the check is a no-op and emits
       a single diagnostic.
-      """,
-      params: [
-        exclude_actions: "List of `{Module, :action_name}` tuples to skip."
-      ]
+      """
     ]
 
   alias AshCredo.Introspection
@@ -61,7 +42,6 @@ defmodule AshCredo.Check.Design.MissingCodeInterface do
   @impl true
   def run(%SourceFile{} = source_file, params) do
     issue_meta = IssueMeta.for(source_file, params)
-    exclude_actions = Params.get(params, :exclude_actions, __MODULE__)
 
     CompiledIntrospection.with_compiled_check(
       fn ->
@@ -74,23 +54,22 @@ defmodule AshCredo.Check.Design.MissingCodeInterface do
       fn ->
         source_file
         |> Introspection.resource_contexts()
-        |> Enum.flat_map(&check_resource(&1, issue_meta, exclude_actions))
+        |> Enum.flat_map(&check_resource(&1, issue_meta))
       end
     )
   end
 
-  defp check_resource(%{absolute_segments: nil}, _issue_meta, _exclude_actions), do: []
+  defp check_resource(%{absolute_segments: nil}, _issue_meta), do: []
 
   defp check_resource(
          %{absolute_segments: segments, module_ast: module_ast} = context,
-         issue_meta,
-         exclude_actions
+         issue_meta
        ) do
     resource = Module.concat(segments)
 
     with false <- Introspection.embedded_resource?(context),
          {:ok, info} <- CompiledIntrospection.inspect_module(resource) do
-      flag_missing_interfaces(resource, info, module_ast, context, issue_meta, exclude_actions)
+      flag_missing_interfaces(resource, info, module_ast, context, issue_meta)
     else
       true ->
         []
@@ -110,19 +89,13 @@ defmodule AshCredo.Check.Design.MissingCodeInterface do
          %{actions: actions, interfaces: interfaces, domain: resource_domain},
          module_ast,
          context,
-         issue_meta,
-         exclude_actions
+         issue_meta
        ) do
     actions_line = actions_section_line(module_ast, context)
 
     actions
-    |> Enum.reject(&action_excluded?(&1, resource, exclude_actions))
     |> Enum.reject(&action_has_interface?(&1, interfaces, resource_domain, resource))
     |> Enum.map(&missing_interface_issue(&1, resource, actions_line, issue_meta))
-  end
-
-  defp action_excluded?(action, resource, exclude_actions) do
-    {resource, action.name} in exclude_actions
   end
 
   defp action_has_interface?(action, interfaces, resource_domain, resource) do

--- a/lib/ash_credo/check/design/missing_code_interface.ex
+++ b/lib/ash_credo/check/design/missing_code_interface.ex
@@ -67,9 +67,12 @@ defmodule AshCredo.Check.Design.MissingCodeInterface do
        ) do
     resource = Module.concat(segments)
 
-    case CompiledIntrospection.inspect_module(resource) do
-      {:ok, info} ->
-        flag_missing_interfaces(resource, info, module_ast, context, issue_meta)
+    with false <- Introspection.embedded_resource?(context),
+         {:ok, info} <- CompiledIntrospection.inspect_module(resource) do
+      flag_missing_interfaces(resource, info, module_ast, context, issue_meta)
+    else
+      true ->
+        []
 
       {:error, :not_loadable} ->
         CompiledIntrospection.with_unique_not_loadable(resource, fn ->

--- a/lib/ash_credo/check/design/missing_code_interface.ex
+++ b/lib/ash_credo/check/design/missing_code_interface.ex
@@ -33,6 +33,11 @@ defmodule AshCredo.Check.Design.MissingCodeInterface do
       Your project must be compiled before running `mix credo`. If Ash is
       not available in the VM running Credo, the check is a no-op and emits
       a single diagnostic.
+
+      ## Notes
+
+      Embedded resources are skipped by this check, since they typically
+      do not need a code interface.
       """
     ]
 
@@ -69,19 +74,22 @@ defmodule AshCredo.Check.Design.MissingCodeInterface do
       []
     else
       resource = Module.concat(segments)
+      inspect_resource(resource, module_ast, context, issue_meta)
+    end
+  end
 
-      case CompiledIntrospection.inspect_module(resource) do
-        {:ok, info} ->
-          flag_missing_interfaces(resource, info, module_ast, context, issue_meta)
+  defp inspect_resource(resource, module_ast, context, issue_meta) do
+    case CompiledIntrospection.inspect_module(resource) do
+      {:ok, info} ->
+        flag_missing_interfaces(resource, info, module_ast, context, issue_meta)
 
-        {:error, :not_loadable} ->
-          CompiledIntrospection.with_unique_not_loadable(resource, fn ->
-            not_loadable_issue(resource, context, issue_meta)
-          end)
+      {:error, :not_loadable} ->
+        CompiledIntrospection.with_unique_not_loadable(resource, fn ->
+          not_loadable_issue(resource, context, issue_meta)
+        end)
 
-        {:error, _} ->
-          []
-      end
+      {:error, _} ->
+        []
     end
   end
 

--- a/test/ash_credo/check/design/missing_code_interface_test.exs
+++ b/test/ash_credo/check/design/missing_code_interface_test.exs
@@ -89,6 +89,16 @@ defmodule AshCredo.Check.Design.MissingCodeInterfaceTest do
     refute "publish" in triggers
   end
 
+  test "no issue for embedded resources" do
+    source = """
+    defmodule MyApp.Blog.PostMetadata do
+      use Ash.Resource, data_layer: :embedded
+    end
+    """
+
+    assert [] = run_check(MissingCodeInterface, source)
+  end
+
   test "ignores non-Ash modules" do
     source = """
     defmodule MyApp.Utils do


### PR DESCRIPTION
Hey @leonqadirie ! Here's the PR for #80. I finally removed this https://github.com/leonqadirie/ash_credo/pull/81#pullrequestreview-4120848912 to leave the PR as concise as posible. I can open another PR for that if you want :)

## Summary

- Skip embedded resources (`data_layer: :embedded`) in `MissingCodeInterface` check, as they cannot be registered in a domain, and requiring `code_interface` blocks on them is a false positive.
- Add `embedded_resource?` guard at the top of `check_resource/2` using a `with` clause, matching the existing pattern in `MissingDomain`.
- Add test for embedded resource skip.

Closes #80

## Test plan

- [x] All 379 existing tests pass
- [x] New test `"no issue for embedded resources"` passes
- [x] Verified embedded resources with `data_layer: :embedded` produce zero issues