### PR TITLE
perf: memoize per-file AST traversals and module probes

### DIFF
--- a/lib/ash_credo/cache.ex
+++ b/lib/ash_credo/cache.ex
@@ -33,6 +33,11 @@ defmodule AshCredo.Cache do
                         "add `{AshCredo, []}` to `plugins` in .credo.exs"
   @hint_emitted_key {__MODULE__, :missing_table_hint_emitted}
 
+  # Sentinel distinguishing "no entry" from a cached `nil`/`false` in
+  # memoize/2. A computed value that literally equals this tuple would be
+  # recomputed on every call; no realistic value does.
+  @memoize_miss {__MODULE__, :memoize_miss}
+
   @doc """
   Starts the cache GenServer. Idempotent - returns the existing pid if
   already started.
@@ -92,6 +97,26 @@ defmodule AshCredo.Cache do
     end
 
     :ok
+  end
+
+  @doc """
+  Returns the cached value at `key`, computing it with `fun` and storing the
+  result on a miss. `fun` must be a pure function of `key`: concurrent first
+  callers may each compute, and the last write wins.
+
+  When the table is missing, computes on every call (nothing is ever cached).
+  """
+  @spec memoize(term(), (-> term())) :: term()
+  def memoize(key, fun) when is_function(fun, 0) do
+    case get(key, @memoize_miss) do
+      @memoize_miss ->
+        value = fun.()
+        put(key, value)
+        value
+
+      value ->
+        value
+    end
   end
 
   @doc """

--- a/lib/ash_credo/introspection.ex
+++ b/lib/ash_credo/introspection.ex
@@ -21,6 +21,8 @@ defmodule AshCredo.Introspection do
   module directly so dependencies stay honest.
   """
 
+  alias AshCredo.Cache
+
   alias AshCredo.Introspection.{
     Aliases,
     Block,
@@ -33,6 +35,8 @@ defmodule AshCredo.Introspection do
 
   @action_entities ~w(create read update destroy action)a
 
+  @resource_contexts_key_tag {__MODULE__, :resource_contexts}
+
   @doc "Returns all modules in the source file that directly `use Ash.Resource`."
   def resource_modules(source_file), do: modules_using(source_file, [:Ash, :Resource])
 
@@ -42,13 +46,31 @@ defmodule AshCredo.Introspection do
   enclosing path of the resource's `defmodule` name (e.g. `[:MyApp, :Blog, :Post]`
   for a nested `defmodule Post` inside `defmodule MyApp.Blog`). This lets
   compiled-introspection checks resolve the resource to its runtime module atom.
+
+  Memoized in the run-scoped cache keyed on filename plus source hash, so the
+  underlying scope-tracking traversal runs once per file per Credo run instead
+  of once per enabled check.
   """
   def resource_contexts(source_file) do
+    key = {@resource_contexts_key_tag, source_file.filename, source_hash(source_file)}
+
+    Cache.memoize(key, fn -> compute_resource_contexts(source_file) end)
+  end
+
+  defp compute_resource_contexts(source_file) do
     source_file
     |> all_modules_with_path()
     |> Enum.filter(fn {ast, _segs} -> module_uses?(ast, [:Ash, :Resource]) end)
     |> Enum.map(fn {ast, segs} -> resource_context_with_segments(ast, segs) end)
   end
+
+  @doc """
+  Hashes a source file's content for use in content-addressed cache keys.
+  Filename alone is not a safe key: distinct `SourceFile`s regularly share a
+  filename with different content (most prominently in this project's own
+  test suite).
+  """
+  def source_hash(source_file), do: :erlang.md5(SourceFile.source(source_file))
 
   @doc """
   Walks every `defmodule` in a source file and returns

--- a/lib/ash_credo/introspection/ash_call_resolver.ex
+++ b/lib/ash_credo/introspection/ash_call_resolver.ex
@@ -37,9 +37,13 @@ defmodule AshCredo.Introspection.AshCallResolver do
       that do not exist on the resolved resource.
   """
 
+  alias AshCredo.Cache
+  alias AshCredo.Introspection
   alias AshCredo.Introspection.{Aliases, AshCallScanner, AshCallSite}
   alias AshCredo.Introspection.Compiled, as: CompiledIntrospection
   alias Credo.Code.Name
+
+  @sites_key_tag {__MODULE__, :sites}
 
   # Pattern A: resource at arg 0, action in keyword opts (:action key).
   @action_in_opts ~w(read read! get get! stream!)a
@@ -79,9 +83,21 @@ defmodule AshCredo.Introspection.AshCallResolver do
   @doc """
   Walks `source_file` and returns the list of resolved Ash call sites in
   source order.
+
+  Memoized in the run-scoped cache keyed on filename plus source hash, so
+  the scan-and-resolve pass runs once per file per Credo run instead of
+  once per consuming check. Safe to cache despite embedding compiled
+  resolution results: the compiled world is fixed within a run, and the
+  cache is cleared at run boundaries.
   """
   @spec sites(Credo.SourceFile.t()) :: [AshCallSite.t()]
   def sites(source_file) do
+    key = {@sites_key_tag, source_file.filename, Introspection.source_hash(source_file)}
+
+    Cache.memoize(key, fn -> compute_sites(source_file) end)
+  end
+
+  defp compute_sites(source_file) do
     source_file
     |> AshCallScanner.calls_with_context()
     |> Enum.flat_map(&resolve_site/1)

--- a/lib/ash_credo/introspection/compiled.ex
+++ b/lib/ash_credo/introspection/compiled.ex
@@ -60,6 +60,8 @@ defmodule AshCredo.Introspection.Compiled do
   @enclosing_domain_key_tag {__MODULE__, :enclosing_domain}
   @code_interface_bang_key_tag {__MODULE__, :code_interface_bang}
   @ash_available_key {__MODULE__, :ash_available?}
+  @domain_check_key_tag {__MODULE__, :domain?}
+  @callback_module_key_tag {__MODULE__, :ash_callback_module?}
   @ash_missing_warned_key {__MODULE__, :ash_missing_warned}
   @not_loadable_warned_key_tag {__MODULE__, :not_loadable_warned}
 
@@ -320,12 +322,15 @@ defmodule AshCredo.Introspection.Compiled do
   Returns `true` if `module` is an Ash domain loadable in this VM.
 
   Determined by the `spark_is/0` function that Spark DSL modules inject.
-  Not cached. Cheap on positive probes (already-loaded module lookup), but
-  pays a `Code.ensure_compiled/1` filesystem search on negative probes -
-  avoid calling in hot loops with mostly-non-domain inputs.
+  Cached per module, so only the first probe of a given module pays the
+  `Code.ensure_compiled/1` filesystem search on negative results.
   """
   @spec domain?(module()) :: boolean()
   def domain?(module) when is_atom(module) do
+    Cache.memoize({@domain_check_key_tag, module}, fn -> compute_domain?(module) end)
+  end
+
+  defp compute_domain?(module) do
     ash_available?() and
       match?({:module, _}, Code.ensure_compiled(module)) and
       function_exported?(module, :spark_is, 0) and
@@ -338,10 +343,17 @@ defmodule AshCredo.Introspection.Compiled do
   `Calculation`, or any of the `Manual*` action behaviours).
 
   Detected by inspecting the module's `:behaviour` attribute, populated by
-  `use Ash.Resource.Change` and siblings at compile time.
+  `use Ash.Resource.Change` and siblings at compile time. Cached per module,
+  so only the first probe pays the `Code.ensure_compiled/1` cost.
   """
   @spec ash_callback_module?(module()) :: boolean()
   def ash_callback_module?(module) when is_atom(module) do
+    Cache.memoize({@callback_module_key_tag, module}, fn ->
+      compute_ash_callback_module?(module)
+    end)
+  end
+
+  defp compute_ash_callback_module?(module) do
     with true <- ash_available?(),
          {:module, _} <- Code.ensure_compiled(module) do
       module_behaviours(module)

--- a/test/ash_credo/cache_test.exs
+++ b/test/ash_credo/cache_test.exs
@@ -63,6 +63,31 @@ defmodule AshCredo.CacheTest do
     end
   end
 
+  describe "memoize/2" do
+    test "computes on the first call and serves the cached value thereafter" do
+      parent = self()
+
+      compute = fn ->
+        send(parent, :computed)
+        :value
+      end
+
+      assert Cache.memoize(:memo_key, compute) == :value
+      assert_received :computed
+
+      assert Cache.memoize(:memo_key, compute) == :value
+      refute_received :computed
+    end
+
+    test "caches falsy values instead of recomputing them" do
+      assert Cache.memoize(:memo_nil, fn -> nil end) == nil
+      assert Cache.memoize(:memo_nil, fn -> raise "must not recompute" end) == nil
+
+      assert Cache.memoize(:memo_false, fn -> false end) == false
+      assert Cache.memoize(:memo_false, fn -> raise "must not recompute" end) == false
+    end
+  end
+
   describe "clear/0" do
     test "deletes every entry" do
       Cache.put(:a, 1)
@@ -126,6 +151,20 @@ defmodule AshCredo.CacheTest do
 
     test "member?/1 returns false" do
       refute Cache.member?(:k)
+    end
+
+    test "memoize/2 computes on every call (nothing is ever cached)" do
+      parent = self()
+
+      compute = fn ->
+        send(parent, :computed)
+        :value
+      end
+
+      assert Cache.memoize(:memo_key, compute) == :value
+      assert Cache.memoize(:memo_key, compute) == :value
+      assert_received :computed
+      assert_received :computed
     end
 
     test "the first access emits a one-time stderr hint suggesting plugin registration" do

--- a/test/ash_credo/introspection_test.exs
+++ b/test/ash_credo/introspection_test.exs
@@ -159,6 +159,22 @@ defmodule AshCredo.IntrospectionTest do
 
       assert context.absolute_segments == [:Blog, :Post]
     end
+
+    test "memoization discriminates same-filename source files by content" do
+      filename = "memoization_test.ex"
+      with_resource = source_file(@ash_resource, filename)
+      without_resource = source_file(@plain_module, filename)
+
+      assert [%{absolute_segments: [:MyApp, :Post]}] =
+               Introspection.resource_contexts(with_resource)
+
+      # Same filename, different content: must not serve the cached contexts.
+      assert Introspection.resource_contexts(without_resource) == []
+
+      # Repeated calls serve the memoized value for the matching content.
+      assert [%{absolute_segments: [:MyApp, :Post]}] =
+               Introspection.resource_contexts(with_resource)
+    end
   end
 
   describe "ash_domain?/1" do


### PR DESCRIPTION
`Introspection.resource_contexts/1` re-ran its full scope-tracking LexicalScopeWalker traversal once per enabled check per file (7 direct callers plus Orchestration), and `AshCallResolver.sites/1` repeated its scan-and-resolve pass for each of its two consuming checks. Both are now memoized in the existing run-scoped `AshCredo.Cache`, mirroring how `Compiled.inspect_module/1` already uses the same table.

Keys are filename plus an md5 hash of the source. Filename alone is not a safe key: distinct SourceFiles regularly share a filename with different content (most prominently in this project's own test suite, where every check test uses "test_file.ex").

`Compiled.domain?/1` and `ash_callback_module?/1` are also cached per module; both paid a `Code.ensure_compiled/1` code-path scan on every negative probe despite their own docstring warning against hot-loop use.

The repeated get-miss-put idiom is extracted into `Cache.memoize/2` (sentinel-based, so cached `nil`/`false` values are served rather than recomputed). Without the plugin registered there is no table, so memoize computes on every call - behavior there is unchanged.