### PR TITLE
feat: point installer users at the opt-in checks via an Igniter notice

### DIFF
--- a/lib/mix/tasks/ash_credo.install.ex
+++ b/lib/mix/tasks/ash_credo.install.ex
@@ -45,14 +45,23 @@ if Code.ensure_loaded?(Igniter) do
       }
     end
 
+    @opt_in_checks_notice """
+    AshCredo enables only a small set of its checks by default. The rest
+    are opt-in: see the checks table in the README for the full list and a
+    ready-to-paste "enable all checks" config:
+
+        https://ash_credo.hexdocs.pm/readme.html#checks
+    """
+
     @impl Igniter.Mix.Task
     def igniter(igniter) do
-      Igniter.create_or_update_elixir_file(
-        igniter,
+      igniter
+      |> Igniter.create_or_update_elixir_file(
         ".credo.exs",
         default_credo_config(),
         &update_credo_config/1
       )
+      |> Igniter.add_notice(@opt_in_checks_notice)
     end
 
     defp update_credo_config(zipper) do

--- a/test/mix/tasks/ash_credo_install_test.exs
+++ b/test/mix/tasks/ash_credo_install_test.exs
@@ -22,6 +22,33 @@ defmodule Mix.Tasks.AshCredo.InstallTest do
     end
   end
 
+  describe "opt-in checks notice" do
+    test "points at the README checks table on fresh install" do
+      test_project()
+      |> Igniter.compose_task("ash_credo.install")
+      |> assert_has_notice(&(&1 =~ "https://ash_credo.hexdocs.pm/readme.html#checks"))
+    end
+
+    test "is also emitted when .credo.exs already exists" do
+      test_project(
+        files: %{
+          ".credo.exs" => """
+          %{
+            configs: [
+              %{
+                name: "default",
+                plugins: []
+              }
+            ]
+          }
+          """
+        }
+      )
+      |> Igniter.compose_task("ash_credo.install")
+      |> assert_has_notice(&(&1 =~ "opt-in"))
+    end
+  end
+
   describe "with existing .credo.exs" do
     test "adds AshCredo to existing plugins list" do
       test_project(


### PR DESCRIPTION
The installer registered the plugin and stopped, leaving users unaware that only a small default set of checks is active and that the rest must be enabled explicitly in `.credo.exs`.

Add an Igniter.add_notice after the config update linking to the README checks table, which carries the full list and the ready-to-paste "enable all checks" block.