### PR TITLE
feat: support regex entries in SensitiveFieldInAccept dangerous_fields

### DIFF
--- a/lib/ash_credo/check/warning/sensitive_field_in_accept.ex
+++ b/lib/ash_credo/check/warning/sensitive_field_in_accept.ex
@@ -19,7 +19,10 @@ defmodule AshCredo.Check.Warning.SensitiveFieldInAccept do
           end
       """,
       params: [
-        dangerous_fields: "Field names that should not appear in accept lists."
+        dangerous_fields:
+          "Field names that should not appear in accept lists. Atom entries " <>
+            "match exactly; `Regex` entries (e.g. `~r/_token$/`) match against " <>
+            "the field name."
       ]
     ]
 
@@ -70,7 +73,7 @@ defmodule AshCredo.Check.Warning.SensitiveFieldInAccept do
 
   defp dangerous_accept_issues(fields, line_no, dangerous, issue_meta, prefix) do
     fields
-    |> Enum.filter(&(&1 in dangerous))
+    |> Enum.filter(&dangerous_field?(&1, dangerous))
     |> Enum.map(fn field ->
       format_issue(issue_meta,
         message:
@@ -93,7 +96,7 @@ defmodule AshCredo.Check.Warning.SensitiveFieldInAccept do
     |> Enum.flat_map(fn
       {type, default_fields} when type in @writable_action_types and is_list(default_fields) ->
         default_fields
-        |> Enum.filter(&(&1 in dangerous))
+        |> Enum.filter(&dangerous_field?(&1, dangerous))
         |> Enum.map(fn field ->
           format_issue(issue_meta,
             message:
@@ -125,4 +128,14 @@ defmodule AshCredo.Check.Warning.SensitiveFieldInAccept do
         []
     end)
   end
+
+  defp dangerous_field?(field, dangerous) do
+    Enum.any?(dangerous, &field_matches?(field, &1))
+  end
+
+  defp field_matches?(field, %Regex{} = regex) when is_atom(field),
+    do: Regex.match?(regex, Atom.to_string(field))
+
+  defp field_matches?(_field, %Regex{}), do: false
+  defp field_matches?(field, name), do: field == name
 end

--- a/test/ash_credo/check/warning/sensitive_field_in_accept_test.exs
+++ b/test/ash_credo/check/warning/sensitive_field_in_accept_test.exs
@@ -104,6 +104,45 @@ defmodule AshCredo.Check.Warning.SensitiveFieldInAcceptTest do
     assert issue.message =~ "is_admin"
   end
 
+  test "matches dangerous fields by regex when configured" do
+    source = """
+    defmodule MyApp.User do
+      use Ash.Resource, domain: MyApp.Accounts
+
+      actions do
+        create :register do
+          accept [:name, :reset_token, :api_token]
+        end
+      end
+    end
+    """
+
+    issues = run_check(SensitiveFieldInAccept, source, dangerous_fields: [~r/_token$/])
+    assert [_, _] = issues
+    triggers = Enum.map(issues, & &1.trigger)
+    assert "reset_token" in triggers
+    assert "api_token" in triggers
+  end
+
+  test "regex and atom entries can be mixed" do
+    source = """
+    defmodule MyApp.User do
+      use Ash.Resource, domain: MyApp.Accounts
+
+      actions do
+        create :register do
+          accept [:name, :is_admin, :reset_token]
+        end
+      end
+    end
+    """
+
+    issues = run_check(SensitiveFieldInAccept, source, dangerous_fields: [:is_admin, ~r/_token$/])
+    triggers = Enum.map(issues, & &1.trigger)
+    assert "is_admin" in triggers
+    assert "reset_token" in triggers
+  end
+
   test "no issue for safe fields" do
     source = """
     defmodule MyApp.User do


### PR DESCRIPTION
## Motivation

`SensitiveAttributeExposed` already matches sensitive names by atom or regex, but its sibling `SensitiveFieldInAccept` only accepted exact atoms. Teams with naming conventions (e.g. `*_token`, `*_secret`) had to enumerate every field name instead of expressing the rule once.

## Changes

- Match `dangerous_fields` entries by exact atom or `Regex`, mirroring `SensitiveAttributeExposed`
- Document the regex form in the `dangerous_fields` param docs
