### PR TITLE
refactor: document AST limitations and fill check test gaps

### DIFF
--- a/lib/ash_credo/check/warning/empty_domain.ex
+++ b/lib/ash_credo/check/warning/empty_domain.ex
@@ -11,6 +11,14 @@ defmodule AshCredo.Check.Warning.EmptyDomain do
             resource MyApp.Post
             resource MyApp.Comment
           end
+
+      ## Limitations
+
+      This check scans the source AST, so it only sees resources registered
+      literally in the `resources` block. Resources contributed by Spark
+      transformers, extensions, or `Spark.Dsl.Fragment` modules are
+      invisible to it, so a domain whose resources come from such a source
+      may be flagged as empty even though it is not.
       """
     ]
 

--- a/lib/ash_credo/check/warning/sensitive_attribute_exposed.ex
+++ b/lib/ash_credo/check/warning/sensitive_attribute_exposed.ex
@@ -16,6 +16,16 @@ defmodule AshCredo.Check.Warning.SensitiveAttributeExposed do
 
       The `sensitive_names` param accepts atoms (exact name match) and regexes
       (matched against the attribute name), e.g. `[:ssn, ~r/_token$/]`.
+
+      ## Limitations
+
+      This check scans the source AST, so it only sees attributes written
+      literally in the `attributes` block. It cannot see attributes
+      contributed by Spark transformers or extensions - for example
+      `AshAuthentication`'s `:hashed_password` - and so will not flag them
+      even when they are unmarked. It likewise only matches the `attribute`
+      entity: foreign keys and timestamps declared via `belongs_to`,
+      `create_timestamp`, or `update_timestamp` are not inspected.
       """,
       params: [
         sensitive_names:

--- a/test/ash_credo/check/warning/authorizer_without_policies_test.exs
+++ b/test/ash_credo/check/warning/authorizer_without_policies_test.exs
@@ -10,6 +10,8 @@ defmodule AshCredo.Check.Warning.AuthorizerWithoutPoliciesTest do
   #     but defines NO policies block. Failure-path fixture.
   #   * `AshCredoFixtures.Blog.Post`            - has no authorizer at all.
   #     Happy-path fixture (check should silently skip).
+  #   * `AshCredoFixtures.Blog.WithAuthorizerAndPolicies` - declares the
+  #     authorizer AND a non-empty `policies` block. Happy-path fixture.
 
   setup do
     CompiledIntrospection.clear_cache()
@@ -31,6 +33,16 @@ defmodule AshCredo.Check.Warning.AuthorizerWithoutPoliciesTest do
   test "no issue when no authorizer is declared" do
     source = """
     defmodule AshCredoFixtures.Blog.Post do
+      use Ash.Resource, domain: AshCredoFixtures.Blog
+    end
+    """
+
+    assert [] = run_check(AuthorizerWithoutPolicies, source)
+  end
+
+  test "no issue when the authorizer is declared and policies exist" do
+    source = """
+    defmodule AshCredoFixtures.Blog.WithAuthorizerAndPolicies do
       use Ash.Resource, domain: AshCredoFixtures.Blog
     end
     """

--- a/test/ash_credo/check/warning/unknown_action_test.exs
+++ b/test/ash_credo/check/warning/unknown_action_test.exs
@@ -60,8 +60,7 @@ defmodule AshCredo.Check.Warning.UnknownActionTest do
       assert [] = run_check(UnknownAction, source)
     end
 
-    test "fires across all dispatch patterns the helper covers" do
-      # Pattern D builder + non-existent action.
+    test "fires for an Ash.Query.for_read builder (pattern D)" do
       source = """
       defmodule AshCredoFixtures.Blog do
         def query do
@@ -74,6 +73,33 @@ defmodule AshCredo.Check.Warning.UnknownActionTest do
       assert issue.message =~ "Unknown action"
       assert issue.message =~ ":nope"
       assert issue.trigger == "Ash.Query.for_read"
+    end
+
+    test "fires for an Ash.Changeset.for_create builder (pattern D)" do
+      source = """
+      defmodule AshCredoFixtures.Blog do
+        def build do
+          Ash.Changeset.for_create(AshCredoFixtures.Blog.Post, :nope)
+        end
+      end
+      """
+
+      assert [issue] = run_check(UnknownAction, source)
+      assert issue.message =~ "Unknown action"
+      assert issue.message =~ ":nope"
+      assert issue.trigger == "Ash.Changeset.for_create"
+    end
+
+    test "is silent for a resource-first builder naming a real action" do
+      source = """
+      defmodule AshCredoFixtures.Blog do
+        def build do
+          Ash.Changeset.for_create(AshCredoFixtures.Blog.Post, :create)
+        end
+      end
+      """
+
+      assert [] = run_check(UnknownAction, source)
     end
 
     test "is silent for plain Elixir modules and non-Ash calls" do

--- a/test/support/fixtures/ash_fixtures.ex
+++ b/test/support/fixtures/ash_fixtures.ex
@@ -79,6 +79,7 @@ defmodule AshCredoFixtures.Blog do
     resource AshCredoFixtures.Blog.Contact
     resource AshCredoFixtures.Blog.GenericActions
     resource AshCredoFixtures.Blog.WithAuthorizer
+    resource AshCredoFixtures.Blog.WithAuthorizerAndPolicies
     resource AshCredoFixtures.Blog.WithCalcInterface
   end
 end
@@ -277,6 +278,34 @@ defmodule AshCredoFixtures.Blog.WithAuthorizer do
     domain: AshCredoFixtures.Blog,
     validate_domain_inclusion?: false,
     authorizers: [Ash.Policy.Authorizer]
+
+  actions do
+    defaults [:read]
+    default_accept []
+  end
+
+  attributes do
+    uuid_primary_key :id
+  end
+end
+
+defmodule AshCredoFixtures.Blog.WithAuthorizerAndPolicies do
+  @moduledoc """
+  `AuthorizerWithoutPolicies` happy-path fixture: declares
+  `Ash.Policy.Authorizer` AND defines a non-empty `policies` block, so the
+  check must stay silent.
+  """
+
+  use Ash.Resource,
+    domain: AshCredoFixtures.Blog,
+    validate_domain_inclusion?: false,
+    authorizers: [Ash.Policy.Authorizer]
+
+  policies do
+    policy always() do
+      authorize_if always()
+    end
+  end
 
   actions do
     defaults [:read]


### PR DESCRIPTION
Two small, independent improvements from a codebase review.

## Document AST limitations
`SensitiveAttributeExposed` and `EmptyDomain` scan the source AST, so they
cannot see attributes or resources contributed by Spark transformers,
extensions, or DSL fragments. Both checks now carry a `## Limitations`
section saying so, to prevent false confidence:

- a domain whose resources come from an extension may be flagged as empty;
- sensitive attributes like AshAuthentication's `hashed_password`, or fields
  declared via `belongs_to`/timestamp entities, are not inspected.

## Fill check test gaps
- `AuthorizerWithoutPolicies` had no happy-path test for a resource that
  declares the authorizer *and* defines policies. Added the
  `WithAuthorizerAndPolicies` fixture and a test asserting the check stays
  silent, so a regression flagging correctly-configured resources would be
  caught.
- `UnknownAction`'s dispatch-pattern test only exercised `Ash.Query.for_read`
  despite claiming to cover all of them. Split it and added
  `Ash.Changeset.for_create` coverage (an unknown-action hit and a real-action
  pass) for the resource-first Pattern D builders.

`EmptyDomain` was reviewed and left as-is: it is a pure-AST check with no
not-loadable path, and its cases are already fully covered.