### PR TITLE
feat: support regex entries and more defaults in sensitive_names

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ The following checks accept custom parameters:
 | `Warning.AuthorizeFalse` | `include_non_ash_calls` | `true` | When `false`, only checks Ash API calls and action DSL definitions |
 | `Warning.AuthorizeFalse` | `excluded_paths` | `[~r"/test/", "test"]` | Paths or regexes to skip. Binary entries match as path segments or full file paths. Defaults to test directories where `authorize?: false` is typically intentional |
 | `Warning.MissingMacroDirective` | `macro_modules` | `[Ash.Query, Ash.Expr]` | Modules whose qualified macro calls the check validates. Macros are read from `module.__info__(:macros)`, so only real macros are flagged |
-| `Warning.SensitiveAttributeExposed` | `sensitive_names` | `~w(password hashed_password password_hash token secret api_key private_key ssn)a` | Attribute names to flag when not marked `sensitive?: true` |
+| `Warning.SensitiveAttributeExposed` | `sensitive_names` | `~w(password hashed_password password_hash password_digest token access_token secret client_secret totp_secret api_key private_key ssn)a` | Attribute names to flag when not marked `sensitive?: true`. Atom entries match exactly; `Regex` entries (e.g. `~r/_token$/`) match against the attribute name |
 | `Warning.SensitiveFieldInAccept` | `dangerous_fields` | `~w(is_admin admin permissions api_key secret_key)a` | Field names to flag when found in `accept` lists |
 | `Refactor.DirectiveInFunctionBody` | `directive_modules` | `[Ash.Query, Ash.Expr]` | List of modules whose `require`/`import`/`alias` must live at module level. Add any other macro module your team treats the same way |
 | `Refactor.LargeResource` | `max_lines` | `400` | Maximum line count before triggering |

--- a/lib/ash_credo/check/warning/sensitive_attribute_exposed.ex
+++ b/lib/ash_credo/check/warning/sensitive_attribute_exposed.ex
@@ -5,7 +5,7 @@ defmodule AshCredo.Check.Warning.SensitiveAttributeExposed do
     tags: [:ash, :security],
     param_defaults: [
       sensitive_names:
-        ~w(password hashed_password password_hash token secret api_key private_key ssn)a
+        ~w(password hashed_password password_hash password_digest token access_token secret client_secret totp_secret api_key private_key ssn)a
     ],
     explanations: [
       check: """
@@ -13,9 +13,14 @@ defmodule AshCredo.Check.Warning.SensitiveAttributeExposed do
       This prevents them from being leaked in logs, error messages, and inspections.
 
           attribute :password_hash, :string, sensitive?: true
+
+      The `sensitive_names` param accepts atoms (exact name match) and regexes
+      (matched against the attribute name), e.g. `[:ssn, ~r/_token$/]`.
       """,
       params: [
-        sensitive_names: "Attribute names considered sensitive."
+        sensitive_names:
+          "Attribute names considered sensitive. Atom entries match exactly; " <>
+            "`Regex` entries (e.g. `~r/_token$/`) match against the attribute name."
       ]
     ]
 
@@ -52,8 +57,11 @@ defmodule AshCredo.Check.Warning.SensitiveAttributeExposed do
   end
 
   defp sensitive_name?({:attribute, _meta, [name | _]}, sensitive_names) when is_atom(name) do
-    name in sensitive_names
+    Enum.any?(sensitive_names, &name_matches?(name, &1))
   end
 
   defp sensitive_name?(_, _), do: false
+
+  defp name_matches?(name, %Regex{} = regex), do: Regex.match?(regex, Atom.to_string(name))
+  defp name_matches?(name, sensitive_name), do: name == sensitive_name
 end

--- a/test/ash_credo/check/warning/sensitive_attribute_exposed_test.exs
+++ b/test/ash_credo/check/warning/sensitive_attribute_exposed_test.exs
@@ -71,6 +71,99 @@ defmodule AshCredo.Check.Warning.SensitiveAttributeExposedTest do
     assert [] = run_check(SensitiveAttributeExposed, source)
   end
 
+  test "reports new default names like access_token" do
+    source = """
+    defmodule MyApp.User do
+      use Ash.Resource, domain: MyApp.Accounts
+
+      attributes do
+        uuid_primary_key :id
+        attribute :access_token, :string
+        attribute :client_secret, :string
+        attribute :totp_secret, :string
+        attribute :password_digest, :string
+      end
+    end
+    """
+
+    issues = run_check(SensitiveAttributeExposed, source)
+
+    assert sorted_triggers(issues) == ~w(access_token client_secret password_digest totp_secret)
+  end
+
+  test "regex entry in sensitive_names matches compound attribute names" do
+    source = """
+    defmodule MyApp.Webhook do
+      use Ash.Resource, domain: MyApp.Integrations
+
+      attributes do
+        uuid_primary_key :id
+        attribute :webhook_secret, :string
+        attribute :name, :string
+      end
+    end
+    """
+
+    assert [issue] =
+             run_check(SensitiveAttributeExposed, source, sensitive_names: [~r/_secret$/])
+
+    assert issue.trigger == "webhook_secret"
+  end
+
+  test "regex entry does not match non-matching names and atoms keep exact-match semantics" do
+    source = """
+    defmodule MyApp.Webhook do
+      use Ash.Resource, domain: MyApp.Integrations
+
+      attributes do
+        uuid_primary_key :id
+        attribute :secret_color, :string
+        attribute :password, :string
+        attribute :user_password, :string
+      end
+    end
+    """
+
+    issues =
+      run_check(SensitiveAttributeExposed, source, sensitive_names: [:password, ~r/_secret$/])
+
+    assert [issue] = issues
+    assert issue.trigger == "password"
+  end
+
+  test "regex-matched attribute marked sensitive stays silent" do
+    source = """
+    defmodule MyApp.Webhook do
+      use Ash.Resource, domain: MyApp.Integrations
+
+      attributes do
+        uuid_primary_key :id
+        attribute :webhook_secret, :string, sensitive?: true
+      end
+    end
+    """
+
+    assert [] =
+             run_check(SensitiveAttributeExposed, source, sensitive_names: [~r/_secret$/])
+  end
+
+  test "custom sensitive_names param fully replaces defaults" do
+    source = """
+    defmodule MyApp.User do
+      use Ash.Resource, domain: MyApp.Accounts
+
+      attributes do
+        uuid_primary_key :id
+        attribute :password, :string
+        attribute :pin_code, :string
+      end
+    end
+    """
+
+    assert [issue] = run_check(SensitiveAttributeExposed, source, sensitive_names: [:pin_code])
+    assert issue.trigger == "pin_code"
+  end
+
   test "ignores non-Ash modules" do
     source = """
     defmodule MyApp.Utils do


### PR DESCRIPTION
SensitiveAttributeExposed matched attribute names against the sensitive_names param with exact atom membership only, so compound names like :access_token or :user_password evaded the check, and the default list lacked common variants such as :client_secret.

The check now accepts %Regex{} entries in sensitive_names alongside atoms: atoms keep their exact-match semantics, while a regex entry flags any attribute whose name (as a string) matches it, e.g. ~r/_token$/. The defaults gain :password_digest, :access_token, :client_secret, and :totp_secret, grouped with their base names.

The param docstring, check explanation, and the README configurable-params table document both entry types.