### PR TITLE
feat: add AnonymousFunctionInDsl check for fn callbacks in the DSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ If you have any compiled-introspection checks enabled, run `mix compile` before 
 | `SensitiveFieldInAccept` | Warning | High | No | Flags privilege-escalation fields (`is_admin`, `permissions`, ...) in `accept` lists |
 | `UnknownAction` | Warning | High | No | Flags `Ash.*` calls referencing actions that do not exist on the resolved resource, with a fuzzy `Did you mean` hint. **Requires compiled project.** |
 | `WildcardAcceptOnAction` | Warning | High | No | Detects `accept :*` on `create`/`update` actions (mass-assignment risk) |
+| `AnonymousFunctionInDsl` | Refactor | Normal | No | Flags `fn`/`&` captures passed to `change`/`validate`/`prepare`/`calculate` - anonymous functions can never be atomic (changes/validations) or supply an expression (calculations); extract them into callback modules |
 | `DirectiveInFunctionBody` | Refactor | Normal | No | Flags `require`/`import`/`alias` of configured modules (default `Ash.Query`, `Ash.Expr`) declared inside function bodies instead of at module level |
 | `LargeResource` | Refactor | Low | No | Flags resource files exceeding 400 lines |
 | `RaisingCall` | Refactor | Low | No | Flags Ash bang calls - top-level `Ash.read!`/`Ash.create!`/`Ash.Filter.parse!` plus code-interface bangs like `MyApp.Blog.create_post!`. Orphan bangs (those without a non-bang counterpart, e.g. `Ash.stream!`, `Ash.Seed.seed!`) are detected dynamically and skipped. Test directories excluded by default. **Requires compiled project.** |
@@ -183,6 +184,7 @@ checks: %{
     {AshCredo.Check.Warning.SensitiveFieldInAccept, []},
     {AshCredo.Check.Warning.UnknownAction, []},
     {AshCredo.Check.Warning.WildcardAcceptOnAction, []},
+    {AshCredo.Check.Refactor.AnonymousFunctionInDsl, []},
     {AshCredo.Check.Refactor.DirectiveInFunctionBody, []},
     {AshCredo.Check.Refactor.LargeResource, []},
     {AshCredo.Check.Refactor.RaisingCall, []},

--- a/lib/ash_credo.ex
+++ b/lib/ash_credo.ex
@@ -52,6 +52,7 @@ defmodule AshCredo do
             {AshCredo.Check.Warning.UnknownAction, false},
             {AshCredo.Check.Warning.WildcardAcceptOnAction, false},
             # Refactor
+            {AshCredo.Check.Refactor.AnonymousFunctionInDsl, false},
             {AshCredo.Check.Refactor.DirectiveInFunctionBody, false},
             {AshCredo.Check.Refactor.LargeResource, false},
             {AshCredo.Check.Refactor.RaisingCall, false},

--- a/lib/ash_credo/check/refactor/anonymous_function_in_dsl.ex
+++ b/lib/ash_credo/check/refactor/anonymous_function_in_dsl.ex
@@ -1,0 +1,185 @@
+defmodule AshCredo.Check.Refactor.AnonymousFunctionInDsl do
+  use Credo.Check,
+    base_priority: :normal,
+    category: :refactor,
+    tags: [:ash],
+    explanations: [
+      check: """
+      Flags anonymous functions (`fn ... end` or `&...` captures) passed to
+      `change`, `validate`, `prepare`, or `calculate` in the resource DSL.
+      Prefer to put the code in its own module and refer to that instead.
+
+      For changes and validations this is more than style: anonymous
+      functions can never participate in atomic execution, because Ash
+      cannot inspect what they contain. An update or destroy action
+      carrying one either fails its atomicity requirement at runtime or
+      forces `require_atomic? false`. Anonymous function changes also
+      cannot support batching. Function captures compile to the same
+      `*.Function` wrapper as `fn` and carry the same limitation.
+
+          # Bad - can never be atomic, forces require_atomic? false
+          update :update do
+            change fn changeset, _context ->
+              Ash.Changeset.force_change_attribute(changeset, :slug, slug())
+            end
+          end
+
+          # Good - module callback, can implement atomic/3
+          update :update do
+            change MyApp.Changes.SlugifyName
+          end
+
+      Calculations have the equivalent limitation through `expression/2`:
+      an anonymous function calculation can never supply an expression, so
+      the data layer cannot run it and sorting on it raises an
+      `UndefinedFunctionError` at runtime. A module using
+      `Ash.Resource.Calculation` can implement `expression/2`; an `expr(...)`
+      calculation is data-layer-native and is not flagged.
+
+      Anonymous functions are fine for prototyping, which is why this
+      check is opt-in; silence individual call sites with
+      `# credo:disable-for-next-line`.
+      """
+    ]
+
+  alias AshCredo.Introspection
+  alias AshCredo.Orchestration
+
+  @wrappers ~w(change validate prepare)a
+  @action_types ~w(create read update destroy action)a
+
+  # Sections whose direct entries are change/validate/prepare entities.
+  @entity_sections ~w(changes validations preparations)a
+
+  @module_advice %{
+    change:
+      "anonymous function changes can never be made atomic or support batching. " <>
+        "Extract it into a module with `use Ash.Resource.Change`",
+    validate:
+      "anonymous function validations can never be made atomic. " <>
+        "Extract it into a module with `use Ash.Resource.Validation`",
+    prepare: "Extract it into a module with `use Ash.Resource.Preparation`",
+    calculate:
+      "anonymous function calculations can never supply an expression, so the data " <>
+        "layer cannot run them and sorting on them raises at runtime. Extract it into a " <>
+        "module with `use Ash.Resource.Calculation` (which can implement `expression/2`) " <>
+        "or use `expr(...)`"
+  }
+
+  @impl true
+  def run(%SourceFile{} = source_file, params) do
+    Orchestration.flat_map_resource_context(source_file, params, fn context, issue_meta ->
+      action_issues(context, issue_meta) ++
+        entity_section_issues(context, issue_meta) ++
+        pipeline_issues(context, issue_meta) ++
+        calculation_issues(context, issue_meta)
+    end)
+  end
+
+  defp action_issues(context, issue_meta) do
+    entity_body_issues(context, :actions, @action_types, issue_meta)
+  end
+
+  defp pipeline_issues(context, issue_meta) do
+    entity_body_issues(context, :pipelines, [:pipeline], issue_meta)
+  end
+
+  defp entity_body_issues(context, section_name, entity_names, issue_meta) do
+    case Introspection.resource_section(context, section_name) do
+      nil ->
+        []
+
+      section_ast ->
+        section_ast
+        |> Introspection.action_entities(entity_names)
+        |> Enum.flat_map(fn entity_ast ->
+          entity_ast
+          |> Introspection.entity_body()
+          |> Enum.flat_map(&anonymous_wrapper_issues(&1, issue_meta))
+        end)
+    end
+  end
+
+  defp entity_section_issues(context, issue_meta) do
+    Enum.flat_map(@entity_sections, fn section_name ->
+      case Introspection.resource_section(context, section_name) do
+        nil ->
+          []
+
+        section_ast ->
+          section_ast
+          |> Introspection.action_entities(@wrappers)
+          |> Enum.flat_map(&anonymous_wrapper_issues(&1, issue_meta))
+      end
+    end)
+  end
+
+  # The callback is `calculate`'s third positional argument
+  # (`calculate :name, :type, fn ... end`), unlike the wrappers, where it
+  # is the first.
+  defp calculation_issues(context, issue_meta) do
+    case Introspection.resource_section(context, :calculations) do
+      nil ->
+        []
+
+      section_ast ->
+        section_ast
+        |> Introspection.action_entities([:calculate])
+        |> Enum.flat_map(&calculate_entity_issues(&1, issue_meta))
+    end
+  end
+
+  defp calculate_entity_issues(
+         {:calculate, meta, [_name, _type, calculation | _]} = entity_ast,
+         issue_meta
+       ) do
+    if anonymous_function?(calculation) do
+      [anonymous_issue(:calculate, meta, issue_meta)]
+    else
+      do_block_calculation_issues(entity_ast, issue_meta)
+    end
+  end
+
+  defp calculate_entity_issues(entity_ast, issue_meta) do
+    do_block_calculation_issues(entity_ast, issue_meta)
+  end
+
+  defp do_block_calculation_issues(entity_ast, issue_meta) do
+    entity_ast
+    |> Introspection.entity_body()
+    |> Enum.flat_map(fn
+      {:calculation, meta, [calculation | _]} ->
+        if anonymous_function?(calculation) do
+          [anonymous_issue(:calculate, meta, issue_meta)]
+        else
+          []
+        end
+
+      _other ->
+        []
+    end)
+  end
+
+  defp anonymous_wrapper_issues({wrapper, meta, [first_arg | _]}, issue_meta)
+       when wrapper in @wrappers do
+    if anonymous_function?(first_arg) do
+      [anonymous_issue(wrapper, meta, issue_meta)]
+    else
+      []
+    end
+  end
+
+  defp anonymous_wrapper_issues(_other, _issue_meta), do: []
+
+  defp anonymous_issue(wrapper, meta, issue_meta) do
+    format_issue(issue_meta,
+      message: "`#{wrapper}` is passed an anonymous function - #{@module_advice[wrapper]}.",
+      trigger: "#{wrapper}",
+      line_no: meta[:line]
+    )
+  end
+
+  defp anonymous_function?({:fn, _, _}), do: true
+  defp anonymous_function?({:&, _, _}), do: true
+  defp anonymous_function?(_other), do: false
+end

--- a/test/ash_credo/check/refactor/anonymous_function_in_dsl_test.exs
+++ b/test/ash_credo/check/refactor/anonymous_function_in_dsl_test.exs
@@ -1,0 +1,255 @@
+defmodule AshCredo.Check.Refactor.AnonymousFunctionInDslTest do
+  use AshCredo.CheckCase
+
+  alias AshCredo.Check.Refactor.AnonymousFunctionInDsl
+
+  test "reports fn passed to change in a create action" do
+    source = """
+    defmodule MyApp.Post do
+      use Ash.Resource, domain: MyApp.Blog
+
+      actions do
+        create :create do
+          change fn changeset, _context -> changeset end
+        end
+      end
+    end
+    """
+
+    assert [issue] = run_check(AnonymousFunctionInDsl, source)
+    assert issue.trigger == "change"
+    assert issue.line_no == 6
+    assert issue.message =~ "atomic"
+    assert issue.message =~ "Ash.Resource.Change"
+  end
+
+  test "reports fn passed to validate in an update action" do
+    source = """
+    defmodule MyApp.Post do
+      use Ash.Resource, domain: MyApp.Blog
+
+      actions do
+        update :update do
+          validate fn changeset, _context -> :ok end
+        end
+      end
+    end
+    """
+
+    assert [issue] = run_check(AnonymousFunctionInDsl, source)
+    assert issue.trigger == "validate"
+    assert issue.message =~ "Ash.Resource.Validation"
+  end
+
+  test "reports fn passed to prepare in a read action" do
+    source = """
+    defmodule MyApp.Post do
+      use Ash.Resource, domain: MyApp.Blog
+
+      actions do
+        read :search do
+          prepare fn query, _context -> query end
+        end
+      end
+    end
+    """
+
+    assert [issue] = run_check(AnonymousFunctionInDsl, source)
+    assert issue.trigger == "prepare"
+    assert issue.message =~ "Ash.Resource.Preparation"
+    refute issue.message =~ "atomic"
+  end
+
+  test "reports function captures the same as fn" do
+    source = """
+    defmodule MyApp.Post do
+      use Ash.Resource, domain: MyApp.Blog
+
+      actions do
+        create :create do
+          change &MyApp.Helpers.slugify/2
+        end
+      end
+    end
+    """
+
+    assert [issue] = run_check(AnonymousFunctionInDsl, source)
+    assert issue.trigger == "change"
+  end
+
+  test "reports anonymous functions in the global changes/validations/preparations sections" do
+    source = """
+    defmodule MyApp.Post do
+      use Ash.Resource, domain: MyApp.Blog
+
+      changes do
+        change fn changeset, _context -> changeset end
+      end
+
+      validations do
+        validate fn changeset, _context -> :ok end
+      end
+
+      preparations do
+        prepare fn query, _context -> query end
+      end
+    end
+    """
+
+    issues = run_check(AnonymousFunctionInDsl, source)
+    assert [_, _, _] = issues
+    assert MapSet.equal?(trigger_set(issues), MapSet.new(~w(change validate prepare)))
+  end
+
+  test "reports anonymous functions inside pipeline bodies" do
+    source = """
+    defmodule MyApp.Post do
+      use Ash.Resource, domain: MyApp.Blog
+
+      pipelines do
+        pipeline :slugify do
+          change fn changeset, _context -> changeset end
+        end
+      end
+    end
+    """
+
+    assert [issue] = run_check(AnonymousFunctionInDsl, source)
+    assert issue.trigger == "change"
+    assert issue.line_no == 6
+  end
+
+  test "no issue for module-based callbacks" do
+    source = """
+    defmodule MyApp.Post do
+      use Ash.Resource, domain: MyApp.Blog
+
+      actions do
+        create :create do
+          change MyApp.Changes.SlugifyName
+          validate {MyApp.Validations.NameNotProfane, []}
+        end
+
+        read :search do
+          prepare MyApp.Preparations.DefaultSort
+        end
+      end
+    end
+    """
+
+    assert [] = run_check(AnonymousFunctionInDsl, source)
+  end
+
+  test "no issue for wrapped builtins" do
+    source = """
+    defmodule MyApp.Post do
+      use Ash.Resource, domain: MyApp.Blog
+
+      actions do
+        create :create do
+          change set_attribute(:status, :draft)
+          validate present(:name)
+        end
+
+        read :search do
+          prepare build(sort: [:name])
+        end
+      end
+    end
+    """
+
+    assert [] = run_check(AnonymousFunctionInDsl, source)
+  end
+
+  test "reports fn passed to calculate" do
+    source = """
+    defmodule MyApp.Post do
+      use Ash.Resource, domain: MyApp.Blog
+
+      calculations do
+        calculate :display_name, :string, fn records, _context ->
+          Enum.map(records, & &1.name)
+        end
+      end
+    end
+    """
+
+    assert [issue] = run_check(AnonymousFunctionInDsl, source)
+    assert issue.trigger == "calculate"
+    assert issue.line_no == 5
+    assert issue.message =~ "expression"
+    assert issue.message =~ "Ash.Resource.Calculation"
+  end
+
+  test "reports fn given via the calculation option in a calculate do-block" do
+    source = """
+    defmodule MyApp.Post do
+      use Ash.Resource, domain: MyApp.Blog
+
+      calculations do
+        calculate :display_name, :string do
+          calculation fn records, _context -> Enum.map(records, & &1.name) end
+        end
+      end
+    end
+    """
+
+    assert [issue] = run_check(AnonymousFunctionInDsl, source)
+    assert issue.trigger == "calculate"
+    assert issue.line_no == 6
+  end
+
+  test "no issue for expr, module, and tuple calculations" do
+    source = """
+    defmodule MyApp.Post do
+      use Ash.Resource, domain: MyApp.Blog
+
+      calculations do
+        calculate :full_name, :string, expr(first_name <> " " <> last_name)
+        calculate :slug, :string, MyApp.Calculations.Slug
+        calculate :initials, :string, {MyApp.Calculations.Initials, separator: "."}
+
+        calculate :display, :string, MyApp.Calculations.Display do
+          public? true
+        end
+      end
+    end
+    """
+
+    assert [] = run_check(AnonymousFunctionInDsl, source)
+  end
+
+  test "no issue for anonymous functions in regular resource functions" do
+    source = """
+    defmodule MyApp.Post do
+      use Ash.Resource, domain: MyApp.Blog
+
+      actions do
+        create :create
+      end
+
+      def transform(items) do
+        Enum.map(items, fn item -> item.name end)
+      end
+    end
+    """
+
+    assert [] = run_check(AnonymousFunctionInDsl, source)
+  end
+
+  test "ignores non-Ash modules" do
+    source = """
+    defmodule MyApp.Pipeline do
+      def run do
+        change fn x -> x end
+        validate fn x -> x end
+      end
+
+      def change(fun), do: fun
+      def validate(fun), do: fun
+    end
+    """
+
+    assert [] = run_check(AnonymousFunctionInDsl, source)
+  end
+end


### PR DESCRIPTION
Flags anonymous functions (fn and & captures) passed to change, validate, prepare, or calculate in the resource DSL, suggesting a callback module instead.

The justification is mechanical, verified against vendored Ash 3.28:

- Changes/validations: anonymous functions can never participate in atomic execution because Ash cannot inspect what they contain; an update/destroy carrying one either fails its atomicity requirement at runtime or forces require_atomic? false. Anonymous function changes also cannot support batching.

- Calculations: the Ash.Resource.Calculation behaviour's optional expression/2 callback is what enables data-layer execution and sorting; the Function wrapper that fn/captures compile to can never provide it. A runtime probe shows sorting on an anonymous function calculation raises UndefinedFunctionError (Ash.Resource.Calculation.Function.expression/2 is undefined), while the same calculation as a module with expression/2 sorts fine. expr(...) calculations are data-layer-native and are not flagged.

- Captures are flagged like fn: a compiled probe shows both forms resolve to the same Ash.Resource.*.Function wrapper, so they share the limitations.

- prepare is flagged on organizational grounds only - its message omits the atomicity rationale, which does not apply to preparations.

Pure AST, scoped to known DSL positions (action bodies, the global changes/validations/preparations sections, pipeline bodies, and the calculations section, where the callback is the third positional argument or a do-block calculation option) so same-named functions in regular resource code are never matched. Opt-in; silence individual prototyping sites with credo:disable-for-next-line.