### PR TITLE
feat: add MissingValidationWrapper check for naked validation builtins

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ AshCredo detects common anti-patterns, security pitfalls, and missing best pract
 
 - `Warning.MissingChangeWrapper`
 - `Warning.MissingMacroDirective`
+- `Warning.MissingValidationWrapper`
 - `Warning.PinnedTimeInExpression`
 
 ## Installation
@@ -76,9 +77,10 @@ If you have any compiled-introspection checks enabled, run `mix compile` before 
 | `AuthorizeFalse` | Warning | High | No | Flags literal `authorize?: false` in Ash calls, action DSL, and (by default) any other call site |
 | `AuthorizerWithoutPolicies` | Warning | High | No | Detects resources with `Ash.Policy.Authorizer` but no policies defined. **Requires compiled project.** |
 | `EmptyDomain` | Warning | Normal | No | Flags domains with no resources registered |
-| `MissingChangeWrapper` | Warning | High | Yes | Flags builtin change functions (`manage_relationship`, `set_attribute`, ...) used without `change` wrapper in actions |
+| `MissingChangeWrapper` | Warning | High | Yes | Flags builtin change functions (`manage_relationship`, `set_attribute`, ...) used without `change` wrapper in actions - the bare call compiles but is silently discarded |
 | `MissingDomain` | Warning | Normal | No | Ensures non-embedded resources set the `domain:` option |
 | `MissingMacroDirective` | Warning | High | Yes | Flags qualified calls to `Ash.Query`/`Ash.Expr` macros (`filter`, `expr`, ...) when the enclosing module does not have a matching module-level `require`/`import`. Catches the runtime `UndefinedFunctionError` that slips past the compiler when the macro argument is a bare runtime value. **Requires compiled project** and **configurable**. |
+| `MissingValidationWrapper` | Warning | High | Yes | Flags builtin validation functions (`present`, `attribute_equals`, ...) used without `validate` wrapper in actions - the bare call compiles but the validation never runs |
 | `NoActions` | Warning | Normal | No | Flags resources with data layers but no actions defined. **Requires compiled project.** |
 | `OverlyPermissivePolicy` | Warning | High | No | Flags unscoped `authorize_if always()` policies |
 | `PinnedTimeInExpression` | Warning | High | Yes | Flags `^Date.utc_today()` / `^DateTime.utc_now()` in Ash expressions (frozen at compile time) |

--- a/lib/ash_credo.ex
+++ b/lib/ash_credo.ex
@@ -40,6 +40,7 @@ defmodule AshCredo do
             {AshCredo.Check.Warning.MissingChangeWrapper, []},
             {AshCredo.Check.Warning.MissingDomain, false},
             {AshCredo.Check.Warning.MissingMacroDirective, []},
+            {AshCredo.Check.Warning.MissingValidationWrapper, []},
             {AshCredo.Check.Warning.NoActions, false},
             {AshCredo.Check.Warning.OverlyPermissivePolicy, false},
             {AshCredo.Check.Warning.PinnedTimeInExpression, []},

--- a/lib/ash_credo/check/warning/missing_change_wrapper.ex
+++ b/lib/ash_credo/check/warning/missing_change_wrapper.ex
@@ -8,8 +8,10 @@ defmodule AshCredo.Check.Warning.MissingChangeWrapper do
       Builtin change functions like `manage_relationship`, `set_attribute`, and
       `relate_actor` must be wrapped in `change` when used inside an action body.
 
-      Without the wrapper, the function call returns a change reference tuple that
-      is silently discarded - the change never runs and no error is raised.
+      These builtins are plain functions imported into the DSL scope. Without
+      the wrapper, the call returns a change spec tuple that is silently
+      discarded - the change never runs and no error or warning is raised at
+      compile time or runtime.
 
           # Bad - compiles but silently does nothing
           create :some_action do
@@ -22,15 +24,15 @@ defmodule AshCredo.Check.Warning.MissingChangeWrapper do
             argument :thing, :map
             change manage_relationship(:thing, :thing, type: :create)
           end
+
+      `Warning.MissingValidationWrapper` is the equivalent check for
+      validation builtins.
       """
     ]
 
-  alias AshCredo.Introspection
   alias AshCredo.Orchestration
 
-  @action_types ~w(create update destroy action)a
-
-  @naked_change_fns ~w(
+  @change_builtins ~w(
     manage_relationship
     relate_actor
     set_attribute
@@ -49,33 +51,16 @@ defmodule AshCredo.Check.Warning.MissingChangeWrapper do
     debug_log
   )a
 
+  # No :read - read actions do not import Ash.Resource.Change.Builtins, so
+  # a bare change builtin there fails to compile and needs no lint.
+  @action_types ~w(create update destroy action)a
+
   @impl true
-  def run(%SourceFile{} = source_file, params),
-    do: Orchestration.flat_map_resource_section(source_file, params, :actions, &check_actions/2)
-
-  defp check_actions(nil, _issue_meta), do: []
-
-  defp check_actions(actions_ast, issue_meta) do
-    actions_ast
-    |> Introspection.action_entities(@action_types)
-    |> Enum.flat_map(&find_naked_changes(&1, issue_meta))
+  def run(%SourceFile{} = source_file, params) do
+    Orchestration.naked_builtin_issues(source_file, params, __MODULE__,
+      builtins: @change_builtins,
+      wrapper: "change",
+      action_types: @action_types
+    )
   end
-
-  defp find_naked_changes(action_ast, issue_meta) do
-    action_ast
-    |> Introspection.entity_body()
-    |> Enum.filter(&naked_change?/1)
-    |> Enum.map(fn {func_name, meta, _} ->
-      format_issue(issue_meta,
-        message:
-          "`#{func_name}` has no effect without a `change` wrapper. " <>
-            "Use `change #{func_name}(...)` instead.",
-        trigger: "#{func_name}",
-        line_no: meta[:line]
-      )
-    end)
-  end
-
-  defp naked_change?({func_name, _, _}) when func_name in @naked_change_fns, do: true
-  defp naked_change?(_), do: false
 end

--- a/lib/ash_credo/check/warning/missing_validation_wrapper.ex
+++ b/lib/ash_credo/check/warning/missing_validation_wrapper.ex
@@ -1,0 +1,76 @@
+defmodule AshCredo.Check.Warning.MissingValidationWrapper do
+  use Credo.Check,
+    base_priority: :high,
+    category: :warning,
+    tags: [:ash],
+    explanations: [
+      check: """
+      Builtin validation functions like `present`, `attribute_equals`, and
+      `compare` must be wrapped in `validate` when used inside an action body.
+
+      These builtins are plain functions imported into the DSL scope. Without
+      the wrapper, the call returns a validation spec tuple that is silently
+      discarded - the validation never runs, unvalidated input passes
+      through, and no error or warning is raised at compile time or runtime.
+
+          # Bad - compiles but the validation never runs
+          create :register do
+            accept [:email]
+            present(:email)
+          end
+
+          # Good - wrapped in validate
+          create :register do
+            accept [:email]
+            validate present(:email)
+          end
+
+      Because some builtin names are common words (`present`, `compare`,
+      `match`), a bare call to a same-named local helper inside an action
+      body would be flagged too; silence such a call with
+      `# credo:disable-for-next-line`. `Warning.MissingChangeWrapper` is the
+      equivalent check for change builtins.
+      """
+    ]
+
+  alias AshCredo.Orchestration
+
+  @validation_builtins ~w(
+    absent
+    action_is
+    any
+    argument_does_not_equal
+    argument_equals
+    argument_in
+    attribute_does_not_equal
+    attribute_equals
+    attribute_in
+    attributes_absent
+    attributes_present
+    byte_size
+    changing
+    compare
+    confirm
+    data_one_of
+    match
+    negate
+    numericality
+    one_of
+    pre_flight_authorization
+    present
+    string_length
+  )a
+
+  # Includes :read - read actions import Ash.Resource.Validation.Builtins
+  # and accept `validate` entities, so they carry the same trap.
+  @action_types ~w(create read update destroy action)a
+
+  @impl true
+  def run(%SourceFile{} = source_file, params) do
+    Orchestration.naked_builtin_issues(source_file, params, __MODULE__,
+      builtins: @validation_builtins,
+      wrapper: "validate",
+      action_types: @action_types
+    )
+  end
+end

--- a/lib/ash_credo/orchestration.ex
+++ b/lib/ash_credo/orchestration.ex
@@ -149,4 +149,66 @@ defmodule AshCredo.Orchestration do
   end
 
   defp short_name(check), do: check |> Module.split() |> List.last()
+
+  @doc """
+  Flags bare calls to configured builtin functions at statement position
+  inside action bodies, suggesting the given DSL `wrapper` keyword. Shared
+  core of the `MissingChangeWrapper`/`MissingValidationWrapper` check
+  family: Ash's builtins are plain functions imported into the DSL scope
+  that return spec tuples, so an unwrapped call is silently discarded and
+  nothing warns at compile time or runtime.
+
+  `check` is the emitting check module. Required `opts`:
+
+    * `:builtins` - builtin function names to match
+    * `:wrapper` - the DSL keyword to suggest (e.g. `"change"`)
+    * `:action_types` - action entity types to scan; checks scope this to
+      the actions whose scope actually imports their builtin family, so a
+      bare call elsewhere is a compile error the compiler already catches
+  """
+  def naked_builtin_issues(%SourceFile{} = source_file, params, check, opts) do
+    builtins = opts |> Keyword.fetch!(:builtins) |> MapSet.new()
+    wrapper = Keyword.fetch!(opts, :wrapper)
+    action_types = Keyword.fetch!(opts, :action_types)
+
+    flat_map_resource_section(source_file, params, :actions, fn
+      nil, _issue_meta ->
+        []
+
+      actions_ast, issue_meta ->
+        actions_ast
+        |> Introspection.action_entities(action_types)
+        |> Enum.flat_map(&naked_builtin_calls(&1, builtins, wrapper, issue_meta, check))
+    end)
+  end
+
+  defp naked_builtin_calls(action_ast, builtins, wrapper, issue_meta, check) do
+    action_ast
+    |> Introspection.entity_body()
+    |> Enum.flat_map(fn
+      {func_name, meta, _} ->
+        if MapSet.member?(builtins, func_name) do
+          [naked_builtin_issue(func_name, wrapper, meta, issue_meta, check)]
+        else
+          []
+        end
+
+      _ ->
+        []
+    end)
+  end
+
+  defp naked_builtin_issue(func_name, wrapper, meta, issue_meta, check) do
+    Check.format_issue(
+      issue_meta,
+      [
+        message:
+          "`#{func_name}` has no effect without a `#{wrapper}` wrapper. " <>
+            "Use `#{wrapper} #{func_name}(...)` instead.",
+        trigger: "#{func_name}",
+        line_no: meta[:line]
+      ],
+      check
+    )
+  end
 end

--- a/test/ash_credo/check/warning/missing_change_wrapper_test.exs
+++ b/test/ash_credo/check/warning/missing_change_wrapper_test.exs
@@ -163,6 +163,38 @@ defmodule AshCredo.Check.Warning.MissingChangeWrapperTest do
     assert [] = run_check(MissingChangeWrapper, source)
   end
 
+  test "does not scan read actions (change builtins do not compile there)" do
+    source = """
+    defmodule MyApp.Post do
+      use Ash.Resource, domain: MyApp.Blog
+
+      actions do
+        read :search do
+          set_attribute(:foo, 1)
+        end
+      end
+    end
+    """
+
+    assert [] = run_check(MissingChangeWrapper, source)
+  end
+
+  test "does not flag naked validation builtins (MissingValidationWrapper's job)" do
+    source = """
+    defmodule MyApp.User do
+      use Ash.Resource, domain: MyApp.Accounts
+
+      actions do
+        create :register do
+          present(:email)
+        end
+      end
+    end
+    """
+
+    assert [] = run_check(MissingChangeWrapper, source)
+  end
+
   test "no issue when no actions section" do
     source = """
     defmodule MyApp.Post do

--- a/test/ash_credo/check/warning/missing_validation_wrapper_test.exs
+++ b/test/ash_credo/check/warning/missing_validation_wrapper_test.exs
@@ -1,0 +1,175 @@
+defmodule AshCredo.Check.Warning.MissingValidationWrapperTest do
+  use AshCredo.CheckCase
+
+  alias AshCredo.Check.Warning.MissingValidationWrapper
+
+  test "reports issue for naked validation builtin with a validate suggestion" do
+    source = """
+    defmodule MyApp.User do
+      use Ash.Resource, domain: MyApp.Accounts
+
+      actions do
+        create :register do
+          accept [:email]
+          present(:email)
+        end
+      end
+    end
+    """
+
+    assert [issue] = run_check(MissingValidationWrapper, source)
+    assert issue.trigger == "present"
+    assert issue.line_no == 7
+    assert issue.message =~ "`validate` wrapper"
+    assert issue.message =~ "validate present(...)"
+  end
+
+  test "no issue when validation builtin is wrapped in validate" do
+    source = """
+    defmodule MyApp.User do
+      use Ash.Resource, domain: MyApp.Accounts
+
+      actions do
+        create :register do
+          accept [:email]
+          validate present(:email)
+        end
+      end
+    end
+    """
+
+    assert [] = run_check(MissingValidationWrapper, source)
+  end
+
+  test "no issue when wrapped validation carries options like where:" do
+    source = """
+    defmodule MyApp.User do
+      use Ash.Resource, domain: MyApp.Accounts
+
+      actions do
+        update :update do
+          validate present(:email), where: [changing(:email)]
+        end
+      end
+    end
+    """
+
+    assert [] = run_check(MissingValidationWrapper, source)
+  end
+
+  test "reports multiple naked validations across actions" do
+    source = """
+    defmodule MyApp.User do
+      use Ash.Resource, domain: MyApp.Accounts
+
+      actions do
+        create :register do
+          present(:email)
+        end
+
+        update :promote do
+          attribute_equals(:active, true)
+        end
+      end
+    end
+    """
+
+    issues = run_check(MissingValidationWrapper, source)
+    assert [_, _] = issues
+    assert find_by_trigger(issues, "present")
+    assert find_by_trigger(issues, "attribute_equals").message =~ "validate attribute_equals(...)"
+  end
+
+  test "reports issue in generic action" do
+    source = """
+    defmodule MyApp.User do
+      use Ash.Resource, domain: MyApp.Accounts
+
+      actions do
+        action :check, :ok do
+          compare(:age, greater_than_or_equal_to: 18)
+        end
+      end
+    end
+    """
+
+    assert [issue] = run_check(MissingValidationWrapper, source)
+    assert issue.trigger == "compare"
+  end
+
+  test "reports naked validation builtin in read action" do
+    source = """
+    defmodule MyApp.User do
+      use Ash.Resource, domain: MyApp.Accounts
+
+      actions do
+        read :search do
+          argument :query, :string
+          present(:query)
+        end
+      end
+    end
+    """
+
+    assert [issue] = run_check(MissingValidationWrapper, source)
+    assert issue.trigger == "present"
+    assert issue.line_no == 7
+  end
+
+  test "no issue for wrapped validate in read action" do
+    source = """
+    defmodule MyApp.User do
+      use Ash.Resource, domain: MyApp.Accounts
+
+      actions do
+        read :search do
+          argument :query, :string
+          validate present(:query)
+        end
+      end
+    end
+    """
+
+    assert [] = run_check(MissingValidationWrapper, source)
+  end
+
+  test "does not flag naked change builtins (MissingChangeWrapper's job)" do
+    source = """
+    defmodule MyApp.Post do
+      use Ash.Resource, domain: MyApp.Blog
+
+      actions do
+        create :create do
+          set_attribute(:status, :draft)
+        end
+      end
+    end
+    """
+
+    assert [] = run_check(MissingValidationWrapper, source)
+  end
+
+  test "no issue when no actions section" do
+    source = """
+    defmodule MyApp.User do
+      use Ash.Resource, domain: MyApp.Accounts
+
+      attributes do
+        uuid_primary_key :id
+      end
+    end
+    """
+
+    assert [] = run_check(MissingValidationWrapper, source)
+  end
+
+  test "ignores non-Ash modules" do
+    source = """
+    defmodule MyApp.Utils do
+      def present(value), do: value != nil
+    end
+    """
+
+    assert [] = run_check(MissingValidationWrapper, source)
+  end
+end


### PR DESCRIPTION
Ash's validation builtins (present, attribute_equals, compare, ...) share the silent-discard failure mode MissingChangeWrapper catches for change builtins: plain functions imported into the action DSL scope that return spec tuples, so a bare call compiles, verifies, and registers nothing. Verified empirically against Ash with a clean verifier run: a bare `present(:email)` leaves the compiled action with changes: [], a changeset missing the attribute stays valid, and the compiler diagnostics are byte-identical to the correct code.

Rather than widening MissingChangeWrapper, this ships as a separate default-on check: the check name is user-facing surface (output, config, disable comments), opt-out should be `{check, false}` rather than a buried param, and the repo's convention is one concern per precisely-named check. The shared detection core lives in Orchestration.naked_builtin_issues/5; both checks are thin shells over it.

The builtin lists are deliberately NOT configurable: they mirror Ash.Resource.Change.Builtins and Ash.Resource.Validation.Builtins - facts about Ash's API surface this library maintains. Credo params replace defaults wholesale, so a configurable list would let users fork it and silently miss builtins added in later releases. One-off false positives (a local helper named `present`/`compare`/`match` called bare in an action body) are silenced with standard credo:disable comments, as documented in the check explanation.