### PR TITLE
fix: degrade gracefully when cache table is missing

### DIFF
--- a/lib/ash_credo.ex
+++ b/lib/ash_credo.ex
@@ -60,6 +60,8 @@ defmodule AshCredo do
   }
   """
 
+  # The missing-table hint in AshCredo.Cache quotes this registration
+  # (`{AshCredo, []}` under `plugins`); keep them in sync if it changes.
   def init(exec) do
     Cache.ensure_started!()
     Cache.clear()

--- a/lib/ash_credo/cache.ex
+++ b/lib/ash_credo/cache.ex
@@ -15,11 +15,23 @@ defmodule AshCredo.Cache do
   `:ash_credo` application boots. `AshCredo.init/1` additionally calls
   `ensure_started!/0` before any check runs, so the table is also available
   when `mix credo` runs without booting the `:ash_credo` application.
+
+  If the table does not exist - for example when checks are enabled directly
+  in `.credo.exs` without registering the `{AshCredo, []}` plugin, so
+  `AshCredo.init/1` never runs - every function degrades gracefully instead
+  of raising: reads behave as if nothing were cached and writes are no-ops.
+  Checks then work correctly, just without cross-call caching. The first
+  such access emits a one-time hint to stderr suggesting the plugin
+  registration.
   """
 
   use GenServer
 
   @table :ash_credo_cache
+
+  @missing_table_hint "ash_credo plugin not registered - checks run uncached; " <>
+                        "add `{AshCredo, []}` to `plugins` in .credo.exs"
+  @hint_emitted_key {__MODULE__, :missing_table_hint_emitted}
 
   @doc """
   Starts the cache GenServer. Idempotent - returns the existing pid if
@@ -56,9 +68,14 @@ defmodule AshCredo.Cache do
   """
   @spec get(term(), term()) :: term()
   def get(key, default \\ nil) do
-    case :ets.lookup(@table, key) do
-      [{^key, value}] -> value
-      [] -> default
+    if table_exists?() do
+      case :ets.lookup(@table, key) do
+        [{^key, value}] -> value
+        [] -> default
+      end
+    else
+      warn_missing_table()
+      default
     end
   end
 
@@ -68,7 +85,12 @@ defmodule AshCredo.Cache do
   """
   @spec put(term(), term()) :: :ok
   def put(key, value) do
-    :ets.insert(@table, {key, value})
+    if table_exists?() do
+      :ets.insert(@table, {key, value})
+    else
+      warn_missing_table()
+    end
+
     :ok
   end
 
@@ -77,15 +99,30 @@ defmodule AshCredo.Cache do
   Returns `true` if this call inserted (the caller is the first to see
   this key), `false` if `key` was already present. Use this when you
   need to act exactly once per key across concurrent callers.
+
+  When the table is missing, returns `true` on every call (nothing is
+  ever cached, so every caller looks like the first one).
   """
   @spec insert_new(term()) :: boolean()
   def insert_new(key) do
-    :ets.insert_new(@table, {key, true})
+    if table_exists?() do
+      :ets.insert_new(@table, {key, true})
+    else
+      warn_missing_table()
+      true
+    end
   end
 
   @doc "Returns `true` if `key` is present in the cache."
   @spec member?(term()) :: boolean()
-  def member?(key), do: :ets.member(@table, key)
+  def member?(key) do
+    if table_exists?() do
+      :ets.member(@table, key)
+    else
+      warn_missing_table()
+      false
+    end
+  end
 
   @doc """
   Deletes every entry in the cache. Idempotent and safe to call before
@@ -93,11 +130,44 @@ defmodule AshCredo.Cache do
   """
   @spec clear() :: :ok
   def clear do
-    if :ets.whereis(@table) != :undefined do
+    if table_exists?() do
       :ets.delete_all_objects(@table)
     end
 
     :ok
+  end
+
+  @doc """
+  Forgets that the missing-table hint was emitted, so the next missing-table
+  access emits it again. Test helper that keeps the flag key private to this
+  module.
+  """
+  @spec reset_missing_table_hint() :: :ok
+  def reset_missing_table_hint do
+    :persistent_term.erase(@hint_emitted_key)
+    :ok
+  end
+
+  @doc """
+  Marks the missing-table hint as already emitted, silencing it for the rest
+  of the VM's lifetime. Test helper that keeps the flag key private to this
+  module.
+  """
+  @spec mark_missing_table_hint_emitted() :: :ok
+  def mark_missing_table_hint_emitted do
+    :persistent_term.put(@hint_emitted_key, true)
+  end
+
+  defp table_exists?, do: :ets.whereis(@table) != :undefined
+
+  # One hint per VM, tracked outside the (missing) table: a no-plugin run
+  # would otherwise repeat the message once per accessor call per file.
+  # Concurrent first callers may rarely both emit; best-effort is fine here.
+  defp warn_missing_table do
+    if not :persistent_term.get(@hint_emitted_key, false) do
+      :persistent_term.put(@hint_emitted_key, true)
+      IO.puts(:stderr, @missing_table_hint)
+    end
   end
 
   # ── GenServer callbacks ──

--- a/test/ash_credo/cache_test.exs
+++ b/test/ash_credo/cache_test.exs
@@ -1,7 +1,11 @@
 defmodule AshCredo.CacheTest do
   use ExUnit.Case, async: false
 
+  import ExUnit.CaptureIO
+
   alias AshCredo.Cache
+
+  @table :ash_credo_cache
 
   setup do
     Cache.ensure_started!()
@@ -83,6 +87,129 @@ defmodule AshCredo.CacheTest do
     test "is idempotent" do
       assert :ok = Cache.ensure_started!()
       assert :ok = Cache.ensure_started!()
+    end
+  end
+
+  describe "when the ETS table is missing" do
+    # Simulates running checks without the plugin registered in .credo.exs:
+    # `AshCredo.init/1` never runs, so the table is never created. Accessors
+    # must degrade to "nothing cached" defaults instead of raising.
+    setup do
+      stop_cache_owner()
+      # Pretend the hint was already emitted so the accessor tests below
+      # stay silent; the hint test resets this to exercise the first call.
+      Cache.mark_missing_table_hint_emitted()
+
+      on_exit(fn ->
+        Cache.reset_missing_table_hint()
+        restart_cache_owner()
+      end)
+
+      :ok
+    end
+
+    test "get/2 returns the default" do
+      assert Cache.get(:anything) == nil
+      assert Cache.get(:anything, :default) == :default
+    end
+
+    test "put/2 is a no-op that returns :ok" do
+      assert Cache.put(:k, 1) == :ok
+      # Still no table, and nothing was stored anywhere.
+      assert :ets.whereis(@table) == :undefined
+    end
+
+    test "insert_new/1 returns true (nothing is ever cached)" do
+      assert Cache.insert_new(:once) == true
+      assert Cache.insert_new(:once) == true
+    end
+
+    test "member?/1 returns false" do
+      refute Cache.member?(:k)
+    end
+
+    test "the first access emits a one-time stderr hint suggesting plugin registration" do
+      Cache.reset_missing_table_hint()
+
+      hint = capture_io(:stderr, fn -> Cache.get(:k) end)
+      assert hint =~ "ash_credo plugin not registered"
+      assert hint =~ "add `{AshCredo, []}` to `plugins`"
+
+      # Every subsequent accessor call stays silent.
+      assert capture_io(:stderr, fn ->
+               Cache.get(:k)
+               Cache.put(:k, 1)
+               Cache.insert_new(:k)
+               Cache.member?(:k)
+             end) == ""
+    end
+  end
+
+  describe "missing-table hint with the table present" do
+    test "accessors never emit the hint" do
+      Cache.reset_missing_table_hint()
+
+      assert capture_io(:stderr, fn ->
+               Cache.put(:k, 1)
+               Cache.get(:k)
+               Cache.insert_new(:other)
+               Cache.member?(:k)
+             end) == ""
+    end
+  end
+
+  defp stop_cache_owner do
+    case Process.whereis(Cache) do
+      nil ->
+        :ok
+
+      pid ->
+        # Detach from the application supervisor (if supervised) so the
+        # child is not immediately restarted, then stop the owner.
+        if sup = Process.whereis(AshCredo.Supervisor) do
+          _ = Supervisor.terminate_child(sup, Cache)
+          _ = Supervisor.delete_child(sup, Cache)
+        end
+
+        if Process.alive?(pid) do
+          ref = Process.monitor(pid)
+          GenServer.stop(pid)
+
+          receive do
+            {:DOWN, ^ref, :process, ^pid, _reason} -> :ok
+          after
+            1_000 -> raise "cache owner did not stop"
+          end
+        end
+    end
+
+    wait_until(fn -> :ets.whereis(@table) == :undefined end)
+  end
+
+  defp restart_cache_owner do
+    # Restart under the application supervisor (not via ensure_started!/0,
+    # which would link the GenServer to this short-lived on_exit process
+    # and take the cache down with it).
+    case Process.whereis(AshCredo.Supervisor) do
+      nil ->
+        Cache.ensure_started!()
+
+      sup ->
+        case Supervisor.start_child(sup, Cache) do
+          {:ok, _pid} -> :ok
+          {:error, {:already_started, _pid}} -> :ok
+          {:error, :already_present} -> {:ok, _pid} = Supervisor.restart_child(sup, Cache)
+        end
+    end
+
+    wait_until(fn -> :ets.whereis(@table) != :undefined end)
+  end
+
+  defp wait_until(fun, attempts \\ 200) do
+    cond do
+      fun.() -> :ok
+      attempts == 0 -> raise "condition not met in time"
+      true -> wait_until(fun, attempts - 1)
     end
   end
 end


### PR DESCRIPTION
The cache ETS table only exists once the Credo plugin is registered and `AshCredo.init/1` has run. Enabling checks directly in `checks:` without the plugin (the usual way third-party Credo checks are consumed) made every accessor raise ArgumentError, which Credo surfaced as per-file "Error while running check" warnings, silently degrading 22 of 23 checks to no-ops.

Guard `get/2`, `put/2`, `insert_new/1`, and `member?/1` on `:ets.whereis/1`, as `clear/0` already did: the checks now run correctly without the plugin, just uncached and without default-check registration. Behavior with the plugin registered is unchanged.

The first access without the table emits a one-time (per VM, tracked via :persistent_term) hint to stderr pointing users at the plugin registration, so the degraded mode is discoverable instead of silent.