### PR TITLE
fix: skip uniqueness checks in embedded resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,8 @@ If you have any compiled-introspection checks enabled, run `mix compile` before 
 | `LargeResource` | Refactor | Low | No | Flags resource files exceeding 400 lines |
 | `RaisingCall` | Refactor | Low | No | Flags Ash bang calls - top-level `Ash.read!`/`Ash.create!`/`Ash.Filter.parse!` plus code-interface bangs like `MyApp.Blog.create_post!`. Orphan bangs (those without a non-bang counterpart, e.g. `Ash.stream!`, `Ash.Seed.seed!`) are detected dynamically and skipped. Test directories excluded by default. **Requires compiled project.** |
 | `UseCodeInterface` | Refactor | Normal | No | Flags `Ash.*` calls where both resource and action are literals - names the exact code interface function to call instead. **Requires compiled project** and **configurable** (see below). Pair with `Warning.UnknownAction` for typo detection. |
-| `MissingCodeInterface` | Design | Low | No | Flags each action that has no code interface (resource- or domain-level). **Requires compiled project.** |
-| `MissingIdentity` | Design | Normal | No | Suggests identities for attributes like `email`, `username`, `slug`. **Requires compiled project.** |
+| `MissingCodeInterface` | Design | Low | No | Flags each action on non-embedded resources that has no code interface (resource- or domain-level). **Requires compiled project.** |
+| `MissingIdentity` | Design | Normal | No | Suggests identities for attributes like `email`, `username`, `slug` on non-embedded resources. **Requires compiled project.** |
 | `MissingPrimaryAction` | Design | Normal | No | Flags missing `primary?: true` when multiple actions of the same type exist. **Requires compiled project.** |
 | `MissingTimestamps` | Design | Normal | No | Suggests adding `timestamps()` to persisted resources. **Requires compiled project.** |
 | `ActionMissingDescription` | Readability | Low | No | Flags actions without a `description` |

--- a/lib/ash_credo/check/design/missing_code_interface.ex
+++ b/lib/ash_credo/check/design/missing_code_interface.ex
@@ -95,10 +95,11 @@ defmodule AshCredo.Check.Design.MissingCodeInterface do
          issue_meta,
          excluded_actions
        ) do
-    if Introspection.embedded_resource?(context) do
+    resource = Module.concat(segments)
+
+    if CompiledIntrospection.embedded?(resource) do
       []
     else
-      resource = Module.concat(segments)
       inspect_resource(resource, module_ast, context, issue_meta, excluded_actions)
     end
   end

--- a/lib/ash_credo/check/design/missing_identity.ex
+++ b/lib/ash_credo/check/design/missing_identity.ex
@@ -68,6 +68,14 @@ defmodule AshCredo.Check.Design.MissingIdentity do
        ) do
     resource = Module.concat(segments)
 
+    if CompiledIntrospection.embedded?(resource) do
+      []
+    else
+      inspect_resource(resource, context, candidates, issue_meta)
+    end
+  end
+
+  defp inspect_resource(resource, context, candidates, issue_meta) do
     case CompiledIntrospection.inspect_module(resource) do
       {:ok, info} ->
         flag_missing_identities(resource, info, context, candidates, issue_meta)

--- a/lib/ash_credo/introspection/compiled.ex
+++ b/lib/ash_credo/introspection/compiled.ex
@@ -81,6 +81,7 @@ defmodule AshCredo.Introspection.Compiled do
 
   @type info_map :: %{
           resource?: boolean(),
+          embedded?: boolean(),
           domain: module() | nil,
           interfaces: [struct()],
           calculation_interfaces: [struct()],
@@ -301,6 +302,16 @@ defmodule AshCredo.Introspection.Compiled do
   @spec resource?(module()) :: boolean()
   def resource?(module) when is_atom(module) do
     match?({:ok, %{resource?: true}}, inspect_module(module))
+  end
+
+  @doc """
+  Returns `true` if `module` is a loaded Ash resource flagged as embedded
+  (via `Ash.Resource.Info.embedded?/1`). Returns `false` for non-embedded
+  resources, non-resources, and unloadable modules.
+  """
+  @spec embedded?(module()) :: boolean()
+  def embedded?(module) when is_atom(module) do
+    match?({:ok, %{embedded?: true}}, inspect_module(module))
   end
 
   @doc """
@@ -670,6 +681,7 @@ defmodule AshCredo.Introspection.Compiled do
           {:ok,
            %{
              resource?: true,
+             embedded?: ResourceInfo.embedded?(module),
              domain: ResourceInfo.domain(module),
              interfaces: ResourceInfo.interfaces(module),
              calculation_interfaces: ResourceInfo.calculation_interfaces(module),

--- a/test/ash_credo/check/design/missing_code_interface_test.exs
+++ b/test/ash_credo/check/design/missing_code_interface_test.exs
@@ -88,7 +88,7 @@ defmodule AshCredo.Check.Design.MissingCodeInterfaceTest do
 
   test "no issue for embedded resources" do
     source = """
-    defmodule MyApp.Blog.PostMetadata do
+    defmodule AshCredoFixtures.Accounts.EmbeddedContact do
       use Ash.Resource, data_layer: :embedded
     end
     """

--- a/test/ash_credo/check/design/missing_identity_test.exs
+++ b/test/ash_credo/check/design/missing_identity_test.exs
@@ -58,6 +58,16 @@ defmodule AshCredo.Check.Design.MissingIdentityTest do
              run_check(MissingIdentity, source, identity_candidates: ~w(slug handle phone)a)
   end
 
+  test "ignores embedded resources" do
+    source = """
+    defmodule AshCredoFixtures.Accounts.EmbeddedContact do
+      use Ash.Resource, data_layer: :embedded
+    end
+    """
+
+    assert [] = run_check(MissingIdentity, source)
+  end
+
   test "ignores non-Ash modules" do
     source = """
     defmodule MyApp.Utils do

--- a/test/support/fixtures/ash_fixtures.ex
+++ b/test/support/fixtures/ash_fixtures.ex
@@ -147,6 +147,21 @@ defmodule AshCredoFixtures.Accounts.Profile do
   end
 end
 
+defmodule AshCredoFixtures.Accounts.EmbeddedContact do
+  @moduledoc """
+  `MissingIdentity` embedded-resource fixture: declares `data_layer: :embedded`
+  and an `:email` attribute with no covering identity. Identities on embedded
+  resources are silently ignored by Ash (the `Ash.DataLayer.Simple` data layer
+  has no identity enforcement), so the check must skip them.
+  """
+
+  use Ash.Resource, data_layer: :embedded
+
+  attributes do
+    attribute :email, :string, public?: true
+  end
+end
+
 defmodule AshCredoFixtures.Accounts do
   @moduledoc "Fixture domain for cross-domain tests."
 


### PR DESCRIPTION
Closes #122.

Also use the _compiled_ embedded? helper in `MissingCodeInterface` check.