### PR TITLE
feat!: add excluded_paths param to AuthorizeFalse check

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ The following checks accept custom parameters:
 | Check | Parameter | Default | Description |
 |---|---|---|---|
 | `Warning.AuthorizeFalse` | `include_non_ash_calls` | `true` | When `false`, only checks Ash API calls and action DSL definitions |
+| `Warning.AuthorizeFalse` | `excluded_paths` | `[~r"/test/", "test"]` | Paths or regexes to skip. Defaults to test directories where `authorize?: false` is typically intentional |
 | `Warning.MissingMacroDirective` | `macro_modules` | `[Ash.Query, Ash.Expr]` | Modules whose qualified macro calls the check validates. Macros are read from `module.__info__(:macros)`, so only real macros are flagged |
 | `Warning.SensitiveAttributeExposed` | `sensitive_names` | `~w(password hashed_password password_hash token secret api_key private_key ssn)a` | Attribute names to flag when not marked `sensitive?: true` |
 | `Warning.SensitiveFieldInAccept` | `dangerous_fields` | `~w(is_admin admin permissions api_key secret_key)a` | Field names to flag when found in `accept` lists |

--- a/lib/ash_credo/check/warning/authorize_false.ex
+++ b/lib/ash_credo/check/warning/authorize_false.ex
@@ -3,7 +3,10 @@ defmodule AshCredo.Check.Warning.AuthorizeFalse do
     base_priority: :high,
     category: :warning,
     tags: [:ash, :security],
-    param_defaults: [include_non_ash_calls: true],
+    param_defaults: [
+      include_non_ash_calls: true,
+      excluded_paths: [~r"/test/", "test"]
+    ],
     explanations: [
       check: """
       Using `authorize?: false` bypasses Ash authorization entirely, making it
@@ -31,13 +34,20 @@ defmodule AshCredo.Check.Warning.AuthorizeFalse do
       wrapper functions. Set `include_non_ash_calls: false` to restrict detection
       to Ash API calls and action DSL definitions only.
 
+      Test directories are excluded by default, since bypassing authorization in
+      test setup and factories is typically intentional. Override `excluded_paths`
+      to scope the check differently.
+
       In either mode the check is purely syntactic: it cannot follow values through
       variables, config lookups, or function return values.
       """,
       params: [
         include_non_ash_calls:
           "When `true` (default), flags `authorize?: false` anywhere in source. " <>
-            "When `false`, only checks Ash API calls and action DSL definitions."
+            "When `false`, only checks Ash API calls and action DSL definitions.",
+        excluded_paths:
+          "List of paths or regexes to exclude from this check. " <>
+            "Defaults to test directories, since `authorize?: false` is intentional in test setup."
       ]
     ]
 
@@ -45,24 +55,40 @@ defmodule AshCredo.Check.Warning.AuthorizeFalse do
 
   @impl true
   def run(%SourceFile{} = source_file, params) do
-    issue_meta = IssueMeta.for(source_file, params)
+    excluded_paths = Params.get(params, :excluded_paths, __MODULE__)
 
-    lines =
-      if Params.get(params, :include_non_ash_calls, __MODULE__) do
-        all_authorize_false_lines(source_file)
-      else
-        ash_authorize_false_lines(source_file)
-      end
+    if ignore_path?(source_file.filename, excluded_paths) do
+      []
+    else
+      issue_meta = IssueMeta.for(source_file, params)
 
-    Enum.map(lines, fn line ->
-      format_issue(issue_meta,
-        message:
-          "`authorize?: false` bypasses authorization. Use system actors with bypass policies instead.",
-        trigger: "authorize?: false",
-        line_no: line
-      )
-    end)
+      lines =
+        if Params.get(params, :include_non_ash_calls, __MODULE__) do
+          all_authorize_false_lines(source_file)
+        else
+          ash_authorize_false_lines(source_file)
+        end
+
+      Enum.map(lines, fn line ->
+        format_issue(issue_meta,
+          message:
+            "`authorize?: false` bypasses authorization. Use system actors with bypass policies instead.",
+          trigger: "authorize?: false",
+          line_no: line
+        )
+      end)
+    end
   end
+
+  defp ignore_path?(filename, excluded_paths) do
+    directory = Path.dirname(filename)
+    Enum.any?(excluded_paths, &matches_path?(directory, &1))
+  end
+
+  defp matches_path?(directory, %Regex{} = regex), do: Regex.match?(regex, directory)
+
+  defp matches_path?(directory, path) when is_binary(path),
+    do: String.starts_with?(directory, path)
 
   defp ash_authorize_false_lines(source_file) do
     call_lines =

--- a/test/ash_credo/check/warning/authorize_false_test.exs
+++ b/test/ash_credo/check/warning/authorize_false_test.exs
@@ -277,4 +277,60 @@ defmodule AshCredo.Check.Warning.AuthorizeFalseTest do
     assert [issue] = run_check(AuthorizeFalse, source)
     assert issue.trigger == "authorize?: false"
   end
+
+  describe "excluded_paths" do
+    test "skips files under test/ by default" do
+      source = """
+      defmodule MyApp.UserTest do
+        def setup_user do
+          Ash.read!(MyApp.User, authorize?: false)
+        end
+      end
+      """
+
+      assert [] = run_check(AuthorizeFalse, source, __filename__: "test/my_app/user_test.exs")
+    end
+
+    test "skips nested directories under test/" do
+      source = """
+      Ash.read!(MyApp.User, authorize?: false)
+      """
+
+      assert [] = run_check(AuthorizeFalse, source, __filename__: "test/support/factories.ex")
+    end
+
+    test "still flags lib/ files" do
+      source = """
+      defmodule MyApp.Accounts do
+        def list_users, do: Ash.read!(MyApp.User, authorize?: false)
+      end
+      """
+
+      assert [_] = run_check(AuthorizeFalse, source, __filename__: "lib/my_app/accounts.ex")
+    end
+
+    test "respects an empty excluded_paths override" do
+      source = """
+      Ash.read!(MyApp.User, authorize?: false)
+      """
+
+      assert [_] =
+               run_check(AuthorizeFalse, source,
+                 __filename__: "test/my_app/user_test.exs",
+                 excluded_paths: []
+               )
+    end
+
+    test "respects a custom excluded_paths list" do
+      source = """
+      Ash.read!(MyApp.User, authorize?: false)
+      """
+
+      assert [] =
+               run_check(AuthorizeFalse, source,
+                 __filename__: "priv/seeds.exs",
+                 excluded_paths: ["priv"]
+               )
+    end
+  end
 end

--- a/test/support/check_case.ex
+++ b/test/support/check_case.ex
@@ -15,8 +15,10 @@ defmodule AshCredo.CheckCase do
   end
 
   def run_check(check_module, source_code, params \\ []) do
+    {filename, params} = Keyword.pop(params, :__filename__, "test_file.ex")
+
     source_code
-    |> source_file()
+    |> source_file(filename)
     |> check_module.run(params)
   end
 end


### PR DESCRIPTION
BREAKING CHANGE: AuthorizeFalse doesn't check in test directory (technically non-breaking in SemVer) by default