### PR TITLE
docs: use package.hexdocs.pm subdomain for documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # AshCredo
 
 [![Hex.pm](https://img.shields.io/hexpm/v/ash_credo.svg)](https://hex.pm/packages/ash_credo)
-[![HexDocs](https://img.shields.io/badge/hex-docs-blue.svg)](https://hexdocs.pm/ash_credo)
+[![HexDocs](https://img.shields.io/badge/hex-docs-blue.svg)](https://ash-credo.hexdocs.pm)
 [![License: MIT](https://img.shields.io/badge/license-MIT-brightgreen.svg)](https://opensource.org/licenses/MIT)
 
 Unofficial static code analysis checks for the [Ash Framework](https://ash-hq.org), built as a [Credo](https://github.com/rrrene/credo) plugin.
@@ -19,11 +19,11 @@ AshCredo detects common anti-patterns, security pitfalls, and missing best pract
 
 ## Installation
 
-AshCredo requires [Credo](https://hexdocs.pm/credo) to already be installed in your project.
+AshCredo requires [Credo](https://credo.hexdocs.pm) to already be installed in your project.
 
 ### With Igniter (recommended)
 
-If your project uses [Igniter](https://hexdocs.pm/igniter), a single command will add the dependency and register the plugin in your `.credo.exs`:
+If your project uses [Igniter](https://igniter.hexdocs.pm), a single command will add the dependency and register the plugin in your `.credo.exs`:
 
 ```bash
 mix igniter.install ash_credo

--- a/lib/mix/tasks/ash_credo.install.ex
+++ b/lib/mix/tasks/ash_credo.install.ex
@@ -93,7 +93,7 @@ else
       Mix.shell().error("""
       The task 'ash_credo.install' requires igniter. Please install igniter and try again.
 
-      For more information, see: https://hexdocs.pm/igniter/readme.html#installation
+      For more information, see: https://igniter.hexdocs.pm/readme.html#installation
       """)
 
       exit({:shutdown, 1})


### PR DESCRIPTION
Switch `hexdocs.pm/<package>` links to the `<package>.hexdocs.pm` subdomain format.