### PR TITLE
test: cover the max_lines boundary and issue anchoring in LargeResource

### DIFF
--- a/test/ash_credo/check/refactor/large_resource_test.exs
+++ b/test/ash_credo/check/refactor/large_resource_test.exs
@@ -26,6 +26,49 @@ defmodule AshCredo.Check.Refactor.LargeResourceTest do
     assert [] = run_check(LargeResource, source, max_lines: 300)
   end
 
+  test "no issue when resource spans exactly max_lines lines" do
+    # defmodule on line 1 through end on line 10 - exactly 10 lines.
+    source = """
+    defmodule MyApp.Post do
+      use Ash.Resource, domain: MyApp.Blog
+
+      attributes do
+        attribute :field_1, :string
+        attribute :field_2, :string
+        attribute :field_3, :string
+        attribute :field_4, :string
+      end
+    end
+    """
+
+    assert source |> String.trim_trailing("\n") |> String.split("\n") |> length() == 10
+    assert [] = run_check(LargeResource, source, max_lines: 10)
+  end
+
+  test "reports one anchored issue when resource spans max_lines + 1 lines" do
+    # defmodule on line 1 through end on line 11 - exactly 11 lines.
+    source = """
+    defmodule MyApp.Post do
+      use Ash.Resource, domain: MyApp.Blog
+
+      attributes do
+        attribute :field_1, :string
+        attribute :field_2, :string
+        attribute :field_3, :string
+        attribute :field_4, :string
+        attribute :field_5, :string
+      end
+    end
+    """
+
+    assert source |> String.trim_trailing("\n") |> String.split("\n") |> length() == 11
+    assert [issue] = run_check(LargeResource, source, max_lines: 10)
+    assert issue.message =~ "11 lines"
+    assert issue.message =~ "limit: 10"
+    assert issue.line_no == 2
+    assert issue.trigger == "11 lines"
+  end
+
   test "ignores non-Ash modules" do
     source = """
     defmodule MyApp.Utils do


### PR DESCRIPTION
The existing LargeResource tests only exercised line counts far from the configured limit (23 lines vs max_lines: 10 and 3 lines vs 300), so the strict greater-than comparison in the check could regress to
>= without any test failing. They also never asserted where the issue
is anchored or what its trigger contains.

Add two boundary tests built around the check's line-count semantics (end line - start line + 1 of the defmodule, blank lines included), with empirical line-count assertions on the constructed sources:

- a resource spanning exactly max_lines lines produces no issue, pinning the strict > comparison
- a resource spanning max_lines + 1 lines produces exactly one issue whose message contains both the actual count and the limit, whose line_no is the use Ash.Resource line, and whose trigger is the check's "<count> lines" format