### PR TITLE
chore(ci): bump to OTP 29 and Elixir 1.20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,8 +43,8 @@ jobs:
       - uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1.24.0
         id: beam
         with:
-          otp-version: "28"
-          elixir-version: "1.19"
+          otp-version: "29"
+          elixir-version: "1.20"
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |


### PR DESCRIPTION
OTP 29.0.2 is the newest OTP line and hex.pm publishes v1.20.1-otp-29 precompiled builds.