### PR TITLE
refactor: make checks more idiomatic

### DIFF
--- a/lib/ash_credo/check/design/missing_code_interface.ex
+++ b/lib/ash_credo/check/design/missing_code_interface.ex
@@ -139,6 +139,6 @@ defmodule AshCredo.Check.Design.MissingCodeInterface do
   defp actions_section_line(module_ast, context) do
     actions_ast = Introspection.find_dsl_section(module_ast, :actions)
 
-    Introspection.section_issue_line(actions_ast, Map.get(context, :use_line), 1)
+    Introspection.section_issue_line(actions_ast, context.use_line, 1)
   end
 end

--- a/lib/ash_credo/check/design/missing_code_interface.ex
+++ b/lib/ash_credo/check/design/missing_code_interface.ex
@@ -80,24 +80,22 @@ defmodule AshCredo.Check.Design.MissingCodeInterface do
   end
 
   defp check_resource(resource, context, issue_meta, excluded_actions) do
-    if CompiledIntrospection.embedded?(resource) do
-      []
-    else
-      inspect_resource(resource, context.module_ast, context, issue_meta, excluded_actions)
-    end
-  end
-
-  defp inspect_resource(resource, module_ast, context, issue_meta, excluded_actions) do
-    case CompiledIntrospection.inspect_module(resource) do
-      {:ok, info} ->
-        flag_missing_interfaces(resource, info, module_ast, context, issue_meta, excluded_actions)
-
-      {:error, :not_loadable} ->
-        Orchestration.unique_not_loadable_issues(resource, context, issue_meta, __MODULE__)
-
-      {:error, _} ->
+    resource
+    |> CompiledIntrospection.inspect_module()
+    |> Orchestration.with_resource_info(resource, context, issue_meta, __MODULE__, fn
+      %{embedded?: true} ->
         []
-    end
+
+      info ->
+        flag_missing_interfaces(
+          resource,
+          info,
+          context.module_ast,
+          context,
+          issue_meta,
+          excluded_actions
+        )
+    end)
   end
 
   defp flag_missing_interfaces(

--- a/lib/ash_credo/check/design/missing_identity.ex
+++ b/lib/ash_credo/check/design/missing_identity.ex
@@ -53,24 +53,12 @@ defmodule AshCredo.Check.Design.MissingIdentity do
   end
 
   defp check_resource(resource, context, candidates, issue_meta) do
-    if CompiledIntrospection.embedded?(resource) do
-      []
-    else
-      inspect_resource(resource, context, candidates, issue_meta)
-    end
-  end
-
-  defp inspect_resource(resource, context, candidates, issue_meta) do
-    case CompiledIntrospection.inspect_module(resource) do
-      {:ok, info} ->
-        flag_missing_identities(resource, info, context, candidates, issue_meta)
-
-      {:error, :not_loadable} ->
-        Orchestration.unique_not_loadable_issues(resource, context, issue_meta, __MODULE__)
-
-      {:error, _} ->
-        []
-    end
+    resource
+    |> CompiledIntrospection.inspect_module()
+    |> Orchestration.with_resource_info(resource, context, issue_meta, __MODULE__, fn
+      %{embedded?: true} -> []
+      info -> flag_missing_identities(resource, info, context, candidates, issue_meta)
+    end)
   end
 
   defp flag_missing_identities(

--- a/lib/ash_credo/check/design/missing_primary_action.ex
+++ b/lib/ash_credo/check/design/missing_primary_action.ex
@@ -53,16 +53,11 @@ defmodule AshCredo.Check.Design.MissingPrimaryAction do
   end
 
   defp check_resource(resource, context, issue_meta) do
-    case CompiledIntrospection.actions(resource) do
-      {:ok, actions} ->
-        flag_missing_primaries(actions, context.module_ast, context, issue_meta)
-
-      {:error, :not_loadable} ->
-        Orchestration.unique_not_loadable_issues(resource, context, issue_meta, __MODULE__)
-
-      {:error, _} ->
-        []
-    end
+    resource
+    |> CompiledIntrospection.actions()
+    |> Orchestration.with_resource_info(resource, context, issue_meta, __MODULE__, fn actions ->
+      flag_missing_primaries(actions, context.module_ast, context, issue_meta)
+    end)
   end
 
   defp flag_missing_primaries(actions, module_ast, context, issue_meta) do

--- a/lib/ash_credo/check/design/missing_primary_action.ex
+++ b/lib/ash_credo/check/design/missing_primary_action.ex
@@ -93,6 +93,6 @@ defmodule AshCredo.Check.Design.MissingPrimaryAction do
   defp actions_section_line(module_ast, context) do
     actions_ast = Introspection.find_dsl_section(module_ast, :actions)
 
-    Introspection.section_issue_line(actions_ast, Map.get(context, :use_line), 1)
+    Introspection.section_issue_line(actions_ast, context.use_line, 1)
   end
 end

--- a/lib/ash_credo/check/design/missing_timestamps.ex
+++ b/lib/ash_credo/check/design/missing_timestamps.ex
@@ -41,20 +41,21 @@ defmodule AshCredo.Check.Design.MissingTimestamps do
   end
 
   defp check_resource_timestamps(resource, context, issue_meta) do
-    case CompiledIntrospection.attributes(resource) do
-      {:ok, attributes} ->
+    resource
+    |> CompiledIntrospection.attributes()
+    |> Orchestration.with_resource_info(
+      resource,
+      context,
+      issue_meta,
+      __MODULE__,
+      fn attributes ->
         if has_timestamps?(attributes) do
           []
         else
           [missing_timestamps_issue(context.module_ast, context, issue_meta)]
         end
-
-      {:error, :not_loadable} ->
-        Orchestration.unique_not_loadable_issues(resource, context, issue_meta, __MODULE__)
-
-      {:error, _} ->
-        []
-    end
+      end
+    )
   end
 
   # A resource has timestamps when it contains TWO DISTINCT datetime

--- a/lib/ash_credo/check/design/missing_timestamps.ex
+++ b/lib/ash_credo/check/design/missing_timestamps.ex
@@ -80,18 +80,26 @@ defmodule AshCredo.Check.Design.MissingTimestamps do
     has_create? and has_update?
   end
 
-  defp create_timestamp_attribute?(attribute) do
-    Map.get(attribute, :writable?) == false and
-      is_function(Map.get(attribute, :default)) and
-      not is_function(Map.get(attribute, :update_default)) and
-      datetime_attribute_type?(Map.get(attribute, :type))
+  defp create_timestamp_attribute?(%{
+         writable?: false,
+         default: default,
+         update_default: update_default,
+         type: type
+       }) do
+    is_function(default) and not is_function(update_default) and datetime_attribute_type?(type)
   end
 
-  defp update_timestamp_attribute?(attribute) do
-    Map.get(attribute, :writable?) == false and
-      is_function(Map.get(attribute, :update_default)) and
-      datetime_attribute_type?(Map.get(attribute, :type))
+  defp create_timestamp_attribute?(_attribute), do: false
+
+  defp update_timestamp_attribute?(%{
+         writable?: false,
+         update_default: update_default,
+         type: type
+       }) do
+    is_function(update_default) and datetime_attribute_type?(type)
   end
+
+  defp update_timestamp_attribute?(_attribute), do: false
 
   # Restrict timestamp detection to datetime-typed attributes so that
   # PK attributes produced by e.g. `uuid_primary_key :id` - which are

--- a/lib/ash_credo/check/refactor/raising_call.ex
+++ b/lib/ash_credo/check/refactor/raising_call.ex
@@ -139,23 +139,19 @@ defmodule AshCredo.Check.Refactor.RaisingCall do
       when is_atom(fun_name) and is_list(meta) ->
         module = Module.concat(expanded_module)
 
-        cond do
-          not bang?(fun_name) ->
-            []
-
-          MapSet.member?(excluded_functions, {module, fun_name}) ->
-            []
-
-          true ->
-            ash_call_issues(
-              non_bang_counterpart(module, fun_name),
-              module_ast,
-              expanded_module,
-              fun_name,
-              meta,
-              flag_bang_only,
-              issue_meta
-            )
+        with true <- bang?(fun_name),
+             false <- MapSet.member?(excluded_functions, {module, fun_name}) do
+          ash_call_issues(
+            non_bang_counterpart(module, fun_name),
+            module_ast,
+            expanded_module,
+            fun_name,
+            meta,
+            flag_bang_only,
+            issue_meta
+          )
+        else
+          _ -> []
         end
 
       _ ->

--- a/lib/ash_credo/check/refactor/use_code_interface.ex
+++ b/lib/ash_credo/check/refactor/use_code_interface.ex
@@ -217,7 +217,7 @@ defmodule AshCredo.Check.Refactor.UseCodeInterface do
   end
 
   defp interface_action?(iface, action_name) do
-    (Map.get(iface, :action) || Map.get(iface, :name)) == action_name
+    (iface.action || iface.name) == action_name
   end
 
   defp interface_matches_site?(iface, %{call_kind: :get_one, lookup_keys: keys}, info) do
@@ -246,20 +246,15 @@ defmodule AshCredo.Check.Refactor.UseCodeInterface do
 
   defp interface_lookup_keys(iface, info) do
     cond do
-      Map.get(iface, :get_by) ->
-        List.wrap(Map.get(iface, :get_by))
-
-      Map.get(iface, :get_by_identity) ->
-        identity_keys(info, Map.get(iface, :get_by_identity))
-
-      true ->
-        nil
+      iface.get_by -> List.wrap(iface.get_by)
+      iface.get_by_identity -> identity_keys(info, iface.get_by_identity)
+      true -> nil
     end
   end
 
   defp identity_keys(%{identities: identities}, identity_name) when is_list(identities) do
     Enum.find_value(identities, fn identity ->
-      if Map.get(identity, :name) == identity_name, do: Map.get(identity, :keys)
+      if identity.name == identity_name, do: identity.keys
     end)
   end
 
@@ -270,9 +265,7 @@ defmodule AshCredo.Check.Refactor.UseCodeInterface do
   end
 
   defp get_interface?(iface) do
-    Map.get(iface, :get?) == true or
-      not is_nil(Map.get(iface, :get_by)) or
-      not is_nil(Map.get(iface, :get_by_identity))
+    iface.get? == true or not is_nil(iface.get_by) or not is_nil(iface.get_by_identity)
   end
 
   defp caller_atom(%{enclosing_module_segments: segs}) when is_list(segs) and segs != [] do

--- a/lib/ash_credo/check/warning/actor_on_call_options.ex
+++ b/lib/ash_credo/check/warning/actor_on_call_options.ex
@@ -96,11 +96,12 @@ defmodule AshCredo.Check.Warning.ActorOnCallOptions do
        when is_atom(name) and (is_atom(ctx) or is_nil(ctx)) do
     key = {name, ctx}
 
-    not MapSet.member?(seen, key) and
-      case Map.get(call_info.bindings, key) do
-        nil -> false
-        bound -> builder_subject?(bound, call_info, MapSet.put(seen, key))
-      end
+    with false <- MapSet.member?(seen, key),
+         %{^key => bound} <- call_info.bindings do
+      builder_subject?(bound, call_info, MapSet.put(seen, key))
+    else
+      _ -> false
+    end
   end
 
   defp builder_subject?(ast, call_info, _seen), do: builder_call?(ast, call_info)

--- a/lib/ash_credo/check/warning/authorize_false.ex
+++ b/lib/ash_credo/check/warning/authorize_false.ex
@@ -102,16 +102,9 @@ defmodule AshCredo.Check.Warning.AuthorizeFalse do
   defp action_authorize_false_lines(nil), do: []
 
   defp action_authorize_false_lines(actions_ast) do
-    actions_ast
-    |> Introspection.action_entities()
-    |> Enum.flat_map(fn action ->
-      action
-      |> Introspection.option_occurrences(:authorize?)
-      |> Enum.flat_map(fn
-        {false, line} -> [line]
-        _ -> []
-      end)
-    end)
+    for action <- Introspection.action_entities(actions_ast),
+        {false, line} <- Introspection.option_occurrences(action, :authorize?),
+        do: line
   end
 
   defp all_authorize_false_lines(source_file) do

--- a/lib/ash_credo/check/warning/authorizer_without_policies.ex
+++ b/lib/ash_credo/check/warning/authorizer_without_policies.ex
@@ -47,16 +47,11 @@ defmodule AshCredo.Check.Warning.AuthorizerWithoutPolicies do
   end
 
   defp check_resource(resource, context, issue_meta) do
-    case CompiledIntrospection.inspect_module(resource) do
-      {:ok, info} ->
-        flag_if_authorizer_without_policies(resource, info, context, issue_meta)
-
-      {:error, :not_loadable} ->
-        Orchestration.unique_not_loadable_issues(resource, context, issue_meta, __MODULE__)
-
-      {:error, _} ->
-        []
-    end
+    resource
+    |> CompiledIntrospection.inspect_module()
+    |> Orchestration.with_resource_info(resource, context, issue_meta, __MODULE__, fn info ->
+      flag_if_authorizer_without_policies(resource, info, context, issue_meta)
+    end)
   end
 
   defp flag_if_authorizer_without_policies(

--- a/lib/ash_credo/check/warning/authorizer_without_policies.ex
+++ b/lib/ash_credo/check/warning/authorizer_without_policies.ex
@@ -79,7 +79,7 @@ defmodule AshCredo.Check.Warning.AuthorizerWithoutPolicies do
       message:
         "Resource has Ash.Policy.Authorizer but no policies defined. All actions will be denied.",
       trigger: "Ash.Policy.Authorizer",
-      line_no: Map.get(context, :use_line) || 1
+      line_no: context.use_line || 1
     )
   end
 end

--- a/lib/ash_credo/check/warning/empty_domain.ex
+++ b/lib/ash_credo/check/warning/empty_domain.ex
@@ -29,8 +29,8 @@ defmodule AshCredo.Check.Warning.EmptyDomain do
     resources_ast = Introspection.find_dsl_section(module_ast, :resources)
     use_line = Introspection.find_use_line(module_ast, [:Ash, :Domain])
 
-    cond do
-      is_nil(resources_ast) ->
+    case resources_ast do
+      nil ->
         [
           format_issue(issue_meta,
             message: "Domain has no `resources` block.",
@@ -39,17 +39,18 @@ defmodule AshCredo.Check.Warning.EmptyDomain do
           )
         ]
 
-      not Introspection.section_has_entries?(resources_ast) ->
-        [
-          format_issue(issue_meta,
-            message: "Domain has an empty `resources` block.",
-            trigger: "resources",
-            line_no: Introspection.section_issue_line(resources_ast, use_line)
-          )
-        ]
-
-      true ->
-        []
+      resources_ast ->
+        if Introspection.section_has_entries?(resources_ast) do
+          []
+        else
+          [
+            format_issue(issue_meta,
+              message: "Domain has an empty `resources` block.",
+              trigger: "resources",
+              line_no: Introspection.section_issue_line(resources_ast, use_line)
+            )
+          ]
+        end
     end
   end
 end

--- a/lib/ash_credo/check/warning/missing_domain.ex
+++ b/lib/ash_credo/check/warning/missing_domain.ex
@@ -20,23 +20,20 @@ defmodule AshCredo.Check.Warning.MissingDomain do
   def run(%SourceFile{} = source_file, params),
     do: Orchestration.flat_map_resource_context(source_file, params, &missing_domain_issues/2)
 
-  defp missing_domain_issues(%ResourceContext{use_opts: opts} = context, issue_meta) do
-    case opts do
-      opts when is_list(opts) ->
-        if Keyword.has_key?(opts, :domain) or Introspection.embedded_resource?(context) do
-          []
-        else
-          [
-            format_issue(issue_meta,
-              message: "Resource is missing a `domain:` option in `use Ash.Resource`.",
-              trigger: "use Ash.Resource",
-              line_no: Introspection.resource_issue_line(context)
-            )
-          ]
-        end
-
-      _ ->
-        []
+  defp missing_domain_issues(%ResourceContext{use_opts: opts} = context, issue_meta)
+       when is_list(opts) do
+    if Keyword.has_key?(opts, :domain) or Introspection.embedded_resource?(context) do
+      []
+    else
+      [
+        format_issue(issue_meta,
+          message: "Resource is missing a `domain:` option in `use Ash.Resource`.",
+          trigger: "use Ash.Resource",
+          line_no: Introspection.resource_issue_line(context)
+        )
+      ]
     end
   end
+
+  defp missing_domain_issues(_context, _issue_meta), do: []
 end

--- a/lib/ash_credo/check/warning/missing_macro_directive.ex
+++ b/lib/ash_credo/check/warning/missing_macro_directive.ex
@@ -275,12 +275,13 @@ defmodule AshCredo.Check.Warning.MissingMacroDirective do
   # segment is an atom (rejecting interpolated/quoted aliases like
   # `unquote(mod)` or `__MODULE__` mid-segment), otherwise `:error`.
   defp atomic_module(segs) do
-    segs
-    |> Enum.reduce_while([], fn
-      seg, acc when is_atom(seg) -> {:cont, [seg | acc]}
-      _seg, _acc -> {:halt, :error}
-    end)
-    |> case do
+    reduced =
+      Enum.reduce_while(segs, [], fn
+        seg, acc when is_atom(seg) -> {:cont, [seg | acc]}
+        _seg, _acc -> {:halt, :error}
+      end)
+
+    case reduced do
       :error -> :error
       reversed -> {:ok, reversed |> Enum.reverse() |> Module.concat()}
     end

--- a/lib/ash_credo/check/warning/redundant_validation.ex
+++ b/lib/ash_credo/check/warning/redundant_validation.ex
@@ -58,9 +58,7 @@ defmodule AshCredo.Check.Warning.RedundantValidation do
       source_file,
       params,
       __MODULE__,
-      fn resource, context, issue_meta ->
-        check_resource(resource, context, issue_meta)
-      end
+      &check_resource/3
     )
   end
 

--- a/lib/ash_credo/check/warning/redundant_validation.ex
+++ b/lib/ash_credo/check/warning/redundant_validation.ex
@@ -175,16 +175,12 @@ defmodule AshCredo.Check.Warning.RedundantValidation do
   defp entry_on(_entry), do: nil
 
   defp resolve_candidates(resource, context, candidates, issue_meta) do
-    case CompiledIntrospection.inspect_module(resource) do
-      {:ok, %{attributes: attributes, actions: actions}} ->
+    resource
+    |> CompiledIntrospection.inspect_module()
+    |> Orchestration.with_resource_info(resource, context, issue_meta, __MODULE__, fn
+      %{attributes: attributes, actions: actions} ->
         flag_redundant(resource, candidates, attributes, actions, issue_meta)
-
-      {:error, :not_loadable} ->
-        Orchestration.unique_not_loadable_issues(resource, context, issue_meta, __MODULE__)
-
-      {:error, _} ->
-        []
-    end
+    end)
   end
 
   defp flag_redundant(resource, candidates, attributes, actions, issue_meta) do

--- a/lib/ash_credo/introspection/compiled.ex
+++ b/lib/ash_credo/introspection/compiled.ex
@@ -524,12 +524,14 @@ defmodule AshCredo.Introspection.Compiled do
       when is_list(known_actions) and is_atom(target_name) do
     target_str = Atom.to_string(target_name)
 
-    known_actions
-    |> Enum.map(fn action ->
-      {action.name, String.jaro_distance(target_str, Atom.to_string(action.name))}
-    end)
-    |> Enum.filter(fn {_, score} -> score >= 0.75 end)
-    |> case do
+    scored =
+      known_actions
+      |> Enum.map(fn action ->
+        {action.name, String.jaro_distance(target_str, Atom.to_string(action.name))}
+      end)
+      |> Enum.filter(fn {_, score} -> score >= 0.75 end)
+
+    case scored do
       [] -> nil
       scored -> scored |> Enum.max_by(&elem(&1, 1)) |> elem(0)
     end

--- a/lib/ash_credo/introspection/compiled.ex
+++ b/lib/ash_credo/introspection/compiled.ex
@@ -272,17 +272,7 @@ defmodule AshCredo.Introspection.Compiled do
   """
   @spec macros(module()) :: {:ok, MapSet.t(atom())} | {:error, :not_loadable}
   def macros(module) when is_atom(module) do
-    key = {@macros_key_tag, module}
-
-    case Cache.get(key, :miss) do
-      :miss ->
-        result = do_macros(module)
-        Cache.put(key, result)
-        result
-
-      cached ->
-        cached
-    end
+    Cache.memoize({@macros_key_tag, module}, fn -> do_macros(module) end)
   end
 
   defp do_macros(module) do
@@ -409,17 +399,9 @@ defmodule AshCredo.Introspection.Compiled do
           {:ok, %{scope: :resource | :domain, interface: struct(), resource: module() | nil}}
           | {:error, :not_code_interface | error()}
   def code_interface_bang(module, fun) when is_atom(module) and is_atom(fun) do
-    key = {@code_interface_bang_key_tag, module, fun}
-
-    case Cache.get(key, :miss) do
-      :miss ->
-        result = do_code_interface_bang(module, fun)
-        Cache.put(key, result)
-        result
-
-      cached ->
-        cached
-    end
+    Cache.memoize({@code_interface_bang_key_tag, module, fun}, fn ->
+      do_code_interface_bang(module, fun)
+    end)
   end
 
   defp do_code_interface_bang(module, fun) do
@@ -526,17 +508,9 @@ defmodule AshCredo.Introspection.Compiled do
   # `UseCodeInterface` at O(N) across a file with N `Ash.*` calls into the
   # same domain instead of O(N*M).
   defp cached_domain_references(domain) do
-    key = {@domain_refs_key_tag, domain}
-
-    case Cache.get(key, :miss) do
-      :miss ->
-        refs = Ash.Domain.Info.resource_references(domain)
-        Cache.put(key, refs)
-        refs
-
-      cached ->
-        cached
-    end
+    Cache.memoize({@domain_refs_key_tag, domain}, fn ->
+      Ash.Domain.Info.resource_references(domain)
+    end)
   end
 
   @doc """
@@ -631,15 +605,7 @@ defmodule AshCredo.Introspection.Compiled do
   """
   @spec enclosing_domain(module()) :: module() | nil
   def enclosing_domain(module) when is_atom(module) do
-    case Cache.get({@enclosing_domain_key_tag, module}, :miss) do
-      :miss ->
-        result = compute_enclosing_domain(module)
-        Cache.put({@enclosing_domain_key_tag, module}, result)
-        result
-
-      cached ->
-        cached
-    end
+    Cache.memoize({@enclosing_domain_key_tag, module}, fn -> compute_enclosing_domain(module) end)
   end
 
   defp compute_enclosing_domain(module) do

--- a/lib/ash_credo/orchestration.ex
+++ b/lib/ash_credo/orchestration.ex
@@ -148,6 +148,25 @@ defmodule AshCredo.Orchestration do
     end)
   end
 
+  @doc """
+  Dispatches the result of a `Compiled.inspect_module/1`-style introspection
+  lookup (`inspect_module/1` itself or any accessor built on it, such as
+  `attributes/1` or `actions/1`). Invokes `on_ok.(info)` for `{:ok, info}`,
+  emits the deduplicated "could not load" diagnostic for
+  `{:error, :not_loadable}`, and contributes no issues for any other error.
+
+  Every compiled resource check funnels its lookup result through here, so the
+  not-loadable handling lives in one place.
+  """
+  def with_resource_info(result, resource, context, issue_meta, check, on_ok)
+      when is_function(on_ok, 1) do
+    case result do
+      {:ok, info} -> on_ok.(info)
+      {:error, :not_loadable} -> unique_not_loadable_issues(resource, context, issue_meta, check)
+      {:error, _} -> []
+    end
+  end
+
   defp short_name(check), do: check |> Module.split() |> List.last()
 
   @doc """

--- a/lib/ash_credo/orchestration.ex
+++ b/lib/ash_credo/orchestration.ex
@@ -141,7 +141,7 @@ defmodule AshCredo.Orchestration do
           message:
             "Could not load `#{inspect(resource)}` for `#{short_name(check)}`. " <>
               "Run `mix compile` before `mix credo`, or disable this check in `.credo.exs`.",
-          line_no: Map.get(context, :use_line) || 1
+          line_no: context.use_line || 1
         ],
         check
       )


### PR DESCRIPTION
Idiomatic-Elixir cleanup across the check and introspection modules, staged in three behavior-preserving commits. No test changed; each commit independently compiles clean, passes all tests and the `mix lint` chain.

## Tier 1 — structural dedup
- Replace 4 hand-rolled cache-miss blocks in `Compiled` with the existing `Cache.memoize/2` (`macros`, `code_interface_bang`, `cached_domain_references`, `enclosing_domain`).
- Extract `Orchestration.with_resource_info/6` to centralize the `inspect_module` result dispatch that was copy-pasted across 6 compiled resource checks.
- Fold the separate `embedded?` probe into the `{:ok, %{embedded?: true}}` branch for `MissingIdentity` and `MissingCodeInterface`, dropping a redundant lookup and a wrapper function.

## Tier 2 — local idioms
- Match struct fields in function heads / use dot access instead of `Map.get` on known structs: timestamp attribute predicates, code-interface field reads, `ResourceContext.use_line`.
- `for` comprehension for the nested `authorize?`-false scan; head guard for `MissingDomain`'s `use_opts`; `case` on `nil` for `EmptyDomain`; `with` for `RaisingCall`'s bang/excluded cascade.

## Tier 3 — micro/stylistic
- Assign the intermediate before matching instead of piping into `case` (`atomic_module`, `suggest_action_name`).
- Express `ActorOnCallOptions`' binding lookup as a `with` over the seen-set guard plus a map pattern match.
- Pass `&check_resource/3` directly where a lambda only forwarded its arguments.