### PR TITLE
test: cover defaults and generic actions in ActionMissingDescription

### DIFF
--- a/test/ash_credo/check/readability/action_missing_description_test.exs
+++ b/test/ash_credo/check/readability/action_missing_description_test.exs
@@ -72,6 +72,56 @@ defmodule AshCredo.Check.Readability.ActionMissingDescriptionTest do
     assert [] = run_check(ActionMissingDescription, source)
   end
 
+  test "no issue for actions declared via defaults" do
+    source = """
+    defmodule MyApp.Post do
+      use Ash.Resource, domain: MyApp.Blog
+
+      actions do
+        defaults [:read, :destroy, create: :*, update: :*]
+      end
+    end
+    """
+
+    assert [] = run_check(ActionMissingDescription, source)
+  end
+
+  test "reports generic action without description, anchored at its line" do
+    source = """
+    defmodule MyApp.Post do
+      use Ash.Resource, domain: MyApp.Blog
+
+      actions do
+        action :send_newsletter, :ok do
+          run MyApp.SendNewsletter
+        end
+      end
+    end
+    """
+
+    assert [issue] = run_check(ActionMissingDescription, source)
+    assert issue.trigger == "send_newsletter"
+    assert issue.line_no == 5
+    assert issue.message =~ "send_newsletter"
+  end
+
+  test "no issue for generic action with description" do
+    source = """
+    defmodule MyApp.Post do
+      use Ash.Resource, domain: MyApp.Blog
+
+      actions do
+        action :send_newsletter, :ok do
+          description "Sends the weekly newsletter."
+          run MyApp.SendNewsletter
+        end
+      end
+    end
+    """
+
+    assert [] = run_check(ActionMissingDescription, source)
+  end
+
   test "ignores non-Ash modules" do
     source = """
     defmodule MyApp.Utils do


### PR DESCRIPTION
The test file exercised only named CRUD entities, leaving two shapes unverified: `defaults [...]` (must stay silent - default actions cannot carry a description) and generic `action :name, :type` (must be flagged; the check's @action_types includes :action but no test proved it). The generic-action test asserts trigger and line anchoring, and a described generic action is covered as the negative counterpart.