### PR TITLE
feat: add RedundantValidation check for present on non-nullable attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ If you have any compiled-introspection checks enabled, run `mix compile` before 
 | `NoActions` | Warning | Normal | No | Flags resources with data layers but no actions defined. **Requires compiled project.** |
 | `OverlyPermissivePolicy` | Warning | High | No | Flags unscoped `authorize_if always()` policies |
 | `PinnedTimeInExpression` | Warning | High | Yes | Flags `^Date.utc_today()` / `^DateTime.utc_now()` in Ash expressions (frozen at compile time) |
+| `RedundantValidation` | Warning | Normal | No | Flags `validate present(...)` on attributes that already have `allow_nil? false` - the constraint guarantees presence, making the validation redundant (skips `allow_nil_input` escape hatches). **Requires compiled project.** |
 | `SensitiveAttributeExposed` | Warning | High | No | Flags sensitive attributes (password, token, secret, ...) not marked `sensitive?: true` |
 | `SensitiveFieldInAccept` | Warning | High | No | Flags privilege-escalation fields (`is_admin`, `permissions`, ...) in `accept` lists |
 | `UnknownAction` | Warning | High | No | Flags `Ash.*` calls referencing actions that do not exist on the resolved resource, with a fuzzy `Did you mean` hint. **Requires compiled project.** |
@@ -110,6 +111,7 @@ They see the fully-resolved resource state - including anything Spark transforme
 - `Warning.AuthorizerWithoutPolicies`
 - `Warning.MissingMacroDirective`
 - `Warning.NoActions`
+- `Warning.RedundantValidation`
 - `Warning.UnknownAction`
 - `Refactor.RaisingCall`
 - `Refactor.UseCodeInterface`
@@ -176,6 +178,7 @@ checks: %{
     {AshCredo.Check.Warning.MissingDomain, []},
     {AshCredo.Check.Warning.NoActions, []},
     {AshCredo.Check.Warning.OverlyPermissivePolicy, []},
+    {AshCredo.Check.Warning.RedundantValidation, []},
     {AshCredo.Check.Warning.SensitiveAttributeExposed, []},
     {AshCredo.Check.Warning.SensitiveFieldInAccept, []},
     {AshCredo.Check.Warning.UnknownAction, []},

--- a/lib/ash_credo.ex
+++ b/lib/ash_credo.ex
@@ -46,6 +46,7 @@ defmodule AshCredo do
             {AshCredo.Check.Warning.NoActions, false},
             {AshCredo.Check.Warning.OverlyPermissivePolicy, false},
             {AshCredo.Check.Warning.PinnedTimeInExpression, []},
+            {AshCredo.Check.Warning.RedundantValidation, false},
             {AshCredo.Check.Warning.SensitiveAttributeExposed, false},
             {AshCredo.Check.Warning.SensitiveFieldInAccept, false},
             {AshCredo.Check.Warning.UnknownAction, false},

--- a/lib/ash_credo/check/warning/redundant_validation.ex
+++ b/lib/ash_credo/check/warning/redundant_validation.ex
@@ -1,0 +1,245 @@
+defmodule AshCredo.Check.Warning.RedundantValidation do
+  use Credo.Check,
+    base_priority: :normal,
+    category: :warning,
+    tags: [:ash],
+    explanations: [
+      check: """
+      Flags `validate present(...)` where every referenced field is an
+      attribute that already has `allow_nil? false`. The attribute
+      constraint guarantees presence on its own, so the validation can only
+      ever duplicate an error the changeset already carries. Straight from
+      Ash's usage rules: avoid validations that duplicate attribute
+      constraints.
+
+          # Bad - allow_nil? false already rejects nil
+          attributes do
+            attribute :name, :string, allow_nil?: false
+          end
+
+          actions do
+            create :create do
+              validate present(:name)
+            end
+          end
+
+          # Good - let the attribute constraint handle it
+          attributes do
+            attribute :name, :string, allow_nil?: false
+          end
+
+      Fields opened up via `allow_nil_input` on an action are skipped:
+      there the attribute may legitimately be nil at validation time (for
+      example filled by the data layer during an upsert), so `present` does
+      add a real constraint. Validations in read and generic actions are
+      also skipped, because `present` resolves against action arguments
+      there, not attributes.
+
+      ## Requirements
+
+      Your project must be compiled before running `mix credo`. If Ash is
+      not available in the VM running Credo, the check is a no-op and emits
+      a single diagnostic.
+      """
+    ]
+
+  alias AshCredo.Introspection
+  alias AshCredo.Introspection.Compiled, as: CompiledIntrospection
+  alias AshCredo.Orchestration
+
+  # Only changeset-based actions resolve `present` against attributes (with
+  # argument-to-attribute fallback); in read and generic actions it checks
+  # arguments only, so attribute nullability proves nothing there.
+  @changeset_action_types ~w(create update destroy)a
+
+  @impl true
+  def run(%SourceFile{} = source_file, params) do
+    Orchestration.compiled_check_on_named_resources(
+      source_file,
+      params,
+      __MODULE__,
+      fn resource, context, issue_meta ->
+        check_resource(resource, context, issue_meta)
+      end
+    )
+  end
+
+  defp check_resource(resource, context, issue_meta) do
+    case action_candidates(context) ++ global_candidates(context) do
+      [] -> []
+      candidates -> resolve_candidates(resource, context, candidates, issue_meta)
+    end
+  end
+
+  defp action_candidates(context) do
+    case Introspection.resource_section(context, :actions) do
+      nil ->
+        []
+
+      actions_ast ->
+        actions_ast
+        |> Introspection.action_entities(@changeset_action_types)
+        |> Enum.flat_map(fn action_ast ->
+          scope = {:action, Introspection.entity_name(action_ast)}
+
+          action_ast
+          |> Introspection.entity_body()
+          |> Enum.flat_map(&parse_validate(&1, scope))
+        end)
+    end
+  end
+
+  defp global_candidates(context) do
+    case Introspection.resource_section(context, :validations) do
+      nil ->
+        []
+
+      validations_ast ->
+        validations_ast
+        |> Introspection.action_entities([:validate])
+        |> Enum.flat_map(&parse_validate(&1, :global))
+    end
+  end
+
+  defp parse_validate({:validate, meta, [present_call | rest]}, scope) do
+    with {:ok, fields, present_opts} <- parse_present(present_call),
+         true <- counting_opts_redundant?(present_opts, length(fields)),
+         true <- scope_applies?(rest, scope) do
+      [%{fields: fields, line: meta[:line], scope: scope}]
+    else
+      _ -> []
+    end
+  end
+
+  defp parse_validate(_other, _scope), do: []
+
+  defp parse_present({:present, _, [fields]}), do: literal_fields(fields, [])
+
+  defp parse_present({:present, _, [fields, opts]}) when is_list(opts),
+    do: literal_fields(fields, opts)
+
+  defp parse_present(_), do: :skip
+
+  defp literal_fields(fields, opts) when is_atom(fields), do: {:ok, [fields], opts}
+
+  defp literal_fields(fields, opts) when is_list(fields) do
+    if Enum.all?(fields, &is_atom/1), do: {:ok, fields, opts}, else: :skip
+  end
+
+  defp literal_fields(_fields, _opts), do: :skip
+
+  # The bare builtin expands to `exactly: count`, which always-present
+  # attributes always satisfy; an explicit `at_least` up to the field count
+  # likewise. Explicit `exactly`/`at_most` (e.g. `exactly: 0` for "must be
+  # absent") or non-literal options change the semantics, so skip them.
+  defp counting_opts_redundant?([], _count), do: true
+
+  defp counting_opts_redundant?(opts, count) do
+    Enum.all?(opts, fn
+      {:at_least, at_least} -> is_integer(at_least) and at_least <= count
+      _other -> false
+    end)
+  end
+
+  # `where`, `message`, and do-blocks never make an always-satisfied
+  # validation meaningful again, so action-level candidates always apply.
+  defp scope_applies?(_rest, {:action, _name}), do: true
+
+  # Global validations default to `on: [:create, :update]`; an explicit `on`
+  # must stay within changeset action types for attribute presence to apply.
+  defp scope_applies?(rest, :global) do
+    case find_on_option(rest) do
+      nil -> true
+      {:found, on} -> on |> List.wrap() |> Enum.all?(&(&1 in @changeset_action_types))
+    end
+  end
+
+  defp find_on_option(rest) do
+    Enum.find_value(rest, fn
+      opts when is_list(opts) ->
+        Enum.find_value(opts, fn
+          {:on, value} -> {:found, value}
+          {:do, block} -> block_on(block)
+          _other -> nil
+        end)
+
+      _other ->
+        nil
+    end)
+  end
+
+  defp block_on({:__block__, _, entries}), do: Enum.find_value(entries, &entry_on/1)
+  defp block_on(entry), do: entry_on(entry)
+
+  defp entry_on({:on, _, [value]}), do: {:found, value}
+  defp entry_on(_entry), do: nil
+
+  defp resolve_candidates(resource, context, candidates, issue_meta) do
+    case CompiledIntrospection.inspect_module(resource) do
+      {:ok, %{attributes: attributes, actions: actions}} ->
+        flag_redundant(resource, candidates, attributes, actions, issue_meta)
+
+      {:error, :not_loadable} ->
+        Orchestration.unique_not_loadable_issues(resource, context, issue_meta, __MODULE__)
+
+      {:error, _} ->
+        []
+    end
+  end
+
+  defp flag_redundant(resource, candidates, attributes, actions, issue_meta) do
+    non_nullable =
+      attributes
+      |> Enum.filter(&(&1.allow_nil? == false))
+      |> MapSet.new(& &1.name)
+
+    candidates
+    |> Enum.filter(&redundant?(&1, non_nullable, actions))
+    |> Enum.map(&redundant_issue(&1, resource, issue_meta))
+  end
+
+  defp redundant?(%{fields: fields, scope: scope}, non_nullable, actions) do
+    Enum.all?(fields, &MapSet.member?(non_nullable, &1)) and
+      no_nullable_inputs?(fields, scope, actions)
+  end
+
+  defp no_nullable_inputs?(fields, {:action, action_name}, actions) do
+    case Enum.find(actions, &(&1.name == action_name)) do
+      # Source names an action the compiled module does not have (stale
+      # build or fragment drift) - do not flag what we cannot resolve.
+      nil -> false
+      action -> Enum.all?(fields, &(&1 not in nullable_inputs(action)))
+    end
+  end
+
+  defp no_nullable_inputs?(fields, :global, actions) do
+    nullable = Enum.flat_map(actions, &nullable_inputs/1)
+    Enum.all?(fields, &(&1 not in nullable))
+  end
+
+  defp nullable_inputs(action), do: List.wrap(Map.get(action, :allow_nil_input) || [])
+
+  defp redundant_issue(%{fields: fields, line: line}, resource, issue_meta) do
+    format_issue(issue_meta,
+      message: message(fields, resource),
+      trigger: "present",
+      line_no: line
+    )
+  end
+
+  defp message([field], resource) do
+    "`validate present(:#{field})` is redundant: attribute `:#{field}` on " <>
+      "`#{inspect(resource)}` already has `allow_nil? false`, which guarantees presence. " <>
+      "Remove the validation - Ash's usage rules advise against validations that " <>
+      "duplicate attribute constraints."
+  end
+
+  defp message(fields, resource) do
+    listed = Enum.map_join(fields, ", ", &":#{&1}")
+
+    "`validate present(...)` on #{listed} is redundant: these attributes on " <>
+      "`#{inspect(resource)}` already have `allow_nil? false`, which guarantees presence. " <>
+      "Remove the validation - Ash's usage rules advise against validations that " <>
+      "duplicate attribute constraints."
+  end
+end

--- a/test/ash_credo/check/warning/redundant_validation_test.exs
+++ b/test/ash_credo/check/warning/redundant_validation_test.exs
@@ -1,0 +1,276 @@
+defmodule AshCredo.Check.Warning.RedundantValidationTest do
+  use AshCredo.CheckCase
+
+  alias AshCredo.Check.Warning.RedundantValidation
+  alias AshCredo.Introspection.Compiled, as: CompiledIntrospection
+
+  # Tests resolve attributes against the compiled fixture
+  # `AshCredoFixtures.Blog.Contact` (test/support/fixtures/ash_fixtures.ex):
+  # `:name` and `:handle` have `allow_nil? false`, `:nickname` is nullable,
+  # and the `:import` create action lists `:name` in `allow_nil_input` -
+  # which also shields GLOBAL validations on `:name`, so the global-scope
+  # happy-path tests use `:handle`.
+
+  setup do
+    CompiledIntrospection.clear_cache()
+    :ok
+  end
+
+  test "reports redundant present on a non-nullable attribute in a create action" do
+    source = """
+    defmodule AshCredoFixtures.Blog.Contact do
+      use Ash.Resource, domain: AshCredoFixtures.Blog
+
+      actions do
+        create :create do
+          validate present(:name)
+        end
+      end
+    end
+    """
+
+    assert [issue] = run_check(RedundantValidation, source)
+    assert issue.trigger == "present"
+    assert issue.line_no == 6
+    assert issue.message =~ "allow_nil? false"
+    assert issue.message =~ ":name"
+  end
+
+  test "reports redundant present in an update action" do
+    source = """
+    defmodule AshCredoFixtures.Blog.Contact do
+      use Ash.Resource, domain: AshCredoFixtures.Blog
+
+      actions do
+        update :rename do
+          validate present(:name)
+        end
+      end
+    end
+    """
+
+    assert [issue] = run_check(RedundantValidation, source)
+    assert issue.trigger == "present"
+  end
+
+  test "reports redundant present in the global validations section" do
+    source = """
+    defmodule AshCredoFixtures.Blog.Contact do
+      use Ash.Resource, domain: AshCredoFixtures.Blog
+
+      validations do
+        validate present(:handle)
+      end
+    end
+    """
+
+    assert [issue] = run_check(RedundantValidation, source)
+    assert issue.line_no == 5
+  end
+
+  test "reports redundant present declared with a do-block message" do
+    source = """
+    defmodule AshCredoFixtures.Blog.Contact do
+      use Ash.Resource, domain: AshCredoFixtures.Blog
+
+      validations do
+        validate present(:handle) do
+          message "Handle is required"
+        end
+      end
+    end
+    """
+
+    assert [issue] = run_check(RedundantValidation, source)
+    assert issue.trigger == "present"
+  end
+
+  test "reports redundant present with at_least up to the field count" do
+    source = """
+    defmodule AshCredoFixtures.Blog.Contact do
+      use Ash.Resource, domain: AshCredoFixtures.Blog
+
+      actions do
+        create :create do
+          validate present(:name, at_least: 1)
+        end
+      end
+    end
+    """
+
+    assert [issue] = run_check(RedundantValidation, source)
+    assert issue.trigger == "present"
+  end
+
+  test "no issue for present on a nullable attribute" do
+    source = """
+    defmodule AshCredoFixtures.Blog.Contact do
+      use Ash.Resource, domain: AshCredoFixtures.Blog
+
+      actions do
+        create :create do
+          validate present(:nickname)
+        end
+      end
+    end
+    """
+
+    assert [] = run_check(RedundantValidation, source)
+  end
+
+  test "no issue when any referenced field is nullable" do
+    source = """
+    defmodule AshCredoFixtures.Blog.Contact do
+      use Ash.Resource, domain: AshCredoFixtures.Blog
+
+      actions do
+        create :create do
+          validate present([:name, :nickname])
+        end
+      end
+    end
+    """
+
+    assert [] = run_check(RedundantValidation, source)
+  end
+
+  test "no issue when the action opens the attribute via allow_nil_input" do
+    source = """
+    defmodule AshCredoFixtures.Blog.Contact do
+      use Ash.Resource, domain: AshCredoFixtures.Blog
+
+      actions do
+        create :import do
+          validate present(:name)
+        end
+      end
+    end
+    """
+
+    assert [] = run_check(RedundantValidation, source)
+  end
+
+  test "no issue for a global validation when any action allows nil input for the field" do
+    source = """
+    defmodule AshCredoFixtures.Blog.Contact do
+      use Ash.Resource, domain: AshCredoFixtures.Blog
+
+      validations do
+        validate present(:name), on: [:create]
+      end
+    end
+    """
+
+    # The compiled :import action lists :name in allow_nil_input, so the
+    # global validation is load-bearing for that action.
+    assert [] = run_check(RedundantValidation, source)
+  end
+
+  test "no issue for present in read actions (checks arguments, not attributes)" do
+    source = """
+    defmodule AshCredoFixtures.Blog.Contact do
+      use Ash.Resource, domain: AshCredoFixtures.Blog
+
+      actions do
+        read :search do
+          argument :name, :string
+          validate present(:name)
+        end
+      end
+    end
+    """
+
+    assert [] = run_check(RedundantValidation, source)
+  end
+
+  test "no issue for a global validation targeting read actions" do
+    source = """
+    defmodule AshCredoFixtures.Blog.Contact do
+      use Ash.Resource, domain: AshCredoFixtures.Blog
+
+      validations do
+        validate present(:handle), on: [:read]
+      end
+    end
+    """
+
+    assert [] = run_check(RedundantValidation, source)
+  end
+
+  test "no issue for present with exactly or at_most semantics" do
+    source = """
+    defmodule AshCredoFixtures.Blog.Contact do
+      use Ash.Resource, domain: AshCredoFixtures.Blog
+
+      actions do
+        create :create do
+          validate present(:name, exactly: 0)
+          validate present(:name, at_most: 1)
+        end
+      end
+    end
+    """
+
+    assert [] = run_check(RedundantValidation, source)
+  end
+
+  test "no issue for non-literal fields" do
+    source = """
+    defmodule AshCredoFixtures.Blog.Contact do
+      use Ash.Resource, domain: AshCredoFixtures.Blog
+
+      actions do
+        create :create do
+          validate present(@required_field)
+        end
+      end
+    end
+    """
+
+    assert [] = run_check(RedundantValidation, source)
+  end
+
+  test "no issue when the source names an action the compiled module lacks" do
+    source = """
+    defmodule AshCredoFixtures.Blog.Contact do
+      use Ash.Resource, domain: AshCredoFixtures.Blog
+
+      actions do
+        create :not_compiled do
+          validate present(:name)
+        end
+      end
+    end
+    """
+
+    assert [] = run_check(RedundantValidation, source)
+  end
+
+  test "reports the not-loadable diagnostic for unknown resource modules" do
+    source = """
+    defmodule MyApp.NotCompiled do
+      use Ash.Resource, domain: MyApp.Domain
+
+      actions do
+        create :create do
+          validate present(:name)
+        end
+      end
+    end
+    """
+
+    assert [issue] = run_check(RedundantValidation, source)
+    assert issue.message =~ "Could not load"
+  end
+
+  test "ignores non-Ash modules" do
+    source = """
+    defmodule MyApp.Utils do
+      def validate(x), do: present(x)
+      def present(x), do: x != nil
+    end
+    """
+
+    assert [] = run_check(RedundantValidation, source)
+  end
+end

--- a/test/support/fixtures/ash_fixtures.ex
+++ b/test/support/fixtures/ash_fixtures.ex
@@ -76,6 +76,7 @@ defmodule AshCredoFixtures.Blog do
     resource AshCredoFixtures.Blog.PartialTimestamps
     resource AshCredoFixtures.Blog.CustomTimestamps
     resource AshCredoFixtures.Blog.Tag
+    resource AshCredoFixtures.Blog.Contact
     resource AshCredoFixtures.Blog.GenericActions
     resource AshCredoFixtures.Blog.Empty
     resource AshCredoFixtures.Blog.WithAuthorizer
@@ -357,6 +358,43 @@ defmodule AshCredoFixtures.Blog.Tag do
   attributes do
     uuid_primary_key :id
     attribute :name, :string, public?: true
+  end
+end
+
+defmodule AshCredoFixtures.Blog.Contact do
+  @moduledoc """
+  `RedundantValidation` fixture: `:name` and `:handle` carry
+  `allow_nil? false`, `:nickname` stays nullable, and the `:import` create
+  action reopens `:name` (but not `:handle`) via `allow_nil_input` - the
+  escape hatch under which a `present` validation is NOT redundant.
+  """
+
+  use Ash.Resource,
+    domain: AshCredoFixtures.Blog,
+    validate_domain_inclusion?: false
+
+  actions do
+    defaults [:read]
+
+    create :create do
+      accept [:name, :nickname]
+    end
+
+    update :rename do
+      accept [:name]
+    end
+
+    create :import do
+      accept [:name, :nickname]
+      allow_nil_input [:name]
+    end
+  end
+
+  attributes do
+    uuid_primary_key :id
+    attribute :name, :string, allow_nil?: false, public?: true
+    attribute :handle, :string, allow_nil?: false, default: "anon", public?: true
+    attribute :nickname, :string, public?: true
   end
 end
 


### PR DESCRIPTION
Flags 'validate present(...)' where every referenced field is an attribute that already has allow_nil? false - straight from Ash's usage rules (usage-rules/actions.md: avoid validations that duplicate attribute constraints). Probes against vendored Ash 3.28 confirmed the redundancy mechanically: with allow_nil? false, nil input fails with a Required error whether or not the validation exists; present only duplicates an InvalidAttribute error on the same field.

Detection is the hybrid AST-plus-compiled shape used by UnknownAction: the AST locates 'validate present(...)' calls (literal fields only) and anchors the issue line; compiled introspection resolves the fully transformed attribute list, so allow_nil? false contributed by extensions is seen too. No new Ash.Resource.Info surface was needed - the Compiled gateway's inspect_module already exposes attributes and actions.

Deliberately skipped, each verified by a compiled probe:

- Fields listed in an action's allow_nil_input: there the attribute may legitimately be nil at validation time (e.g. filled by the data layer during an upsert), making present the only guard - proven by a changeset that is valid without the validation and invalid with it. Global validations are shielded when ANY action opens the field.

- Read and generic actions: Ash.Changeset.present? falls back from argument to attribute, but the Query/ActionInput clause checks arguments only, so attribute nullability proves nothing there.

- Counting options that change semantics: explicit exactly/at_most (e.g. exactly: 0 means 'must be absent') and non-literal options are left alone; the bare builtin (which expands to exactly: count) and at_least up to the field count are flagged.