### PR TITLE
fix: detect additional unscoped policy forms in OverlyPermissivePolicy

### DIFF
--- a/lib/ash_credo/check/warning/overly_permissive_policy.ex
+++ b/lib/ash_credo/check/warning/overly_permissive_policy.ex
@@ -8,6 +8,11 @@ defmodule AshCredo.Check.Warning.OverlyPermissivePolicy do
       An unscoped policy using `authorize_if always()` allows anyone -
       including unauthenticated requests - to perform all actions.
 
+      A policy is unscoped when its condition is `always()` or `expr(true)`,
+      when every element of a list condition is one of those, when it has no
+      condition at all (Ash defaults the condition to true), or when its only
+      body-level `condition` is `always()`/`expr(true)`.
+
       Scope permissive policies to specific actions or action types:
 
           policy action_type(:read) do
@@ -55,16 +60,37 @@ defmodule AshCredo.Check.Warning.OverlyPermissivePolicy do
 
   defp has_authorize_if_always?(_), do: false
 
-  defp scoped_policy?({kind, _, [guard | _]}) when kind in [:policy, :bypass] do
-    case guard do
-      # policy always() - applies to everything, NOT scoped
-      {:always, _, _} -> false
-      # policy expr(true) - effectively unscoped
-      {:expr, _, [true]} -> false
-      # policy action_type(:read), policy action([...]), etc. - scoped
-      _ -> true
+  defp scoped_policy?({kind, _, args} = policy_ast) when kind in [:policy, :bypass] do
+    case Enum.reject(args, &do_block?/1) do
+      # policy do ... end - Ash defaults the condition to static true, so the
+      # policy is only scoped if its body declares a restrictive `condition`
+      [] -> scoped_body_condition?(policy_ast)
+      [condition | _] -> scoped_condition?(condition)
     end
   end
 
   defp scoped_policy?(_), do: false
+
+  defp do_block?([{:do, _} | _]), do: true
+  defp do_block?(_), do: false
+
+  defp scoped_body_condition?(policy_ast) do
+    Enum.any?(Introspection.entity_body(policy_ast), fn
+      {:condition, _, [condition]} -> scoped_condition?(condition)
+      _ -> false
+    end)
+  end
+
+  # Ash ANDs list conditions, so a list is unscoped only when every element
+  # is unscoped (an empty list has no restricting element at all)
+  defp scoped_condition?(condition) when is_list(condition),
+    do: not Enum.all?(condition, &unscoped_condition?/1)
+
+  defp scoped_condition?(condition), do: not unscoped_condition?(condition)
+
+  # always() applies to everything; expr(true) is effectively unscoped.
+  # Anything else - action_type(:read), action([...]), actor checks - scopes.
+  defp unscoped_condition?({:always, _, _}), do: true
+  defp unscoped_condition?({:expr, _, [true]}), do: true
+  defp unscoped_condition?(_), do: false
 end

--- a/test/ash_credo/check/warning/overly_permissive_policy_test.exs
+++ b/test/ash_credo/check/warning/overly_permissive_policy_test.exs
@@ -147,6 +147,126 @@ defmodule AshCredo.Check.Warning.OverlyPermissivePolicyTest do
     assert [] = run_check(OverlyPermissivePolicy, source)
   end
 
+  test "reports issue when policy has no condition argument" do
+    source = """
+    defmodule MyApp.Post do
+      use Ash.Resource, domain: MyApp.Blog, authorizers: [Ash.Policy.Authorizer]
+
+      policies do
+        policy do
+          authorize_if always()
+        end
+      end
+    end
+    """
+
+    assert [issue] = run_check(OverlyPermissivePolicy, source)
+    assert issue.message =~ "Unscoped policy"
+  end
+
+  test "reports issue when condition is a list containing only always()" do
+    source = """
+    defmodule MyApp.Post do
+      use Ash.Resource, domain: MyApp.Blog, authorizers: [Ash.Policy.Authorizer]
+
+      policies do
+        policy [always()] do
+          authorize_if always()
+        end
+      end
+    end
+    """
+
+    assert [issue] = run_check(OverlyPermissivePolicy, source)
+    assert issue.message =~ "Unscoped policy"
+  end
+
+  test "reports issue when bypass condition is a list containing only always()" do
+    source = """
+    defmodule MyApp.Post do
+      use Ash.Resource, domain: MyApp.Blog, authorizers: [Ash.Policy.Authorizer]
+
+      policies do
+        bypass [always()] do
+          authorize_if always()
+        end
+      end
+    end
+    """
+
+    assert [issue] = run_check(OverlyPermissivePolicy, source)
+    assert issue.message =~ "Bypass"
+  end
+
+  test "reports issue when body-level condition is always()" do
+    source = """
+    defmodule MyApp.Post do
+      use Ash.Resource, domain: MyApp.Blog, authorizers: [Ash.Policy.Authorizer]
+
+      policies do
+        policy do
+          condition always()
+          authorize_if always()
+        end
+      end
+    end
+    """
+
+    assert [issue] = run_check(OverlyPermissivePolicy, source)
+    assert issue.message =~ "Unscoped policy"
+  end
+
+  test "reports issue when body-level condition is expr(true)" do
+    source = """
+    defmodule MyApp.Post do
+      use Ash.Resource, domain: MyApp.Blog, authorizers: [Ash.Policy.Authorizer]
+
+      policies do
+        policy do
+          condition expr(true)
+          authorize_if always()
+        end
+      end
+    end
+    """
+
+    assert [issue] = run_check(OverlyPermissivePolicy, source)
+    assert issue.message =~ "Unscoped policy"
+  end
+
+  test "no issue when list condition mixes always() with a restrictive check" do
+    source = """
+    defmodule MyApp.Post do
+      use Ash.Resource, domain: MyApp.Blog, authorizers: [Ash.Policy.Authorizer]
+
+      policies do
+        policy [actor_attribute_equals(:role, :admin), always()] do
+          authorize_if always()
+        end
+      end
+    end
+    """
+
+    assert [] = run_check(OverlyPermissivePolicy, source)
+  end
+
+  test "no issue when body-level condition is restrictive" do
+    source = """
+    defmodule MyApp.Post do
+      use Ash.Resource, domain: MyApp.Blog, authorizers: [Ash.Policy.Authorizer]
+
+      policies do
+        policy do
+          condition actor_attribute_equals(:role, :admin)
+          authorize_if always()
+        end
+      end
+    end
+    """
+
+    assert [] = run_check(OverlyPermissivePolicy, source)
+  end
+
   test "ignores non-Ash modules" do
     source = """
     defmodule MyApp.Utils do


### PR DESCRIPTION
`scoped_policy?/1` only recognized a bare `always()`/`expr(true)` condition argument, missing four unscoped forms:

- `policy do ... end` with no condition (Ash defaults to static true)
- `policy [always()] do ... end` (single-element list condition)
- `bypass [always()]`
- body-level `condition always()`

A policy with no condition argument is now unscoped unless its body declares a restrictive `condition`; a list condition is unscoped only when every element is `always()`/`expr(true)`, since Ash ANDs list conditions.