### PR TITLE
feat: cover pipeline bodies and preparations in the wrapper checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ AshCredo detects common anti-patterns, security pitfalls, and missing best pract
 
 - `Warning.MissingChangeWrapper`
 - `Warning.MissingMacroDirective`
+- `Warning.MissingPrepareWrapper`
 - `Warning.MissingValidationWrapper`
 - `Warning.PinnedTimeInExpression`
 
@@ -78,10 +79,11 @@ If you have any compiled-introspection checks enabled, run `mix compile` before 
 | `AuthorizeFalse` | Warning | High | No | Flags literal `authorize?: false` in Ash calls, action DSL, and (by default) any other call site |
 | `AuthorizerWithoutPolicies` | Warning | High | No | Detects resources with `Ash.Policy.Authorizer` but no policies defined. **Requires compiled project.** |
 | `EmptyDomain` | Warning | Normal | No | Flags domains with no resources registered |
-| `MissingChangeWrapper` | Warning | High | Yes | Flags builtin change functions (`manage_relationship`, `set_attribute`, ...) used without `change` wrapper in actions - the bare call compiles but is silently discarded |
+| `MissingChangeWrapper` | Warning | High | Yes | Flags builtin change functions (`manage_relationship`, `set_attribute`, ...) used without `change` wrapper in actions and pipelines - the bare call compiles but is silently discarded |
 | `MissingDomain` | Warning | Normal | No | Ensures non-embedded resources set the `domain:` option |
 | `MissingMacroDirective` | Warning | High | Yes | Flags qualified calls to `Ash.Query`/`Ash.Expr` macros (`filter`, `expr`, ...) when the enclosing module does not have a matching module-level `require`/`import`. Catches the runtime `UndefinedFunctionError` that slips past the compiler when the macro argument is a bare runtime value. **Requires compiled project** and **configurable**. |
-| `MissingValidationWrapper` | Warning | High | Yes | Flags builtin validation functions (`present`, `attribute_equals`, ...) used without `validate` wrapper in actions - the bare call compiles but the validation never runs |
+| `MissingPrepareWrapper` | Warning | High | Yes | Flags builtin preparation functions (`build`, `set_context`) used without `prepare` wrapper in read/generic actions and pipelines - the bare call compiles but the preparation never runs |
+| `MissingValidationWrapper` | Warning | High | Yes | Flags builtin validation functions (`present`, `attribute_equals`, ...) used without `validate` wrapper in actions and pipelines - the bare call compiles but the validation never runs |
 | `NoActions` | Warning | Normal | No | Flags resources with data layers but no actions defined. **Requires compiled project.** |
 | `OverlyPermissivePolicy` | Warning | High | No | Flags unscoped `authorize_if always()` policies |
 | `PinnedTimeInExpression` | Warning | High | Yes | Flags `^Date.utc_today()` / `^DateTime.utc_now()` in Ash expressions (frozen at compile time) |

--- a/lib/ash_credo.ex
+++ b/lib/ash_credo.ex
@@ -41,6 +41,7 @@ defmodule AshCredo do
             {AshCredo.Check.Warning.MissingChangeWrapper, []},
             {AshCredo.Check.Warning.MissingDomain, false},
             {AshCredo.Check.Warning.MissingMacroDirective, []},
+            {AshCredo.Check.Warning.MissingPrepareWrapper, []},
             {AshCredo.Check.Warning.MissingValidationWrapper, []},
             {AshCredo.Check.Warning.NoActions, false},
             {AshCredo.Check.Warning.OverlyPermissivePolicy, false},

--- a/lib/ash_credo/check/warning/missing_change_wrapper.ex
+++ b/lib/ash_credo/check/warning/missing_change_wrapper.ex
@@ -25,8 +25,12 @@ defmodule AshCredo.Check.Warning.MissingChangeWrapper do
             change manage_relationship(:thing, :thing, type: :create)
           end
 
-      `Warning.MissingValidationWrapper` is the equivalent check for
-      validation builtins.
+      The same trap exists inside `pipeline` bodies (the `pipelines`
+      section), which import the change builtins too - bare calls there are
+      flagged as well.
+
+      `Warning.MissingValidationWrapper` and `Warning.MissingPrepareWrapper`
+      are the equivalent checks for validation and preparation builtins.
       """
     ]
 
@@ -51,16 +55,24 @@ defmodule AshCredo.Check.Warning.MissingChangeWrapper do
     debug_log
   )a
 
-  # No :read - read actions do not import Ash.Resource.Change.Builtins, so
-  # a bare change builtin there fails to compile and needs no lint.
-  @action_types ~w(create update destroy action)a
+  # No :read or :action - those import only the Preparation and Validation
+  # builtins, so a bare change builtin there fails to compile and needs no
+  # lint. The one change builtin that does compile bare in a generic action
+  # is `set_context` (via its Ash.Resource.Preparation.Builtins twin) - it
+  # belongs to MissingPrepareWrapper there, because generic actions take
+  # `prepare`, not `change`.
+  @action_types ~w(create update destroy)a
 
   @impl true
   def run(%SourceFile{} = source_file, params) do
     Orchestration.naked_builtin_issues(source_file, params, __MODULE__,
       builtins: @change_builtins,
       wrapper: "change",
-      action_types: @action_types
+      action_types: @action_types,
+      # Pipeline bodies import all builtin families, including the changes;
+      # the ambiguous `set_context` is owned by this check there, since
+      # pipelines accept `change` entities.
+      pipeline_builtins: @change_builtins
     )
   end
 end

--- a/lib/ash_credo/check/warning/missing_prepare_wrapper.ex
+++ b/lib/ash_credo/check/warning/missing_prepare_wrapper.ex
@@ -1,0 +1,63 @@
+defmodule AshCredo.Check.Warning.MissingPrepareWrapper do
+  use Credo.Check,
+    base_priority: :high,
+    category: :warning,
+    tags: [:ash],
+    explanations: [
+      check: """
+      Builtin preparation functions (`build`, `set_context`) must be wrapped
+      in `prepare` when used inside a read or generic action body.
+
+      These builtins are plain functions imported into the DSL scope. Without
+      the wrapper, the call returns a preparation spec tuple that is silently
+      discarded - the preparation never runs and no error or warning is
+      raised at compile time or runtime.
+
+          # Bad - compiles but the preparation never runs
+          read :recent do
+            build(sort: [inserted_at: :desc])
+          end
+
+          # Good - wrapped in prepare
+          read :recent do
+            prepare build(sort: [inserted_at: :desc])
+          end
+
+      The same trap exists inside `pipeline` bodies (the `pipelines`
+      section), which import the preparation builtins too - a bare `build`
+      there is flagged as well. A bare `set_context` in a pipeline is
+      reported by `Warning.MissingChangeWrapper` instead, because pipelines
+      accept `change` entities and the name exists in both builtin families.
+
+      Because `build` is a common word, a bare call to a same-named local
+      helper inside an action body would be flagged too; silence such a
+      call with `# credo:disable-for-next-line`.
+      `Warning.MissingChangeWrapper` and `Warning.MissingValidationWrapper`
+      are the equivalent checks for change and validation builtins.
+      """
+    ]
+
+  alias AshCredo.Orchestration
+
+  @preparation_builtins ~w(build set_context)a
+
+  # Only :read and :action import Ash.Resource.Preparation.Builtins; a bare
+  # preparation builtin in create/update/destroy fails to compile and needs
+  # no lint.
+  @action_types ~w(read action)a
+
+  # Pipeline bodies import the change builtins alongside the preparations,
+  # making a bare `set_context` ambiguous there; MissingChangeWrapper owns
+  # it in pipelines, so only the unambiguous `build` is flagged here.
+  @pipeline_builtins ~w(build)a
+
+  @impl true
+  def run(%SourceFile{} = source_file, params) do
+    Orchestration.naked_builtin_issues(source_file, params, __MODULE__,
+      builtins: @preparation_builtins,
+      wrapper: "prepare",
+      action_types: @action_types,
+      pipeline_builtins: @pipeline_builtins
+    )
+  end
+end

--- a/lib/ash_credo/check/warning/missing_validation_wrapper.ex
+++ b/lib/ash_credo/check/warning/missing_validation_wrapper.ex
@@ -25,11 +25,16 @@ defmodule AshCredo.Check.Warning.MissingValidationWrapper do
             validate present(:email)
           end
 
+      The same trap exists inside `pipeline` bodies (the `pipelines`
+      section), which import the validation builtins too - bare calls there
+      are flagged as well.
+
       Because some builtin names are common words (`present`, `compare`,
       `match`), a bare call to a same-named local helper inside an action
       body would be flagged too; silence such a call with
-      `# credo:disable-for-next-line`. `Warning.MissingChangeWrapper` is the
-      equivalent check for change builtins.
+      `# credo:disable-for-next-line`. `Warning.MissingChangeWrapper` and
+      `Warning.MissingPrepareWrapper` are the equivalent checks for change
+      and preparation builtins.
       """
     ]
 
@@ -70,7 +75,8 @@ defmodule AshCredo.Check.Warning.MissingValidationWrapper do
     Orchestration.naked_builtin_issues(source_file, params, __MODULE__,
       builtins: @validation_builtins,
       wrapper: "validate",
-      action_types: @action_types
+      action_types: @action_types,
+      pipeline_builtins: @validation_builtins
     )
   end
 end

--- a/lib/ash_credo/orchestration.ex
+++ b/lib/ash_credo/orchestration.ex
@@ -153,10 +153,10 @@ defmodule AshCredo.Orchestration do
   @doc """
   Flags bare calls to configured builtin functions at statement position
   inside action bodies, suggesting the given DSL `wrapper` keyword. Shared
-  core of the `MissingChangeWrapper`/`MissingValidationWrapper` check
-  family: Ash's builtins are plain functions imported into the DSL scope
-  that return spec tuples, so an unwrapped call is silently discarded and
-  nothing warns at compile time or runtime.
+  core of the `MissingChangeWrapper`/`MissingValidationWrapper`/
+  `MissingPrepareWrapper` check family: Ash's builtins are plain functions
+  imported into the DSL scope that return spec tuples, so an unwrapped call
+  is silently discarded and nothing warns at compile time or runtime.
 
   `check` is the emitting check module. Required `opts`:
 
@@ -165,21 +165,60 @@ defmodule AshCredo.Orchestration do
     * `:action_types` - action entity types to scan; checks scope this to
       the actions whose scope actually imports their builtin family, so a
       bare call elsewhere is a compile error the compiler already catches
+
+  Optional `opts`:
+
+    * `:pipeline_builtins` - builtin names to also flag at statement
+      position inside `pipeline` bodies in the `pipelines` section
+      (defaults to `[]`). Pipeline bodies import all three builtin families
+      at once, so checks split ownership of names that exist in more than
+      one family to avoid double-flagging the same call.
   """
   def naked_builtin_issues(%SourceFile{} = source_file, params, check, opts) do
     builtins = opts |> Keyword.fetch!(:builtins) |> MapSet.new()
     wrapper = Keyword.fetch!(opts, :wrapper)
     action_types = Keyword.fetch!(opts, :action_types)
+    pipeline_builtins = opts |> Keyword.get(:pipeline_builtins, []) |> MapSet.new()
 
-    flat_map_resource_section(source_file, params, :actions, fn
-      nil, _issue_meta ->
-        []
+    flat_map_resource_context(source_file, params, fn context, issue_meta ->
+      action_issues =
+        naked_builtin_section_issues(
+          context,
+          {:actions, action_types, builtins},
+          wrapper,
+          issue_meta,
+          check
+        )
 
-      actions_ast, issue_meta ->
-        actions_ast
-        |> Introspection.action_entities(action_types)
-        |> Enum.flat_map(&naked_builtin_calls(&1, builtins, wrapper, issue_meta, check))
+      pipeline_issues =
+        naked_builtin_section_issues(
+          context,
+          {:pipelines, [:pipeline], pipeline_builtins},
+          wrapper,
+          issue_meta,
+          check
+        )
+
+      action_issues ++ pipeline_issues
     end)
+  end
+
+  defp naked_builtin_section_issues(
+         context,
+         {section_name, entity_names, builtins},
+         wrapper,
+         issue_meta,
+         check
+       ) do
+    with true <- MapSet.size(builtins) > 0,
+         section_ast when not is_nil(section_ast) <-
+           Introspection.resource_section(context, section_name) do
+      section_ast
+      |> Introspection.action_entities(entity_names)
+      |> Enum.flat_map(&naked_builtin_calls(&1, builtins, wrapper, issue_meta, check))
+    else
+      _ -> []
+    end
   end
 
   defp naked_builtin_calls(action_ast, builtins, wrapper, issue_meta, check) do

--- a/test/ash_credo/check/warning/missing_change_wrapper_test.exs
+++ b/test/ash_credo/check/warning/missing_change_wrapper_test.exs
@@ -128,7 +128,7 @@ defmodule AshCredo.Check.Warning.MissingChangeWrapperTest do
     assert issue.message =~ "set_attribute"
   end
 
-  test "reports issue in generic action" do
+  test "does not scan generic actions (change builtins do not compile there)" do
     source = """
     defmodule MyApp.Post do
       use Ash.Resource, domain: MyApp.Blog
@@ -136,13 +136,13 @@ defmodule AshCredo.Check.Warning.MissingChangeWrapperTest do
       actions do
         action :promote do
           set_attribute(:featured, true)
+          set_context(%{a: 1})
         end
       end
     end
     """
 
-    assert [issue] = run_check(MissingChangeWrapper, source)
-    assert issue.message =~ "set_attribute"
+    assert [] = run_check(MissingChangeWrapper, source)
   end
 
   test "no issue for non-change calls in action body" do
@@ -179,6 +179,22 @@ defmodule AshCredo.Check.Warning.MissingChangeWrapperTest do
     assert [] = run_check(MissingChangeWrapper, source)
   end
 
+  test "does not flag naked build in pipeline body (MissingPrepareWrapper's job)" do
+    source = """
+    defmodule MyApp.Post do
+      use Ash.Resource, domain: MyApp.Blog
+
+      pipelines do
+        pipeline :sorted do
+          build(sort: [:id])
+        end
+      end
+    end
+    """
+
+    assert [] = run_check(MissingChangeWrapper, source)
+  end
+
   test "does not flag naked validation builtins (MissingValidationWrapper's job)" do
     source = """
     defmodule MyApp.User do
@@ -187,6 +203,44 @@ defmodule AshCredo.Check.Warning.MissingChangeWrapperTest do
       actions do
         create :register do
           present(:email)
+        end
+      end
+    end
+    """
+
+    assert [] = run_check(MissingChangeWrapper, source)
+  end
+
+  test "reports issue for naked change builtins in pipeline body" do
+    source = """
+    defmodule MyApp.Post do
+      use Ash.Resource, domain: MyApp.Blog
+
+      pipelines do
+        pipeline :defaults do
+          set_attribute(:status, :draft)
+          set_context(%{tracing: true})
+        end
+      end
+    end
+    """
+
+    issues = run_check(MissingChangeWrapper, source)
+    assert [_, _] = issues
+    triggers = Enum.map(issues, & &1.trigger)
+    assert "set_attribute" in triggers
+    assert "set_context" in triggers
+  end
+
+  test "no issue when change builtins are wrapped inside pipeline body" do
+    source = """
+    defmodule MyApp.Post do
+      use Ash.Resource, domain: MyApp.Blog
+
+      pipelines do
+        pipeline :defaults do
+          change set_attribute(:status, :draft)
+          change set_context(%{tracing: true})
         end
       end
     end

--- a/test/ash_credo/check/warning/missing_prepare_wrapper_test.exs
+++ b/test/ash_credo/check/warning/missing_prepare_wrapper_test.exs
@@ -1,0 +1,190 @@
+defmodule AshCredo.Check.Warning.MissingPrepareWrapperTest do
+  use AshCredo.CheckCase
+
+  alias AshCredo.Check.Warning.MissingPrepareWrapper
+
+  test "reports issue for naked build in read action" do
+    source = """
+    defmodule MyApp.Post do
+      use Ash.Resource, domain: MyApp.Blog
+
+      actions do
+        read :recent do
+          build(sort: [inserted_at: :desc])
+        end
+      end
+    end
+    """
+
+    assert [issue] = run_check(MissingPrepareWrapper, source)
+    assert issue.trigger == "build"
+    assert issue.line_no == 6
+    assert issue.message =~ "prepare"
+  end
+
+  test "no issue when build is wrapped in prepare" do
+    source = """
+    defmodule MyApp.Post do
+      use Ash.Resource, domain: MyApp.Blog
+
+      actions do
+        read :recent do
+          prepare build(sort: [inserted_at: :desc])
+        end
+      end
+    end
+    """
+
+    assert [] = run_check(MissingPrepareWrapper, source)
+  end
+
+  test "reports issue for naked set_context in read action" do
+    source = """
+    defmodule MyApp.Post do
+      use Ash.Resource, domain: MyApp.Blog
+
+      actions do
+        read :search do
+          set_context(%{tracing: true})
+        end
+      end
+    end
+    """
+
+    assert [issue] = run_check(MissingPrepareWrapper, source)
+    assert issue.trigger == "set_context"
+  end
+
+  test "reports issue for naked preparation builtins in generic action" do
+    source = """
+    defmodule MyApp.Post do
+      use Ash.Resource, domain: MyApp.Blog
+
+      actions do
+        action :compute, :integer do
+          set_context(%{tracing: true})
+          run fn _input, _context -> {:ok, 1} end
+        end
+      end
+    end
+    """
+
+    assert [issue] = run_check(MissingPrepareWrapper, source)
+    assert issue.trigger == "set_context"
+  end
+
+  test "does not scan create/update/destroy actions (preparation builtins do not compile there)" do
+    source = """
+    defmodule MyApp.Post do
+      use Ash.Resource, domain: MyApp.Blog
+
+      actions do
+        create :make do
+          build(sort: [:id])
+        end
+
+        update :rename do
+          build(sort: [:id])
+        end
+
+        destroy :archive do
+          set_context(%{a: 1})
+        end
+      end
+    end
+    """
+
+    assert [] = run_check(MissingPrepareWrapper, source)
+  end
+
+  test "reports issue for naked build in pipeline body" do
+    source = """
+    defmodule MyApp.Post do
+      use Ash.Resource, domain: MyApp.Blog
+
+      pipelines do
+        pipeline :sorted do
+          build(sort: [inserted_at: :desc])
+        end
+      end
+    end
+    """
+
+    assert [issue] = run_check(MissingPrepareWrapper, source)
+    assert issue.trigger == "build"
+    assert issue.line_no == 6
+  end
+
+  test "no issue when build is wrapped in prepare inside pipeline body" do
+    source = """
+    defmodule MyApp.Post do
+      use Ash.Resource, domain: MyApp.Blog
+
+      pipelines do
+        pipeline :sorted do
+          prepare build(sort: [inserted_at: :desc])
+        end
+      end
+    end
+    """
+
+    assert [] = run_check(MissingPrepareWrapper, source)
+  end
+
+  test "does not flag naked set_context in pipeline body (MissingChangeWrapper's job)" do
+    source = """
+    defmodule MyApp.Post do
+      use Ash.Resource, domain: MyApp.Blog
+
+      pipelines do
+        pipeline :ctx do
+          set_context(%{tracing: true})
+        end
+      end
+    end
+    """
+
+    assert [] = run_check(MissingPrepareWrapper, source)
+  end
+
+  test "no issue for non-preparation calls in read action body" do
+    source = """
+    defmodule MyApp.Post do
+      use Ash.Resource, domain: MyApp.Blog
+
+      actions do
+        read :search do
+          argument :query, :string
+          prepare build(sort: [:id])
+        end
+      end
+    end
+    """
+
+    assert [] = run_check(MissingPrepareWrapper, source)
+  end
+
+  test "no issue when no actions or pipelines section" do
+    source = """
+    defmodule MyApp.Post do
+      use Ash.Resource, domain: MyApp.Blog
+
+      attributes do
+        uuid_primary_key :id
+      end
+    end
+    """
+
+    assert [] = run_check(MissingPrepareWrapper, source)
+  end
+
+  test "ignores non-Ash modules" do
+    source = """
+    defmodule MyApp.Utils do
+      def query, do: build(sort: [:id])
+    end
+    """
+
+    assert [] = run_check(MissingPrepareWrapper, source)
+  end
+end

--- a/test/ash_credo/check/warning/missing_validation_wrapper_test.exs
+++ b/test/ash_credo/check/warning/missing_validation_wrapper_test.exs
@@ -133,6 +133,40 @@ defmodule AshCredo.Check.Warning.MissingValidationWrapperTest do
     assert [] = run_check(MissingValidationWrapper, source)
   end
 
+  test "reports issue for naked validation builtin in pipeline body" do
+    source = """
+    defmodule MyApp.User do
+      use Ash.Resource, domain: MyApp.Accounts
+
+      pipelines do
+        pipeline :guarded do
+          present(:email)
+        end
+      end
+    end
+    """
+
+    assert [issue] = run_check(MissingValidationWrapper, source)
+    assert issue.trigger == "present"
+    assert issue.line_no == 6
+  end
+
+  test "no issue when validation builtin is wrapped inside pipeline body" do
+    source = """
+    defmodule MyApp.User do
+      use Ash.Resource, domain: MyApp.Accounts
+
+      pipelines do
+        pipeline :guarded do
+          validate present(:email)
+        end
+      end
+    end
+    """
+
+    assert [] = run_check(MissingValidationWrapper, source)
+  end
+
   test "does not flag naked change builtins (MissingChangeWrapper's job)" do
     source = """
     defmodule MyApp.Post do


### PR DESCRIPTION
The pipelines DSL (Ash 3.23+) imports all three builtin families (Change, Validation, Preparation) into pipeline bodies, so the silent-discard trap the wrapper checks guard against reproduces there: a bare builtin call compiles with diagnostics byte-identical to correct code, the pipeline entity stays empty, and pipe_through expands to nothing - a verified no-op. Ash itself only validates pipe_through references (unknown names raise a DslError at compile time), never empty-because-discarded pipelines.

Three coordinated changes:

- Orchestration.naked_builtin_issues gains an optional :pipeline_builtins opt that additionally scans pipeline entities in the pipelines section. MissingChangeWrapper and MissingValidationWrapper pass their full builtin lists.

- New default-on Warning.MissingPrepareWrapper completes the family for preparation builtins (build, set_context), scanning read and generic actions - the only action types that import Ash.Resource.Preparation.Builtins - plus pipeline bodies.

- MissingChangeWrapper drops :action from its scanned types: generic actions do not import Change.Builtins, so 15 of the 16 change builtins are compile errors there, and the one that does compile bare (set_context, via its Preparation.Builtins twin) needs prepare, not change - change set_context(...) is itself a compile error in a generic action. MissingPrepareWrapper owns it there now.

set_context exists in both the Change and Preparation families, so the checks split ownership to avoid double-flagging: in pipeline bodies (both families imported, change entities accepted) it belongs to MissingChangeWrapper; in read/generic actions (Change.Builtins not imported) to MissingPrepareWrapper.