### PR TITLE
docs: correct SensitiveAttributeExposed limitation note on belongs_to

### DIFF
--- a/lib/ash_credo/check/warning/sensitive_attribute_exposed.ex
+++ b/lib/ash_credo/check/warning/sensitive_attribute_exposed.ex
@@ -23,9 +23,10 @@ defmodule AshCredo.Check.Warning.SensitiveAttributeExposed do
       literally in the `attributes` block. It cannot see attributes
       contributed by Spark transformers or extensions - for example
       `AshAuthentication`'s `:hashed_password` - and so will not flag them
-      even when they are unmarked. It likewise only matches the `attribute`
-      entity: foreign keys and timestamps declared via `belongs_to`,
-      `create_timestamp`, or `update_timestamp` are not inspected.
+      even when they are unmarked. It also only inspects the `attribute`
+      entity: `belongs_to` foreign keys cannot be marked `sensitive?`
+      directly (declare the column as an explicit `attribute` if you need
+      that), and timestamps are not sensitive data, so neither is flagged.
       """,
       params: [
         sensitive_names:


### PR DESCRIPTION
## Motivation

The `SensitiveAttributeExposed` limitation note implied `belongs_to` foreign keys and timestamps ought to be inspected. In fact `belongs_to` does not accept `sensitive?` at all (Ash raises on the unknown option), so flagging one would suggest a fix that does not compile; the secret lives in the referenced resource, and a column that genuinely needs hiding is declared as an explicit `attribute` the check already covers. Timestamps accept `sensitive?` but never hold sensitive data.

## Changes

- Restate the limitation accurately instead of framing `belongs_to`/timestamps as a gap to close
