### PR TITLE
feat!: hoist `PinnedTimeInExpression` check to be enabled by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Enable additional checks by adding them to the `extra` section of your `.credo.e
 }
 ```
 
-To enable **all** checks at once (`Warning.MissingChangeWrapper`, `Warning.MissingMacroDirective`, and `Warning.PinnedTimeInExpression` are already on by default and do not need an entry):
+To enable **all** checks at once (the default-on checks listed above do not need an entry):
 
 ```elixir
 checks: %{

--- a/README.md
+++ b/README.md
@@ -11,7 +11,11 @@ AshCredo detects common anti-patterns, security pitfalls, and missing best pract
 > [!WARNING]
 > This project is experimental and might break frequently.
 
-**Note: Only `MissingChangeWrapper` and `MissingMacroDirective` are enabled by default.** All other checks are opt-in - enable them individually in your `.credo.exs` (see [Configuration](#configuration)).
+**Note: only the following checks are enabled by default.** All other checks are opt-in - enable them individually in your `.credo.exs` (see [Configuration](#configuration)).
+
+- `Warning.MissingChangeWrapper`
+- `Warning.MissingMacroDirective`
+- `Warning.PinnedTimeInExpression`
 
 ## Installation
 
@@ -78,7 +82,7 @@ If you have any compiled-introspection checks enabled, run `mix compile` before 
 | `MissingPrimaryKey` | Warning | High | No | Ensures resources with data layers have a primary key |
 | `NoActions` | Warning | Normal | No | Flags resources with data layers but no actions defined. **Requires compiled project.** |
 | `OverlyPermissivePolicy` | Warning | High | No | Flags unscoped `authorize_if always()` policies |
-| `PinnedTimeInExpression` | Warning | High | No | Flags `^Date.utc_today()` / `^DateTime.utc_now()` in Ash expressions (frozen at compile time) |
+| `PinnedTimeInExpression` | Warning | High | Yes | Flags `^Date.utc_today()` / `^DateTime.utc_now()` in Ash expressions (frozen at compile time) |
 | `SensitiveAttributeExposed` | Warning | High | No | Flags sensitive attributes (password, token, secret, ...) not marked `sensitive?: true` |
 | `SensitiveFieldInAccept` | Warning | High | No | Flags privilege-escalation fields (`is_admin`, `permissions`, ...) in `accept` lists |
 | `UnknownAction` | Warning | High | No | Flags `Ash.*` calls referencing actions that do not exist on the resolved resource, with a fuzzy `Did you mean` hint. **Requires compiled project.** |
@@ -156,7 +160,7 @@ Enable additional checks by adding them to the `extra` section of your `.credo.e
 }
 ```
 
-To enable **all** checks at once (`Warning.MissingChangeWrapper` and `Warning.MissingMacroDirective` are already on by default and do not need an entry):
+To enable **all** checks at once (`Warning.MissingChangeWrapper`, `Warning.MissingMacroDirective`, and `Warning.PinnedTimeInExpression` are already on by default and do not need an entry):
 
 ```elixir
 checks: %{
@@ -168,7 +172,6 @@ checks: %{
     {AshCredo.Check.Warning.MissingPrimaryKey, []},
     {AshCredo.Check.Warning.NoActions, []},
     {AshCredo.Check.Warning.OverlyPermissivePolicy, []},
-    {AshCredo.Check.Warning.PinnedTimeInExpression, []},
     {AshCredo.Check.Warning.SensitiveAttributeExposed, []},
     {AshCredo.Check.Warning.SensitiveFieldInAccept, []},
     {AshCredo.Check.Warning.UnknownAction, []},

--- a/lib/ash_credo.ex
+++ b/lib/ash_credo.ex
@@ -36,7 +36,7 @@ defmodule AshCredo do
             {AshCredo.Check.Warning.MissingPrimaryKey, false},
             {AshCredo.Check.Warning.NoActions, false},
             {AshCredo.Check.Warning.OverlyPermissivePolicy, false},
-            {AshCredo.Check.Warning.PinnedTimeInExpression, false},
+            {AshCredo.Check.Warning.PinnedTimeInExpression, []},
             {AshCredo.Check.Warning.SensitiveAttributeExposed, false},
             {AshCredo.Check.Warning.SensitiveFieldInAccept, false},
             {AshCredo.Check.Warning.UnknownAction, false},

--- a/test/ash_credo_test.exs
+++ b/test/ash_credo_test.exs
@@ -16,7 +16,8 @@ defmodule AshCredoTest do
   # "enable all checks" README block.
   @default_on_checks [
     {"Warning", "MissingChangeWrapper"},
-    {"Warning", "MissingMacroDirective"}
+    {"Warning", "MissingMacroDirective"},
+    {"Warning", "PinnedTimeInExpression"}
   ]
 
   # A check requires a compiled project iff it aliases
@@ -155,6 +156,43 @@ defmodule AshCredoTest do
       assert_category_ordering(
         enable_all_entries,
         ~s("enable all checks" block in #{@readme_file})
+      )
+    end
+
+    test "default-on bullet list in #{@readme_file} matches @default_on_checks" do
+      readme_content = File.read!(@readme_file)
+
+      bullet_block =
+        case Regex.run(
+               ~r/\*\*Note: only the following checks are enabled by default.*?\n((?:- `[\w.]+`\n)+)/s,
+               readme_content,
+               capture: :all_but_first
+             ) do
+          [block] ->
+            block
+
+          _ ->
+            flunk(~s(Could not find the "enabled by default" bullet list in #{@readme_file}))
+        end
+
+      bullet_entries =
+        Regex.scan(~r/- `(\w+)\.(\w+)`/, bullet_block)
+        |> Enum.map(fn [_full, category, name] -> {category, name} end)
+
+      assert_set_equality(
+        @default_on_checks,
+        bullet_entries,
+        fn {cat, name} ->
+          ~s(AshCredo.Check.#{cat}.#{name} is in @default_on_checks but missing from the "enabled by default" bullet list in #{@readme_file})
+        end,
+        fn {cat, name} ->
+          ~s(`#{cat}.#{name}` is listed in the "enabled by default" bullet list in #{@readme_file} but not in @default_on_checks)
+        end
+      )
+
+      assert_category_ordering(
+        bullet_entries,
+        ~s("enabled by default" bullet list in #{@readme_file})
       )
     end
 


### PR DESCRIPTION
BREAKING CHANGE: hoist `PinnedTimeInExpression` check to be enabled by default. It is expected this is an accident in the overwhelming amount of times and in the unlikely case it is not, a local override is preferred.