### PR TITLE
fix: exclude generic actions from missing primary action check

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ If you have any compiled-introspection checks enabled, run `mix compile` before 
 | `UseCodeInterface` | Refactor | Normal | No | Flags `Ash.*` calls where both resource and action are literals - names the exact code interface function to call instead. **Requires compiled project** and **configurable** (see below). Pair with `Warning.UnknownAction` for typo detection. |
 | `MissingCodeInterface` | Design | Low | No | Flags each action on non-embedded resources that has no code interface (resource- or domain-level). **Requires compiled project.** |
 | `MissingIdentity` | Design | Normal | No | Suggests identities for attributes like `email`, `username`, `slug` on non-embedded resources. **Requires compiled project.** |
-| `MissingPrimaryAction` | Design | Normal | No | Flags missing `primary?: true` when multiple actions of the same type exist. **Requires compiled project.** |
+| `MissingPrimaryAction` | Design | Normal | No | Flags missing `primary?: true` when multiple actions of the same CRUD type exist (generic `:action` types are excluded). **Requires compiled project.** |
 | `MissingTimestamps` | Design | Normal | No | Suggests adding `timestamps()` to persisted resources. **Requires compiled project.** |
 | `ActionMissingDescription` | Readability | Low | No | Flags actions without a `description` |
 | `BelongsToMissingAllowNil` | Readability | Normal | No | Flags `belongs_to` without explicit `allow_nil?` |

--- a/lib/ash_credo/check/design/missing_primary_action.ex
+++ b/lib/ash_credo/check/design/missing_primary_action.ex
@@ -5,14 +5,20 @@ defmodule AshCredo.Check.Design.MissingPrimaryAction do
     tags: [:ash],
     explanations: [
       check: """
-      When multiple actions of the same type exist (e.g., two `:create` actions),
-      one should declare `primary?: true`. Without this, Ash raises at runtime
-      when framework features implicitly invoke the primary action.
+      When multiple actions of the same CRUD type exist (e.g., two `:create`
+      actions), one should declare `primary?: true`. Without this, Ash raises
+      at runtime when framework features implicitly invoke the primary action,
+      e.g. default action resolution or `manage_relationship`.
 
           create :register do
             primary? true
             # ...
           end
+
+      Generic actions (type `:action`) are intentionally excluded: they are
+      never invoked implicitly - callers always name them via
+      `Ash.run_action/2` - so `primary?` has no behavioral effect for them. It
+      is only consulted for `:create`, `:read`, `:update`, and `:destroy`.
 
       This check uses Ash's runtime introspection (`Ash.Resource.Info.actions/1`)
       to see the fully-resolved action list - including actions contributed by
@@ -32,7 +38,9 @@ defmodule AshCredo.Check.Design.MissingPrimaryAction do
   alias AshCredo.Introspection.Compiled, as: CompiledIntrospection
   alias AshCredo.Introspection.ResourceContext
 
-  @action_types ~w(create read update destroy action)a
+  # Generic actions (`:action`) are excluded: they are never invoked implicitly,
+  # so `primary?` has no behavioral effect for them.
+  @action_types ~w(create read update destroy)a
 
   @impl true
   def run(%SourceFile{} = source_file, params) do

--- a/test/ash_credo/check/design/missing_primary_action_test.exs
+++ b/test/ash_credo/check/design/missing_primary_action_test.exs
@@ -57,6 +57,19 @@ defmodule AshCredo.Check.Design.MissingPrimaryActionTest do
     assert issue.message =~ "primary?"
   end
 
+  test "no issue for multiple generic actions without a primary" do
+    # Blog.GenericActions has `:ping` and `:pong` generic actions, neither
+    # primary. Generic actions are never invoked implicitly so `primary?` has
+    # no behavioral effect - the check must not flag them.
+    source = """
+    defmodule AshCredoFixtures.Blog.GenericActions do
+      use Ash.Resource, domain: AshCredoFixtures.Blog
+    end
+    """
+
+    assert [] = run_check(MissingPrimaryAction, source)
+  end
+
   test "alias-expands a top-level aliased defmodule name to the real module" do
     # Regression: `Introspection.all_modules_with_path/1` used to treat the
     # literal segments of a `defmodule` name as absolute, so a top-level

--- a/test/support/fixtures/ash_fixtures.ex
+++ b/test/support/fixtures/ash_fixtures.ex
@@ -76,6 +76,7 @@ defmodule AshCredoFixtures.Blog do
     resource AshCredoFixtures.Blog.PartialTimestamps
     resource AshCredoFixtures.Blog.CustomTimestamps
     resource AshCredoFixtures.Blog.Tag
+    resource AshCredoFixtures.Blog.GenericActions
     resource AshCredoFixtures.Blog.Empty
     resource AshCredoFixtures.Blog.WithAuthorizer
     resource AshCredoFixtures.Blog.WithCalcInterface
@@ -355,6 +356,37 @@ defmodule AshCredoFixtures.Blog.Tag do
   attributes do
     uuid_primary_key :id
     attribute :name, :string, public?: true
+  end
+end
+
+defmodule AshCredoFixtures.Blog.GenericActions do
+  @moduledoc """
+  `MissingPrimaryAction` regression fixture: has multiple generic actions
+  (type `:action`) and none marked `primary?: true`. Generic
+  actions are never invoked implicitly - callers always name them via
+  `Ash.run_action/2` - so `primary?` has no behavioral effect and the check
+  must not flag them.
+  """
+
+  use Ash.Resource,
+    domain: AshCredoFixtures.Blog,
+    validate_domain_inclusion?: false
+
+  actions do
+    defaults [:read]
+    default_accept []
+
+    action :ping do
+      run fn _input, _ -> :ok end
+    end
+
+    action :pong do
+      run fn _input, _ -> :ok end
+    end
+  end
+
+  attributes do
+    uuid_primary_key :id
   end
 end
 

--- a/test/support/fixtures/ash_fixtures.ex
+++ b/test/support/fixtures/ash_fixtures.ex
@@ -337,9 +337,10 @@ end
 defmodule AshCredoFixtures.Blog.Tag do
   @moduledoc """
   Resource with multiple `:create` actions and no `primary?: true`. Ash
-  emits a verification warning but compiles the module, so we can
-  introspect it via `Ash.Resource.Info.actions/1` for the
-  `Design.MissingPrimaryAction` failure-path test.
+  compiles this without any error or warning - a missing primary action
+  only fails at runtime - so we can introspect it via
+  `Ash.Resource.Info.actions/1` for the `Design.MissingPrimaryAction`
+  failure-path test.
   """
 
   use Ash.Resource,


### PR DESCRIPTION
closes #134