### PR TITLE
fix: warn instead of crashing on non-literal .credo.exs in installer

### DIFF
--- a/lib/mix/tasks/ash_credo.install.ex
+++ b/lib/mix/tasks/ash_credo.install.ex
@@ -19,6 +19,22 @@ if Code.ensure_loaded?(Igniter) do
     alias Igniter.Code.List
     alias Igniter.Code.Map
 
+    @manual_install_warning """
+    Could not automatically add the AshCredo plugin to .credo.exs - its
+    `configs:` value is not a literal list this installer can navigate.
+
+    Add the plugin to your config manually:
+
+        %{
+          configs: [
+            %{
+              name: "default",
+              plugins: [{AshCredo, []}]
+            }
+          ]
+        }
+    """
+
     @impl Igniter.Mix.Task
     def info(_argv, _composing_task) do
       %Igniter.Mix.Task.Info{
@@ -48,18 +64,26 @@ if Code.ensure_loaded?(Igniter) do
           Sourceror.to_string(new_node)
       end
 
+      # Each step returns `:error` when the config is not a literal it can
+      # navigate. Igniter's updater contract has no clause for a bare
+      # `:error`, so without the `else` that crashes the whole install;
+      # degrade to a warning with manual instructions instead.
       with {:ok, configs_zipper} <-
              Common.move_to_cursor(zipper, "%{configs: __cursor__()}"),
            {:ok, first_config} <-
-             List.move_to_list_item(configs_zipper, fn _ -> true end) do
-        Map.put_in_map(
-          first_config,
-          [:plugins],
-          plugin_list,
-          fn plugins_zipper ->
-            List.prepend_new_to_list(plugins_zipper, plugin_tuple, eq_pred)
-          end
-        )
+             List.move_to_list_item(configs_zipper, fn _ -> true end),
+           {:ok, updated_config} <-
+             Map.put_in_map(
+               first_config,
+               [:plugins],
+               plugin_list,
+               fn plugins_zipper ->
+                 List.prepend_new_to_list(plugins_zipper, plugin_tuple, eq_pred)
+               end
+             ) do
+        {:ok, updated_config}
+      else
+        _ -> {:warning, @manual_install_warning}
       end
     end
 

--- a/test/mix/tasks/ash_credo_install_test.exs
+++ b/test/mix/tasks/ash_credo_install_test.exs
@@ -175,6 +175,40 @@ defmodule Mix.Tasks.AshCredo.InstallTest do
       """)
     end
 
+    test "warns with manual instructions when configs: is not a literal list" do
+      igniter =
+        test_project(
+          files: %{
+            ".credo.exs" => """
+            %{
+              configs: build_configs()
+            }
+            """
+          }
+        )
+        |> Igniter.compose_task("ash_credo.install")
+
+      assert_has_warning(igniter, &(&1 =~ "Add the plugin to your config manually"))
+      assert_unchanged(igniter, ".credo.exs")
+    end
+
+    test "warns with manual instructions when the first config is not a literal map" do
+      igniter =
+        test_project(
+          files: %{
+            ".credo.exs" => """
+            %{
+              configs: [default_config()]
+            }
+            """
+          }
+        )
+        |> Igniter.compose_task("ash_credo.install")
+
+      assert_has_warning(igniter, &(&1 =~ "Add the plugin to your config manually"))
+      assert_unchanged(igniter, ".credo.exs")
+    end
+
     test "works with a realistic .credo.exs from mix credo gen.config" do
       test_project(
         files: %{


### PR DESCRIPTION
`update_credo_config/1` had a `with` without an `else`, and all three navigation steps (move_to_cursor, move_to_list_item, put_in_map) return a bare `:error` when the `configs:` value is not a literal list or its first entry is not a literal map. Igniter's updater contract only handles `{:ok, zipper}`, `{:error, error}`, and `{:warning, warning}`, so the escaped `:error` crashed `mix igniter.install ash_credo` with a CaseClauseError.

Chain all three steps in the `with` and degrade to a `{:warning, ...}` carrying manual installation instructions, leaving the file untouched. Regression tests cover both non-literal shapes.