### PR TITLE
test: scope mix test --cover to library modules

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -15,6 +15,7 @@ defmodule AshCredo.MixProject do
       deps: deps(),
       elixirc_paths: elixirc_paths(Mix.env()),
       test_ignore_filters: [~r{^test/integration/fixtures/}],
+      test_coverage: [ignore_modules: [~r/AshCredoFixtures\./, AshCredo.CheckCase]],
       package: package(),
       docs: docs(),
       source_url: "https://github.com/leonqadirie/ash_credo",


### PR DESCRIPTION
## Motivation

`mix test --cover` counted test-support modules toward the coverage percentage, which distorted it as a measure of how well the shipped library is tested. The fixture resources and, more significantly, the per-resource `Inspect` protocol implementations Ash derives for them (`Inspect.AshCredoFixtures.*`) sat at 0% and dragged the total down even though none of it is library code.

## Changes

- Add `test_coverage: [ignore_modules: ...]` to scope the built-in coverage report to `lib/`
- Ignore the `AshCredoFixtures.*` namespace with an unanchored pattern so the derived `Inspect.AshCredoFixtures.*` modules are excluded too
- Ignore the `AshCredo.CheckCase` test case template
