### PR TITLE
fix: handle bare authorize? variables in AST lists in AuthorizeFalse

### DIFF
--- a/lib/ash_credo/check/warning/authorize_false.ex
+++ b/lib/ash_credo/check/warning/authorize_false.ex
@@ -138,7 +138,10 @@ defmodule AshCredo.Check.Warning.AuthorizeFalse do
   defp has_authorize_false?(args) do
     Enum.any?(args, fn
       {:authorize?, false} -> true
-      kwl when is_list(kwl) -> Keyword.get(kwl, :authorize?) == false
+      # Bare `authorize?` variables have a 3-tuple AST ({:authorize?, meta, nil})
+      # that Keyword.get's :lists.keyfind would match, so only accept literal
+      # 2-tuples here.
+      kwl when is_list(kwl) -> Enum.any?(kwl, &match?({:authorize?, false}, &1))
       _ -> false
     end)
   end

--- a/test/ash_credo/check/warning/authorize_false_test.exs
+++ b/test/ash_credo/check/warning/authorize_false_test.exs
@@ -278,6 +278,57 @@ defmodule AshCredo.Check.Warning.AuthorizeFalseTest do
     assert issue.trigger == "authorize?: false"
   end
 
+  test "no issue and no crash for a bare authorize? variable in an anonymous function" do
+    source = """
+    defmodule MyApp.Accounts do
+      def check do
+        Enum.map([true, false], fn authorize? -> authorize? end)
+      end
+    end
+    """
+
+    assert [] = run_check(AuthorizeFalse, source)
+  end
+
+  test "no issue and no crash for a bare authorize? variable in a case clause" do
+    source = """
+    defmodule MyApp.Accounts do
+      def check(value) do
+        case value do
+          authorize? -> authorize?
+        end
+      end
+    end
+    """
+
+    assert [] = run_check(AuthorizeFalse, source)
+  end
+
+  test "no issue and no crash for a bare authorize? variable in a literal list" do
+    source = """
+    defmodule MyApp.Accounts do
+      def check(authorize?) do
+        [authorize?, :other]
+      end
+    end
+    """
+
+    assert [] = run_check(AuthorizeFalse, source)
+  end
+
+  test "reports issue for authorize?: false appended to opts via ++" do
+    source = """
+    defmodule MyApp.Accounts do
+      def list_users(opts) do
+        Ash.read!(MyApp.User, opts ++ [authorize?: false])
+      end
+    end
+    """
+
+    assert [issue] = run_check(AuthorizeFalse, source)
+    assert issue.trigger == "authorize?: false"
+  end
+
   describe "excluded_paths" do
     test "skips files under test/ by default" do
       source = """


### PR DESCRIPTION
`has_authorize_false?/1` called `Keyword.get/2` on AST lists. Keyword.get relies on :lists.keyfind/3, which matches tuples of any size, so a bare variable named `authorize?` ({:authorize?, meta, nil}) appearing as a direct element of a list raised CaseClauseError and errored the check for the whole file in the default `include_non_ash_calls: true` mode. Trigger forms: `fn authorize? ->`, an unguarded `case` clause binding `authorize?`, or a literal list `[authorize?]`.

Match literal `{:authorize?, false}` 2-tuples explicitly instead. Nested keyword lists such as `opts ++ [authorize?: false]` are still flagged.