### PR TITLE
feat: add ActorOnCallOptions check

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ If you have any compiled-introspection checks enabled, run `mix compile` before 
 
 | Check | Category | Priority | Default | Description |
 |---|---|---|---|---|
+| `ActorOnCallOptions` | Warning | High | No | Flags `actor:`/`tenant:` passed in the options of `Ash.read!`/`Ash.create!`/... when the subject visibly went through a `for_*` builder - per Ash's authorization usage rules they belong on the query/changeset/input |
 | `AuthorizeFalse` | Warning | High | No | Flags literal `authorize?: false` in Ash calls, action DSL, and (by default) any other call site |
 | `AuthorizerWithoutPolicies` | Warning | High | No | Detects resources with `Ash.Policy.Authorizer` but no policies defined. **Requires compiled project.** |
 | `EmptyDomain` | Warning | Normal | No | Flags domains with no resources registered |
@@ -166,6 +167,7 @@ To enable **all** checks at once (the default-on checks listed above do not need
 ```elixir
 checks: %{
   extra: [
+    {AshCredo.Check.Warning.ActorOnCallOptions, []},
     {AshCredo.Check.Warning.AuthorizeFalse, []},
     {AshCredo.Check.Warning.AuthorizerWithoutPolicies, []},
     {AshCredo.Check.Warning.EmptyDomain, []},

--- a/lib/ash_credo.ex
+++ b/lib/ash_credo.ex
@@ -34,6 +34,7 @@ defmodule AshCredo do
         checks: %{
           extra: [
             # Warning
+            {AshCredo.Check.Warning.ActorOnCallOptions, false},
             {AshCredo.Check.Warning.AuthorizeFalse, false},
             {AshCredo.Check.Warning.AuthorizerWithoutPolicies, false},
             {AshCredo.Check.Warning.EmptyDomain, false},

--- a/lib/ash_credo/check/warning/actor_on_call_options.ex
+++ b/lib/ash_credo/check/warning/actor_on_call_options.ex
@@ -1,0 +1,128 @@
+defmodule AshCredo.Check.Warning.ActorOnCallOptions do
+  use Credo.Check,
+    base_priority: :high,
+    category: :warning,
+    tags: [:ash],
+    explanations: [
+      check: """
+      `actor:` and `tenant:` belong on the query/changeset/input, set when it
+      is built - not in the options of the action call. This enforces the
+      rule from Ash's authorization usage rules ("Always set the actor on the
+      query/changeset/input, not when calling the action").
+
+          # Bad - the query was built without the actor
+          Post
+          |> Ash.Query.for_read(:read, %{})
+          |> Ash.read!(actor: current_user)
+
+          # Good - the actor is part of the action context from the start
+          Post
+          |> Ash.Query.for_read(:read, %{}, actor: current_user)
+          |> Ash.read!()
+
+      When a query, changeset, or action input is built via `for_read`,
+      `for_create`, and friends, everything that runs at build time sees the
+      actor and tenant it was built with; supplying them only at call time
+      leaves that build-time context inconsistent.
+
+      Only calls whose subject visibly went through a `for_*` builder are
+      flagged. Forms without a pre-built subject, such as
+      `Ash.read!(Post, actor: actor)` or code interface calls like
+      `MyApp.Blog.list_posts!(actor: actor)`, are sanctioned - there Ash
+      builds the action context with the given actor itself. The check is
+      purely syntactic: it follows pipes and simple variable bindings, but
+      cannot see builders hidden behind function calls.
+      """
+    ]
+
+  alias AshCredo.Introspection.Aliases
+  alias AshCredo.Introspection.AshCallScanner
+
+  # Ash action-invocation functions taking a query/changeset/input subject
+  # plus an options list.
+  @action_funs ~w(read read! read_one read_one! first first! stream! count count! exists exists? create create! update update! destroy destroy! run_action run_action!)a
+
+  # Builders that establish the action context; actor/tenant belong in their
+  # options.
+  @builder_funs ~w(for_read for_create for_update for_destroy for_action)a
+  @builder_modules [[:Ash, :Query], [:Ash, :Changeset], [:Ash, :ActionInput]]
+
+  # `scope:` is deliberately not flagged: passing a scope at call time is a
+  # sanctioned way to inherit actor/tenant from a context.
+  @flagged_keys [:actor, :tenant]
+
+  @impl true
+  def run(%SourceFile{} = source_file, params) do
+    issue_meta = IssueMeta.for(source_file, params)
+
+    source_file
+    |> AshCallScanner.calls_with_context()
+    |> Enum.flat_map(&check_call(&1, issue_meta))
+  end
+
+  defp check_call(%{expanded_module: [:Ash], call_ast: call_ast} = call_info, issue_meta) do
+    {{:., _, [_, fun_name]}, meta, _} = call_ast
+
+    with true <- fun_name in @action_funs,
+         [subject | _] <- call_info.args,
+         keys when keys != [] <- flagged_keys(call_info.args),
+         true <- builder_subject?(subject, call_info, MapSet.new()) do
+      Enum.map(keys, &flagged_key_issue(&1, fun_name, meta, issue_meta))
+    else
+      _ -> []
+    end
+  end
+
+  defp check_call(_call_info, _issue_meta), do: []
+
+  # Walks to the final argument (the options of an Ash call) in one pass
+  # with no intermediate list - the descent is what `List.last/1` does
+  # internally, with the keyword-list shape check fused in.
+  defp flagged_keys([opts]) when is_list(opts) do
+    for {key, _value} <- opts, is_atom(key), key in @flagged_keys, do: key
+  end
+
+  defp flagged_keys([_arg | rest]), do: flagged_keys(rest)
+  defp flagged_keys(_args), do: []
+
+  # True when the call subject visibly went through a `for_*` builder:
+  # directly, anywhere in a pipe chain, or via simple variable bindings
+  # (cycle-guarded, mirroring AshCallResolver's origin tracing).
+  defp builder_subject?({:|>, _, [left, right]}, call_info, seen) do
+    builder_call?(right, call_info) or builder_subject?(left, call_info, seen)
+  end
+
+  defp builder_subject?({name, _, ctx}, call_info, seen)
+       when is_atom(name) and (is_atom(ctx) or is_nil(ctx)) do
+    key = {name, ctx}
+
+    if MapSet.member?(seen, key) do
+      false
+    else
+      case Map.get(call_info.bindings, key) do
+        nil -> false
+        bound -> builder_subject?(bound, call_info, MapSet.put(seen, key))
+      end
+    end
+  end
+
+  defp builder_subject?(ast, call_info, _seen), do: builder_call?(ast, call_info)
+
+  defp builder_call?({{:., _, [module_ast, fun_name]}, _, _}, call_info)
+       when fun_name in @builder_funs do
+    Aliases.resolved_module_ref(module_ast, call_info) in @builder_modules
+  end
+
+  defp builder_call?(_, _), do: false
+
+  defp flagged_key_issue(key, fun_name, meta, issue_meta) do
+    format_issue(issue_meta,
+      message:
+        "`#{key}:` passed in the options of `Ash.#{fun_name}` - set it on the " <>
+          "query/changeset/input when building it (e.g. `for_read(..., #{key}: ...)`) " <>
+          "instead of at call time.",
+      trigger: "#{key}",
+      line_no: meta[:line]
+    )
+  end
+end

--- a/test/ash_credo/check/warning/actor_on_call_options_test.exs
+++ b/test/ash_credo/check/warning/actor_on_call_options_test.exs
@@ -1,0 +1,178 @@
+defmodule AshCredo.Check.Warning.ActorOnCallOptionsTest do
+  use AshCredo.CheckCase
+
+  alias AshCredo.Check.Warning.ActorOnCallOptions
+
+  test "reports actor: on the call after a for_read pipe" do
+    source = """
+    defmodule MyApp.Posts do
+      def list(current_user) do
+        MyApp.Post
+        |> Ash.Query.for_read(:read, %{})
+        |> Ash.read!(actor: current_user)
+      end
+    end
+    """
+
+    assert [issue] = run_check(ActorOnCallOptions, source)
+    assert issue.trigger == "actor"
+    assert issue.line_no == 5
+    assert issue.message =~ "for_read(..., actor: ...)"
+  end
+
+  test "reports tenant: on the call after a for_read pipe" do
+    source = """
+    defmodule MyApp.Posts do
+      def list(tenant) do
+        MyApp.Post
+        |> Ash.Query.for_read(:read, %{})
+        |> Ash.read!(tenant: tenant)
+      end
+    end
+    """
+
+    assert [issue] = run_check(ActorOnCallOptions, source)
+    assert issue.trigger == "tenant"
+  end
+
+  test "reports both keys as separate issues" do
+    source = """
+    defmodule MyApp.Posts do
+      def list(user, tenant) do
+        MyApp.Post
+        |> Ash.Query.for_read(:read, %{})
+        |> Ash.read!(actor: user, tenant: tenant)
+      end
+    end
+    """
+
+    issues = run_check(ActorOnCallOptions, source)
+    assert [_, _] = issues
+    assert find_by_trigger(issues, "actor")
+    assert find_by_trigger(issues, "tenant")
+  end
+
+  test "reports actor: when the built query is bound to a variable" do
+    source = """
+    defmodule MyApp.Posts do
+      def list(current_user) do
+        query = Ash.Query.for_read(MyApp.Post, :read, %{})
+        Ash.read!(query, actor: current_user)
+      end
+    end
+    """
+
+    assert [issue] = run_check(ActorOnCallOptions, source)
+    assert issue.trigger == "actor"
+  end
+
+  test "reports actor: on create after a for_create changeset" do
+    source = """
+    defmodule MyApp.Posts do
+      def create(params, current_user) do
+        MyApp.Post
+        |> Ash.Changeset.for_create(:create, params)
+        |> Ash.create!(actor: current_user)
+      end
+    end
+    """
+
+    assert [issue] = run_check(ActorOnCallOptions, source)
+    assert issue.message =~ "Ash.create!"
+  end
+
+  test "resolves aliased builder modules" do
+    source = """
+    defmodule MyApp.Posts do
+      alias Ash.Query, as: Q
+
+      def list(current_user) do
+        MyApp.Post
+        |> Q.for_read(:read, %{})
+        |> Ash.read!(actor: current_user)
+      end
+    end
+    """
+
+    assert [issue] = run_check(ActorOnCallOptions, source)
+    assert issue.trigger == "actor"
+  end
+
+  test "no issue when the actor is set on the builder" do
+    source = """
+    defmodule MyApp.Posts do
+      def list(current_user) do
+        MyApp.Post
+        |> Ash.Query.for_read(:read, %{}, actor: current_user)
+        |> Ash.read!()
+      end
+    end
+    """
+
+    assert [] = run_check(ActorOnCallOptions, source)
+  end
+
+  test "no issue for actor: without a pre-built subject (sanctioned form)" do
+    source = """
+    defmodule MyApp.Posts do
+      def list(current_user) do
+        Ash.read!(MyApp.Post, actor: current_user)
+      end
+    end
+    """
+
+    assert [] = run_check(ActorOnCallOptions, source)
+  end
+
+  test "no issue for scope: at call time (sanctioned context inheritance)" do
+    source = """
+    defmodule MyApp.Posts do
+      def list(context) do
+        MyApp.Post
+        |> Ash.Query.for_read(:read, %{})
+        |> Ash.read!(scope: context)
+      end
+    end
+    """
+
+    assert [] = run_check(ActorOnCallOptions, source)
+  end
+
+  test "no issue for code interface calls with actor:" do
+    source = """
+    defmodule MyApp.Web do
+      def list(current_user) do
+        MyApp.Blog.list_posts!(actor: current_user)
+      end
+    end
+    """
+
+    assert [] = run_check(ActorOnCallOptions, source)
+  end
+
+  test "no issue when the subject origin is not visible" do
+    source = """
+    defmodule MyApp.Posts do
+      def run(query, current_user) do
+        Ash.read!(query, actor: current_user)
+      end
+    end
+    """
+
+    assert [] = run_check(ActorOnCallOptions, source)
+  end
+
+  test "ignores non-Ash modules" do
+    source = """
+    defmodule MyApp.Utils do
+      def read!(subject, opts), do: {subject, opts}
+
+      def run(q, user) do
+        MyApp.Utils.read!(q, actor: user)
+      end
+    end
+    """
+
+    assert [] = run_check(ActorOnCallOptions, source)
+  end
+end


### PR DESCRIPTION
Ash's authorization usage rules state: "Always set the actor on the query/changeset/input, not when calling the action", with `Ash.Query.for_read(...) |> Ash.read!(actor: actor)` as the canonical "BAD, DO NOT DO THIS" example. The actor and tenant are part of the action context the for_* builders establish; supplying them only at call time leaves whatever ran at build time with an inconsistent context.

The check is deliberately narrower than "any actor: in call options": it flags only calls whose subject visibly went through a for_* builder (directly, anywhere in a pipe chain, or via simple variable bindings, cycle-guarded like AshCallResolver's origin tracing). Forms without a pre-built subject - `Ash.read!(Post, actor: actor)` and code interface calls - are sanctioned: there Ash builds the action context with the given actor itself. `scope:` is never flagged; passing a scope at call time is the documented way to inherit actor/tenant from a context.

Pure AST, opt-in, no params. Builds on AshCallScanner's pipe-normalized calls_with_context.