### PR TITLE
ci: split the check job into parallel test and lint jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
           persist-credentials: false
       - uses: crate-ci/typos@37bb98842b0d8c4ffebdb75301a13db0267cef89 # v1.47.2
 
-  check:
+  test:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -54,6 +54,31 @@ jobs:
           restore-keys: |
             mix-${{ steps.beam.outputs.otp-version }}-${{ steps.beam.outputs.elixir-version }}-
       - run: mix deps.get
+      # Force the plugin to recompile so the integration tests exercise the
+      # current source rather than a stale cached build.
       - run: rm -rf _build/*/lib/ash_credo
       - run: mix test
+
+  lint:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1.24.0
+        id: beam
+        with:
+          otp-version: "29"
+          elixir-version: "1.20"
+      - uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
+        with:
+          path: |
+            deps
+            _build
+          key: mix-${{ steps.beam.outputs.otp-version }}-${{ steps.beam.outputs.elixir-version }}-${{ hashFiles('mix.lock') }}
+          restore-keys: |
+            mix-${{ steps.beam.outputs.otp-version }}-${{ steps.beam.outputs.elixir-version }}-
+      - run: mix deps.get
       - run: mix lint


### PR DESCRIPTION
## Motivation

The single `check` job ran `mix test` and then `mix lint` sequentially, so a lint failure surfaced only after the full test output and the two phases could not run at the same time. Splitting them gives each its own status and lets them run concurrently.

## Changes

- Replace the single `check` job with separate `test` and `lint` jobs
- Keep the `_build/*/lib/ash_credo` recompile step in `test` only, since it exists to force the plugin to rebuild for the integration tests
