### PR TITLE
fix: anchor accept :* issues at the accept line in WildcardAcceptOnAc…

### DIFF
--- a/lib/ash_credo/check/warning/wildcard_accept_on_action.ex
+++ b/lib/ash_credo/check/warning/wildcard_accept_on_action.ex
@@ -32,23 +32,24 @@ defmodule AshCredo.Check.Warning.WildcardAcceptOnAction do
       default_accept_issues(actions_ast, issue_meta)
   end
 
-  defp has_wildcard_accept?(entity_ast) do
-    entity_ast
-    |> Introspection.option_values(:accept)
-    |> Enum.any?(&wildcard_accept_value?/1)
-  end
-
   defp explicit_action_issues(actions_ast, issue_meta) do
+    source_file = IssueMeta.source_file(issue_meta)
+
     actions_ast
     |> Introspection.action_entities(@writable_action_types)
-    |> Enum.filter(&has_wildcard_accept?/1)
-    |> Enum.map(fn {type, meta, _} = entity ->
-      format_issue(issue_meta,
-        message:
-          "Action `#{Introspection.entity_name(entity) || type}` uses `accept :*`. Explicitly list accepted attributes.",
-        trigger: "accept :*",
-        line_no: meta[:line]
-      )
+    |> Enum.flat_map(fn {type, _meta, _} = entity ->
+      entity
+      |> Introspection.option_occurrences(:accept)
+      |> Enum.filter(fn {value, _line_no} -> wildcard_accept_value?(value) end)
+      |> Enum.map(fn {_value, line_no} ->
+        format_issue(issue_meta,
+          message:
+            "Action `#{Introspection.entity_name(entity) || type}` uses `accept :*`. Explicitly list accepted attributes.",
+          trigger: "accept :*",
+          line_no: line_no,
+          column: SourceFile.column(source_file, line_no, "accept")
+        )
+      end)
     end)
   end
 

--- a/test/ash_credo/check/warning/wildcard_accept_on_action_test.exs
+++ b/test/ash_credo/check/warning/wildcard_accept_on_action_test.exs
@@ -18,6 +18,8 @@ defmodule AshCredo.Check.Warning.WildcardAcceptOnActionTest do
 
     assert [issue] = run_check(WildcardAcceptOnAction, source)
     assert issue.message =~ "accept :*"
+    assert issue.line_no == 6
+    assert issue.column != nil
   end
 
   test "reports issue for accept :* on update" do
@@ -33,7 +35,9 @@ defmodule AshCredo.Check.Warning.WildcardAcceptOnActionTest do
     end
     """
 
-    assert [_issue] = run_check(WildcardAcceptOnAction, source)
+    assert [issue] = run_check(WildcardAcceptOnAction, source)
+    assert issue.line_no == 6
+    assert issue.column != nil
   end
 
   test "no issue for explicit accept list" do
@@ -83,6 +87,7 @@ defmodule AshCredo.Check.Warning.WildcardAcceptOnActionTest do
 
     assert [issue] = run_check(WildcardAcceptOnAction, source)
     assert issue.message =~ "accept :*"
+    assert issue.line_no == 5
   end
 
   test "reports issue for inline accept: :* on create with a do block" do
@@ -100,6 +105,7 @@ defmodule AshCredo.Check.Warning.WildcardAcceptOnActionTest do
 
     assert [issue] = run_check(WildcardAcceptOnAction, source)
     assert issue.message =~ "accept :*"
+    assert issue.line_no == 5
   end
 
   test "reports issue for default_accept :*" do


### PR DESCRIPTION
`explicit_action_issues/2` anchored every issue at the action entity header line (meta[:line] of the action tuple). For block-form actions the trigger text "accept :*" lives on a later line, so Credo's trigger-to-column resolution found no match on the reported line and emitted issues with column: nil, pointing tools at the wrong location.

The check now collects :accept occurrences per writable action via Introspection.option_occurrences/2 (the same pattern used by default_accept_issues/2), filters wildcard values with the existing wildcard_accept_value?/1, and emits one issue per occurrence at the occurrence's own line. Inline accept: :* still anchors at the action header line, which is where the option actually appears.

The column is supplied explicitly via SourceFile.column/3 on the "accept" token because Credo's built-in trigger regex requires a boundary character after the trigger and cannot match "accept :*" at end of line.

No existing tests asserted the old header-line anchor; tests now pin the accept line and a non-nil column for block form, and the action line for inline form.