### PR TITLE
docs: ship usage-rules.md for coding agents

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -62,7 +62,7 @@ defmodule AshCredo.MixProject do
   defp package do
     [
       licenses: ["MIT"],
-      files: ~w(lib .formatter.exs mix.exs README* LICENSE* CHANGELOG*),
+      files: ~w(lib .formatter.exs mix.exs README* LICENSE* CHANGELOG* usage-rules.md),
       exclude_patterns: [~r/\.expert/],
       links: %{"GitHub" => "https://github.com/leonqadirie/ash_credo"}
     ]

--- a/test/ash_credo_test.exs
+++ b/test/ash_credo_test.exs
@@ -355,6 +355,13 @@ defmodule AshCredoTest do
       end
     end
 
+    test "usage-rules.md exists and ships in the hex package" do
+      assert File.exists?("usage-rules.md")
+
+      assert "usage-rules.md" in Mix.Project.config()[:package][:files],
+             "usage-rules.md must be listed in package[:files] in mix.exs so it ships on Hex"
+    end
+
     test "every check has a corresponding test file" do
       expected =
         for {cat, name, _path} <- discover_check_modules(), do: {cat, name}

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -1,0 +1,50 @@
+# Rules for working with AshCredo
+
+## Understanding AshCredo
+
+AshCredo is a Credo plugin providing static analysis checks for projects
+built with the Ash Framework. Checks cover Ash resources, domains, and the
+code that calls into them. Some checks analyse unexpanded source AST; others
+introspect compiled modules to see the fully-resolved DSL state, including
+anything Spark transformers and extensions contribute.
+
+## Setup
+
+Register the plugin in `.credo.exs`:
+
+    %{
+      configs: [
+        %{
+          name: "default",
+          plugins: [{AshCredo, []}]
+        }
+      ]
+    }
+
+Projects using Igniter can run `mix igniter.install ash_credo` instead, which
+adds the dependency and registers the plugin.
+
+Registering the plugin matters: it enables the default checks and sets up the
+run-scoped cache. Checks added directly to `checks:` without the plugin still
+work, but run uncached and without any defaults.
+
+## Enabling checks
+
+The plugin enables only a small, low-noise set of checks by default; most
+checks are opt-in. Do not guess check names. The authoritative list is the
+checks table in the README (<https://ash_credo.hexdocs.pm/readme.html#checks>,
+or `deps/ash_credo/README.md` inside a consuming project), which carries each
+check's category, default state, and configurable parameters, plus a
+ready-to-paste "enable all checks" block. Enable opt-in checks by adding them
+to `checks: %{extra: [...]}` in `.credo.exs`.
+
+## Compile before running
+
+Many checks introspect compiled BEAM modules rather than source AST. Run
+`mix compile` before `mix credo`, for example via an alias:
+
+    lint: ["compile", "credo --strict"]
+
+On an uncompiled project those checks emit "could not load" diagnostics
+instead of real results. The affected checks are listed in the README under
+"Checks that require a compiled project".


### PR DESCRIPTION
usage-rules.md is the Ash-ecosystem convention for teaching coding agents how to use a package (ash and igniter both ship one); ash_credo had none, so agents in consuming projects guess at plugin setup and check names.

The file covers plugin registration (and what is lost without it), how to find and enable the opt-in checks, and the compile-before-credo requirement. It deliberately names no checks and no counts - it points at the README checks table and the "Checks that require a compiled project" section instead, both of which the registry tests already keep in sync with the code, so the rules file cannot drift as checks are added or defaults change.

Shipped via package[:files] and guarded by a registry test asserting the file exists and stays listed.