### PR TITLE
feat: add CompileTimeDefault check for frozen attribute/argument defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ AshCredo detects common anti-patterns, security pitfalls, and missing best pract
 
 **Note: only the following checks are enabled by default.** All other checks are opt-in - enable them individually in your `.credo.exs` (see [Configuration](#configuration)).
 
+- `Warning.CompileTimeDefault`
 - `Warning.MissingChangeWrapper`
 - `Warning.MissingMacroDirective`
 - `Warning.MissingPrepareWrapper`
@@ -78,6 +79,7 @@ If you have any compiled-introspection checks enabled, run `mix compile` before 
 | `ActorOnCallOptions` | Warning | High | No | Flags `actor:`/`tenant:` passed in the options of `Ash.read!`/`Ash.create!`/... when the subject visibly went through a `for_*` builder - per Ash's authorization usage rules they belong on the query/changeset/input |
 | `AuthorizeFalse` | Warning | High | No | Flags literal `authorize?: false` in Ash calls, action DSL, and (by default) any other call site |
 | `AuthorizerWithoutPolicies` | Warning | High | No | Detects resources with `Ash.Policy.Authorizer` but no policies defined. **Requires compiled project.** |
+| `CompileTimeDefault` | Warning | High | Yes | Flags `default: DateTime.utc_now()` / `Ash.UUID.generate()` (missing `&.../0` capture) on attributes and arguments - the call runs once at compile time, so every record gets the same frozen value |
 | `EmptyDomain` | Warning | Normal | No | Flags domains with no resources registered |
 | `MissingChangeWrapper` | Warning | High | Yes | Flags builtin change functions (`manage_relationship`, `set_attribute`, ...) used without `change` wrapper in actions and pipelines - the bare call compiles but is silently discarded |
 | `MissingDomain` | Warning | Normal | No | Ensures non-embedded resources set the `domain:` option |

--- a/lib/ash_credo.ex
+++ b/lib/ash_credo.ex
@@ -37,6 +37,7 @@ defmodule AshCredo do
             {AshCredo.Check.Warning.ActorOnCallOptions, false},
             {AshCredo.Check.Warning.AuthorizeFalse, false},
             {AshCredo.Check.Warning.AuthorizerWithoutPolicies, false},
+            {AshCredo.Check.Warning.CompileTimeDefault, []},
             {AshCredo.Check.Warning.EmptyDomain, false},
             {AshCredo.Check.Warning.MissingChangeWrapper, []},
             {AshCredo.Check.Warning.MissingDomain, false},

--- a/lib/ash_credo/check/warning/compile_time_default.ex
+++ b/lib/ash_credo/check/warning/compile_time_default.ex
@@ -1,0 +1,130 @@
+defmodule AshCredo.Check.Warning.CompileTimeDefault do
+  use Credo.Check,
+    base_priority: :high,
+    category: :warning,
+    tags: [:ash],
+    explanations: [
+      check: """
+      Flags `default`/`update_default` values built by calling a
+      time-or-uuid-producing function directly, like
+      `default: DateTime.utc_now()`. DSL options are ordinary expressions
+      evaluated while the module compiles, so the call runs exactly once
+      and the resulting literal is baked into the resource: every record
+      gets the timestamp of the last compile, and a `Ash.UUID.generate()`
+      default hands every record the same "unique" value.
+
+      Ash only re-evaluates defaults per record when given a zero-arity
+      function (or MFA tuple); any other value is used verbatim.
+
+          # Bad - frozen at compile time, identical for every record
+          attribute :scheduled_at, :utc_datetime, default: DateTime.utc_now()
+
+          # Good - re-evaluated for each record
+          attribute :scheduled_at, :utc_datetime, default: &DateTime.utc_now/0
+
+      Action and calculation arguments resolve `default` the same way, so
+      their defaults are checked too. Values wrapped in a zero-arity `fn`
+      or a capture are fine and are not flagged.
+
+      Nothing else catches this: it compiles without warnings, the frozen
+      value type-checks, and no error is ever raised - dev recompiles keep
+      the value looking fresh, and the freeze only shows up in production.
+
+      `Warning.PinnedTimeInExpression` is the sibling check for the same
+      bug class inside Ash expressions (`^DateTime.utc_now()`).
+      """
+    ]
+
+  alias AshCredo.Introspection
+  alias AshCredo.Orchestration
+  alias Credo.Code.Name
+
+  # Functions whose value is only meaningful when produced per record.
+  # Matched on literal alias segments, like the sibling
+  # PinnedTimeInExpression.
+  @frozen_calls [
+    {[:Date], :utc_today},
+    {[:DateTime], :utc_now},
+    {[:NaiveDateTime], :utc_now},
+    {[:Time], :utc_now},
+    {[:Ash, :UUID], :generate},
+    {[:Ecto, :UUID], :generate}
+  ]
+
+  @default_options ~w(default update_default)a
+
+  # Sections where default/update_default options exist: attribute
+  # entities, action arguments, and calculation arguments.
+  @sections ~w(attributes actions calculations)a
+
+  @impl true
+  def run(%SourceFile{} = source_file, params) do
+    Orchestration.flat_map_resource_context(source_file, params, fn context, issue_meta ->
+      Enum.flat_map(@sections, &section_issues(context, &1, issue_meta))
+    end)
+  end
+
+  defp section_issues(context, section_name, issue_meta) do
+    case Introspection.resource_section(context, section_name) do
+      nil -> []
+      section_ast -> default_option_issues(section_ast, issue_meta)
+    end
+  end
+
+  # Collects default/update_default occurrences in both forms: inline
+  # keyword options (`default: value` - a 2-tuple in the AST) and do-block
+  # option calls (`default value`).
+  defp default_option_issues(section_ast, issue_meta) do
+    Credo.Code.prewalk(
+      section_ast,
+      fn
+        {option, _meta, [value]} = node, acc when option in @default_options ->
+          {node, frozen_call_issues(value, option, issue_meta) ++ acc}
+
+        {option, value} = node, acc when option in @default_options ->
+          {node, frozen_call_issues(value, option, issue_meta) ++ acc}
+
+        node, acc ->
+          {node, acc}
+      end,
+      []
+    )
+  end
+
+  # Walks the option value for frozen calls, including inside containers
+  # (`default: %{at: DateTime.utc_now()}` is just as frozen). Subtrees under
+  # `fn` or `&` are pruned: there the call is deferred, which is the fix.
+  defp frozen_call_issues(value, option, issue_meta) do
+    {_ast, issues} =
+      Macro.prewalk(value, [], fn
+        {deferred, _, _}, acc when deferred in [:fn, :&] ->
+          {:pruned, acc}
+
+        {{:., _, [{:__aliases__, _, segments}, fun]}, meta, args} = node, acc
+        when is_list(args) ->
+          if {segments, fun} in @frozen_calls do
+            {node, [frozen_issue(segments, fun, option, meta, issue_meta) | acc]}
+          else
+            {node, acc}
+          end
+
+        node, acc ->
+          {node, acc}
+      end)
+
+    issues
+  end
+
+  defp frozen_issue(segments, fun, option, meta, issue_meta) do
+    called = "#{Name.full(segments)}.#{fun}()"
+
+    format_issue(issue_meta,
+      message:
+        "`#{called}` in `#{option}` is evaluated once at compile time - every record " <>
+          "gets the same frozen value. Use a zero-arity function " <>
+          "(`#{option}: &#{Name.full(segments)}.#{fun}/0`) so it runs per record.",
+      trigger: called,
+      line_no: meta[:line]
+    )
+  end
+end

--- a/test/ash_credo/check/warning/compile_time_default_test.exs
+++ b/test/ash_credo/check/warning/compile_time_default_test.exs
@@ -1,0 +1,221 @@
+defmodule AshCredo.Check.Warning.CompileTimeDefaultTest do
+  use AshCredo.CheckCase
+
+  alias AshCredo.Check.Warning.CompileTimeDefault
+
+  test "reports frozen DateTime.utc_now() in an inline attribute default" do
+    source = """
+    defmodule MyApp.Post do
+      use Ash.Resource, domain: MyApp.Blog
+
+      attributes do
+        uuid_primary_key :id
+        attribute :scheduled_at, :utc_datetime, default: DateTime.utc_now()
+      end
+    end
+    """
+
+    assert [issue] = run_check(CompileTimeDefault, source)
+    assert issue.trigger == "DateTime.utc_now()"
+    assert issue.line_no == 6
+    assert issue.message =~ "compile time"
+    assert issue.message =~ "&DateTime.utc_now/0"
+  end
+
+  test "reports frozen default in an attribute do-block" do
+    source = """
+    defmodule MyApp.Post do
+      use Ash.Resource, domain: MyApp.Blog
+
+      attributes do
+        attribute :published_on, :date do
+          default Date.utc_today()
+        end
+      end
+    end
+    """
+
+    assert [issue] = run_check(CompileTimeDefault, source)
+    assert issue.trigger == "Date.utc_today()"
+    assert issue.line_no == 6
+  end
+
+  test "reports frozen update_default" do
+    source = """
+    defmodule MyApp.Post do
+      use Ash.Resource, domain: MyApp.Blog
+
+      attributes do
+        attribute :updated_at, :utc_datetime, update_default: DateTime.utc_now()
+      end
+    end
+    """
+
+    assert [issue] = run_check(CompileTimeDefault, source)
+    assert issue.message =~ "`update_default`"
+    assert issue.message =~ "update_default: &DateTime.utc_now/0"
+  end
+
+  test "reports frozen Ash.UUID.generate() default" do
+    source = """
+    defmodule MyApp.Post do
+      use Ash.Resource, domain: MyApp.Blog
+
+      attributes do
+        attribute :token, :uuid, default: Ash.UUID.generate()
+      end
+    end
+    """
+
+    assert [issue] = run_check(CompileTimeDefault, source)
+    assert issue.trigger == "Ash.UUID.generate()"
+  end
+
+  test "reports frozen default on an action argument" do
+    source = """
+    defmodule MyApp.Post do
+      use Ash.Resource, domain: MyApp.Blog
+
+      actions do
+        read :recent do
+          argument :since, :utc_datetime, default: DateTime.utc_now()
+        end
+      end
+    end
+    """
+
+    assert [issue] = run_check(CompileTimeDefault, source)
+    assert issue.trigger == "DateTime.utc_now()"
+    assert issue.line_no == 6
+  end
+
+  test "reports frozen default on a calculation argument" do
+    source = """
+    defmodule MyApp.Post do
+      use Ash.Resource, domain: MyApp.Blog
+
+      calculations do
+        calculate :age_at, :integer, expr(date_diff(^arg(:as_of), birthdate)) do
+          argument :as_of, :date, default: Date.utc_today()
+        end
+      end
+    end
+    """
+
+    assert [issue] = run_check(CompileTimeDefault, source)
+    assert issue.trigger == "Date.utc_today()"
+  end
+
+  test "reports frozen call nested inside a container default" do
+    source = """
+    defmodule MyApp.Post do
+      use Ash.Resource, domain: MyApp.Blog
+
+      attributes do
+        attribute :meta, :map, default: %{generated_at: DateTime.utc_now()}
+      end
+    end
+    """
+
+    assert [issue] = run_check(CompileTimeDefault, source)
+    assert issue.trigger == "DateTime.utc_now()"
+  end
+
+  test "reports frozen call with arguments" do
+    source = """
+    defmodule MyApp.Post do
+      use Ash.Resource, domain: MyApp.Blog
+
+      attributes do
+        attribute :scheduled_at, :utc_datetime, default: DateTime.utc_now(:second)
+      end
+    end
+    """
+
+    assert [issue] = run_check(CompileTimeDefault, source)
+    assert issue.trigger == "DateTime.utc_now()"
+  end
+
+  test "no issue for zero-arity captures" do
+    source = """
+    defmodule MyApp.Post do
+      use Ash.Resource, domain: MyApp.Blog
+
+      attributes do
+        uuid_primary_key :id
+        attribute :scheduled_at, :utc_datetime, default: &DateTime.utc_now/0
+        attribute :token, :uuid, default: &Ash.UUID.generate/0
+
+        attribute :updated_at, :utc_datetime do
+          update_default &DateTime.utc_now/0
+        end
+      end
+    end
+    """
+
+    assert [] = run_check(CompileTimeDefault, source)
+  end
+
+  test "no issue for anonymous function defaults" do
+    source = """
+    defmodule MyApp.Post do
+      use Ash.Resource, domain: MyApp.Blog
+
+      attributes do
+        attribute :scheduled_at, :utc_datetime, default: fn -> DateTime.utc_now(:second) end
+      end
+    end
+    """
+
+    assert [] = run_check(CompileTimeDefault, source)
+  end
+
+  test "no issue for literal and unrelated defaults" do
+    source = """
+    defmodule MyApp.Post do
+      use Ash.Resource, domain: MyApp.Blog
+
+      attributes do
+        attribute :status, :atom, default: :draft
+        attribute :count, :integer, default: 0
+        attribute :config, :map, default: %{}
+        attribute :label, :string, default: String.duplicate("-", 3)
+      end
+
+      actions do
+        read :recent do
+          argument :limit, :integer, default: 10
+        end
+      end
+    end
+    """
+
+    assert [] = run_check(CompileTimeDefault, source)
+  end
+
+  test "no issue for timestamps builtins" do
+    source = """
+    defmodule MyApp.Post do
+      use Ash.Resource, domain: MyApp.Blog
+
+      attributes do
+        uuid_primary_key :id
+        create_timestamp :inserted_at
+        update_timestamp :updated_at
+      end
+    end
+    """
+
+    assert [] = run_check(CompileTimeDefault, source)
+  end
+
+  test "ignores non-Ash modules" do
+    source = """
+    defmodule MyApp.Config do
+      def base, do: [default: DateTime.utc_now()]
+    end
+    """
+
+    assert [] = run_check(CompileTimeDefault, source)
+  end
+end


### PR DESCRIPTION
Flags default/update_default values that call a time-or-uuid-producing function directly (default: DateTime.utc_now()) instead of passing a zero-arity capture (default: &DateTime.utc_now/0). DSL options are ordinary expressions evaluated at module compile time, so the call runs exactly once and the literal result is baked into the resource.

The dispatch that makes the capture matter is in Ash itself (changeset.ex default/2, query.ex argument_default/1): an MFA tuple or zero-arity function is invoked per record; any other value is used verbatim. Action and calculation arguments resolve defaults through the same rule, so their defaults are covered too.

A runtime probe against vendored Ash 3.28 confirmed both the bug and the silence: the buggy form compiles with zero diagnostics, two creates 50ms apart share an identical timestamp, and default: Ash.UUID.generate() gives every record the same 'unique' token - nothing in the compiler, Spark option validation, Ash verifiers, or runtime ever objects.

Detection is pure AST over the attributes/actions/calculations sections, matching both option forms (inline keyword and do-block call). The option value is walked recursively, so frozen calls inside containers (default: %{at: DateTime.utc_now()}) are caught, while fn and capture subtrees are pruned - deferral is exactly the fix. The flagged function list (Date.utc_today, DateTime/NaiveDateTime/Time utc_now, Ash.UUID/Ecto.UUID generate) is hardcoded; calling any of them eagerly in a default is never intentional.

Default-on, matching its sibling PinnedTimeInExpression, which covers the same frozen-at-compile-time class inside expressions but cannot see attribute defaults.