### PR TITLE
test: cover introspection internals and harden check assertions

### DIFF
--- a/test/ash_credo/check/warning/missing_domain_test.exs
+++ b/test/ash_credo/check/warning/missing_domain_test.exs
@@ -12,6 +12,8 @@ defmodule AshCredo.Check.Warning.MissingDomainTest do
 
     assert [issue] = run_check(MissingDomain, source)
     assert issue.message =~ "domain:"
+    assert issue.trigger == "use Ash.Resource"
+    assert issue.line_no == 2
   end
 
   test "no issue when domain is present" do
@@ -48,6 +50,7 @@ defmodule AshCredo.Check.Warning.MissingDomainTest do
     assert [issue] = run_check(MissingDomain, source)
     assert issue.message =~ "domain:"
     assert issue.line_no == 6
+    assert issue.trigger == "use Ash.Resource"
   end
 
   test "ignores non-Ash modules" do

--- a/test/ash_credo/check/warning/overly_permissive_policy_test.exs
+++ b/test/ash_credo/check/warning/overly_permissive_policy_test.exs
@@ -18,6 +18,8 @@ defmodule AshCredo.Check.Warning.OverlyPermissivePolicyTest do
 
     assert [issue] = run_check(OverlyPermissivePolicy, source)
     assert issue.message =~ "Unscoped policy"
+    assert issue.trigger == "authorize_if always()"
+    assert issue.line_no == 5
   end
 
   test "reports issue when policy uses expr(true) as guard" do
@@ -68,6 +70,8 @@ defmodule AshCredo.Check.Warning.OverlyPermissivePolicyTest do
 
     assert [issue] = run_check(OverlyPermissivePolicy, source)
     assert issue.message =~ "Bypass"
+    assert issue.trigger == "authorize_if always()"
+    assert issue.line_no == 5
   end
 
   test "reports issue for policy inside policy_group" do
@@ -87,6 +91,9 @@ defmodule AshCredo.Check.Warning.OverlyPermissivePolicyTest do
 
     assert [issue] = run_check(OverlyPermissivePolicy, source)
     assert issue.message =~ "Unscoped policy"
+    assert issue.trigger == "authorize_if always()"
+    # The nested policy sits one line below the enclosing policy_group.
+    assert issue.line_no == 6
   end
 
   test "no issue for scoped bypass" do
@@ -162,6 +169,8 @@ defmodule AshCredo.Check.Warning.OverlyPermissivePolicyTest do
 
     assert [issue] = run_check(OverlyPermissivePolicy, source)
     assert issue.message =~ "Unscoped policy"
+    assert issue.trigger == "authorize_if always()"
+    assert issue.line_no == 5
   end
 
   test "reports issue when condition is a list containing only always()" do
@@ -179,6 +188,8 @@ defmodule AshCredo.Check.Warning.OverlyPermissivePolicyTest do
 
     assert [issue] = run_check(OverlyPermissivePolicy, source)
     assert issue.message =~ "Unscoped policy"
+    assert issue.trigger == "authorize_if always()"
+    assert issue.line_no == 5
   end
 
   test "reports issue when bypass condition is a list containing only always()" do

--- a/test/ash_credo/check/warning/sensitive_attribute_exposed_test.exs
+++ b/test/ash_credo/check/warning/sensitive_attribute_exposed_test.exs
@@ -173,4 +173,35 @@ defmodule AshCredo.Check.Warning.SensitiveAttributeExposedTest do
 
     assert [] = run_check(SensitiveAttributeExposed, source)
   end
+
+  describe "malformed or non-literal DSL shapes are skipped, not crashed" do
+    test "a resource with no attributes section yields no issues" do
+      source = """
+      defmodule MyApp.User do
+        use Ash.Resource, domain: MyApp.Accounts
+
+        actions do
+          defaults [:read]
+        end
+      end
+      """
+
+      assert [] = run_check(SensitiveAttributeExposed, source)
+    end
+
+    test "an attribute with a non-atom name is ignored" do
+      source = """
+      defmodule MyApp.User do
+        use Ash.Resource, domain: MyApp.Accounts
+
+        attributes do
+          uuid_primary_key :id
+          attribute "password", :string
+        end
+      end
+      """
+
+      assert [] = run_check(SensitiveAttributeExposed, source)
+    end
+  end
 end

--- a/test/ash_credo/check/warning/sensitive_field_in_accept_test.exs
+++ b/test/ash_credo/check/warning/sensitive_field_in_accept_test.exs
@@ -209,4 +209,66 @@ defmodule AshCredo.Check.Warning.SensitiveFieldInAcceptTest do
 
     assert issue.message =~ "is_admin"
   end
+
+  describe "malformed or non-literal DSL shapes are skipped, not crashed" do
+    test "a resource with no actions section yields no issues" do
+      source = """
+      defmodule MyApp.Post do
+        use Ash.Resource, domain: MyApp.Blog
+
+        attributes do
+          uuid_primary_key :id
+        end
+      end
+      """
+
+      assert [] = run_check(SensitiveFieldInAccept, source)
+    end
+
+    test "a non-list `accept` value (e.g. `accept :all`) is ignored" do
+      source = """
+      defmodule MyApp.Post do
+        use Ash.Resource, domain: MyApp.Blog
+
+        actions do
+          create :create do
+            accept :all
+          end
+        end
+      end
+      """
+
+      assert [] = run_check(SensitiveFieldInAccept, source)
+    end
+
+    test "a non-list `default_accept` value is ignored" do
+      source = """
+      defmodule MyApp.Post do
+        use Ash.Resource, domain: MyApp.Blog
+
+        actions do
+          default_accept :all
+        end
+      end
+      """
+
+      assert [] = run_check(SensitiveFieldInAccept, source)
+    end
+
+    test "a regex pattern does not match a non-atom field entry" do
+      source = """
+      defmodule MyApp.Post do
+        use Ash.Resource, domain: MyApp.Blog
+
+        actions do
+          create :create do
+            accept ["api_key"]
+          end
+        end
+      end
+      """
+
+      assert [] = run_check(SensitiveFieldInAccept, source, dangerous_fields: [~r/api_key/])
+    end
+  end
 end

--- a/test/ash_credo/check/warning/wildcard_accept_on_action_test.exs
+++ b/test/ash_credo/check/warning/wildcard_accept_on_action_test.exs
@@ -191,4 +191,18 @@ defmodule AshCredo.Check.Warning.WildcardAcceptOnActionTest do
 
     assert issue.message =~ "accept :*"
   end
+
+  test "a resource with no actions section yields no issues" do
+    source = """
+    defmodule MyApp.Post do
+      use Ash.Resource, domain: MyApp.Blog
+
+      attributes do
+        uuid_primary_key :id
+      end
+    end
+    """
+
+    assert [] = run_check(WildcardAcceptOnAction, source)
+  end
 end

--- a/test/ash_credo/check_architecture_test.exs
+++ b/test/ash_credo/check_architecture_test.exs
@@ -18,6 +18,11 @@ defmodule AshCredo.CheckArchitectureTest do
   @check_glob "lib/ash_credo/check/**/*.ex"
   @compiled_segments [:AshCredo, :Introspection, :Compiled]
 
+  # The category/priority vocabularies Credo recognises. A typo here
+  # (`category: :warnings`) otherwise only surfaces as a Credo crash at runtime.
+  @categories ~w(consistency design readability refactor warning)a
+  @priorities ~w(higher high normal low lower)a
+
   # `{module, references_compiled?}` for every check module on disk. Driven by
   # the filesystem rather than `:application.get_key/2`, whose module list lags
   # a freshly added file, so a new check is covered the moment its file exists.
@@ -95,6 +100,27 @@ defmodule AshCredo.CheckArchitectureTest do
     assert untagged == [],
            "These AshCredo checks are missing the :ash tag (needed for " <>
              "`mix credo --only ash`): #{inspect(untagged)}"
+  end
+
+  test "every check declares a known category" do
+    offenders =
+      for {module, _} <- check_files(),
+          module.category() not in @categories,
+          do: {module, module.category()}
+
+    assert offenders == [],
+           "These checks declare an unknown category (Credo will not group " <>
+             "them and may crash): #{inspect(offenders)}"
+  end
+
+  test "every check declares a known base_priority" do
+    offenders =
+      for {module, _} <- check_files(),
+          module.base_priority() not in @priorities,
+          do: {module, module.base_priority()}
+
+    assert offenders == [],
+           "These checks declare an unknown base_priority: #{inspect(offenders)}"
   end
 
   describe "references_compiled?/1 resolves every alias form" do

--- a/test/ash_credo/introspection/aliases_test.exs
+++ b/test/ash_credo/introspection/aliases_test.exs
@@ -1,0 +1,130 @@
+defmodule AshCredo.Introspection.AliasesTest do
+  @moduledoc """
+  Direct unit tests for the pure alias-resolution helpers. These functions are
+  exercised indirectly through the checks, but the long-tail fallback clauses
+  (non-list inputs, `:as` renames, grouped aliases, empty segments) are only
+  reachable here without contriving exotic source. Every check that resolves a
+  module reference depends on this module, so the fallbacks are worth pinning.
+  """
+  use ExUnit.Case, async: true
+
+  alias AshCredo.Introspection.Aliases
+
+  describe "module_aliases/2" do
+    test "collects plain aliases from a module body" do
+      assert Aliases.module_aliases(quoted("alias Ash.Query")) == [{[:Query], [:Ash, :Query]}]
+    end
+
+    test "returns [] for a non-defmodule AST" do
+      assert Aliases.module_aliases({:def, [], []}) == []
+      assert Aliases.module_aliases(:not_an_ast) == []
+    end
+
+    test "honours :before_line, dropping aliases that lack a usable line" do
+      # The alias node is hand-built with empty meta, so `meta[:line]` is nil.
+      # With a `:before_line` set, the nil line takes the non-integer fallback
+      # in `alias_before?/2` and the alias is excluded.
+      module =
+        {:defmodule, [line: 1],
+         [
+           {:__aliases__, [line: 1], [:M]},
+           [do: {:__block__, [], [{:alias, [], [{:__aliases__, [line: 2], [:Ash, :Query]}]}]}]
+         ]}
+
+      assert Aliases.module_aliases(module, before_line: 5) == []
+    end
+  end
+
+  describe "expand_alias/2" do
+    test "expands using the longest-matching alias mapping" do
+      aliases = [{[:Q], [:Ash, :Query]}]
+      assert Aliases.expand_alias([:Q, :Sub], aliases) == [:Ash, :Query, :Sub]
+    end
+
+    test "leaves segments untouched when an alias entry is not a pair" do
+      assert Aliases.expand_alias([:Foo], [:not_a_pair]) == [:Foo]
+    end
+
+    test "returns segments unchanged when aliases is not a list" do
+      assert Aliases.expand_alias([:Foo], nil) == [:Foo]
+    end
+  end
+
+  describe "resolved_module_ref/3" do
+    test "returns non-ref, non-segment input unchanged" do
+      assert Aliases.resolved_module_ref(123, %{aliases: []}) == 123
+    end
+
+    test "resolves against a context map carrying module_ast and aliases" do
+      ctx = %{module_ast: quoted("alias Ash.Query, as: Q"), aliases: [{[:Q], [:Ash, :Query]}]}
+      assert Aliases.resolved_module_ref([:Q], ctx) == [:Ash, :Query]
+    end
+
+    test "resolves against a bare defmodule AST" do
+      module_ast = quoted("alias Ash.Query, as: Q")
+      assert Aliases.resolved_module_ref([:Q], module_ast) == [:Ash, :Query]
+    end
+
+    test "returns segments unchanged for an unrecognised context" do
+      assert Aliases.resolved_module_ref([:Foo], :not_a_context) == [:Foo]
+    end
+  end
+
+  describe "alias_entries/1" do
+    test "maps a plain alias to its default (last-segment) name" do
+      ast = {:alias, [], [{:__aliases__, [], [:Ash, :Query]}]}
+      assert Aliases.alias_entries(ast) == [{[:Query], [:Ash, :Query]}]
+    end
+
+    test "uses the :as rename when present" do
+      ast = {:alias, [], [{:__aliases__, [], [:Ash, :Query]}, [as: {:__aliases__, [], [:Q]}]]}
+      assert Aliases.alias_entries(ast) == [{[:Q], [:Ash, :Query]}]
+    end
+
+    test "falls back to the default name when opts carry no usable :as" do
+      ast = {:alias, [], [{:__aliases__, [], [:Ash, :Query]}, [warn: false]]}
+      assert Aliases.alias_entries(ast) == [{[:Query], [:Ash, :Query]}]
+    end
+
+    test "expands a grouped alias" do
+      ast = grouped_alias([:Ash], [[:Query], [:Changeset]])
+
+      assert Aliases.alias_entries(ast) ==
+               [{[:Query], [:Ash, :Query]}, {[:Changeset], [:Ash, :Changeset]}]
+    end
+
+    test "expands a grouped alias carrying trailing opts" do
+      ast = grouped_alias([:Ash], [[:Query]], warn: false)
+      assert Aliases.alias_entries(ast) == [{[:Query], [:Ash, :Query]}]
+    end
+
+    test "skips grouped suffixes that are not alias nodes" do
+      ast =
+        {:alias, [], [{{:., [], [{:__aliases__, [], [:Ash]}, :{}]}, [], [:not_an_alias_node]}]}
+
+      assert Aliases.alias_entries(ast) == []
+    end
+
+    test "handles an empty target segment list" do
+      ast = {:alias, [], [{:__aliases__, [], []}]}
+      assert Aliases.alias_entries(ast) == [{[nil], []}]
+    end
+
+    test "returns [] for anything that is not an alias node" do
+      assert Aliases.alias_entries(:garbage) == []
+    end
+  end
+
+  defp quoted(src), do: Code.string_to_quoted!("defmodule M do\n#{src}\nend")
+
+  defp grouped_alias(prefix, suffixes, opts \\ nil) do
+    prefix_ast = {:__aliases__, [], prefix}
+    suffix_asts = Enum.map(suffixes, &{:__aliases__, [], &1})
+    group = {{:., [], [prefix_ast, :{}]}, [], suffix_asts}
+
+    case opts do
+      nil -> {:alias, [], [group]}
+      opts -> {:alias, [], [group, opts]}
+    end
+  end
+end

--- a/test/ash_credo/introspection/ash_call_resolver_test.exs
+++ b/test/ash_credo/introspection/ash_call_resolver_test.exs
@@ -1,0 +1,140 @@
+defmodule AshCredo.Introspection.AshCallResolverTest do
+  @moduledoc """
+  Direct tests for the resolved-call-site pipeline. `UnknownAction` and
+  `UseCodeInterface` exercise the common shapes, but the long-tail dispatch
+  branches - literal lookup keys, the `for_*` builders, and the record/query
+  provenance tracing - are only reachable by feeding the resolver the exact
+  call shapes below. They all resolve against the loadable fixture
+  `AshCredoFixtures.Blog.Post` (primary key `:id`, primary `:read` action).
+  """
+  use AshCredo.CheckCase
+
+  alias AshCredo.Introspection.AshCallResolver
+  alias AshCredo.Introspection.Compiled, as: CompiledIntrospection
+
+  setup do
+    CompiledIntrospection.clear_cache()
+    :ok
+  end
+
+  defp sites(source), do: source |> source_file() |> AshCallResolver.sites()
+
+  describe "get-by lookup keys" do
+    test "extracts keys from a literal map id" do
+      source = """
+      defmodule M do
+        def f, do: Ash.get!(AshCredoFixtures.Blog.Post, %{id: 1})
+      end
+      """
+
+      assert [site] = sites(source)
+      assert site.call_kind == :get_one
+      assert site.lookup_keys == [:id]
+    end
+
+    test "extracts keys from a keyword id, ignoring :action" do
+      source = """
+      defmodule M do
+        def f, do: Ash.get!(AshCredoFixtures.Blog.Post, action: :read, id: 1)
+      end
+      """
+
+      assert [site] = sites(source)
+      assert site.lookup_keys == [:id]
+    end
+
+    test "falls back to the resource's single primary key when the id is opaque" do
+      source = """
+      defmodule M do
+        def f(id), do: Ash.get!(AshCredoFixtures.Blog.Post, id)
+      end
+      """
+
+      assert [site] = sites(source)
+      assert site.lookup_keys == [:id]
+    end
+  end
+
+  describe "for_* builders" do
+    test "tags an Ash.Query.for_read call as :query_to" do
+      source = """
+      defmodule M do
+        def f, do: Ash.Query.for_read(AshCredoFixtures.Blog.Post, :read)
+      end
+      """
+
+      assert [site] = sites(source)
+      assert site.builder_prefix == :query_to
+      assert site.call_kind == :builder
+    end
+
+    test "tags an Ash.ActionInput.for_action call as :input_to" do
+      source = """
+      defmodule M do
+        def f, do: Ash.ActionInput.for_action(AshCredoFixtures.Blog.Post, :run)
+      end
+      """
+
+      assert [site] = sites(source)
+      assert site.builder_prefix == :input_to
+    end
+  end
+
+  describe "provenance tracing" do
+    test "traces a record-first for_update back through a get! binding" do
+      source = """
+      defmodule M do
+        def f do
+          post = Ash.get!(AshCredoFixtures.Blog.Post, 1)
+          Ash.Changeset.for_update(post, :archive)
+        end
+      end
+      """
+
+      builder = Enum.find(sites(source), &(&1.builder_prefix == :changeset_to))
+
+      assert match?({:ok, AshCredoFixtures.Blog.Post, _}, builder.resolution)
+      assert builder.action_name == :archive
+    end
+
+    test "traces a bulk_update query origin through a pipe" do
+      source = """
+      defmodule M do
+        def f do
+          AshCredoFixtures.Blog.Post
+          |> Ash.Query.for_read(:read)
+          |> Ash.bulk_update(:archive, %{})
+        end
+      end
+      """
+
+      bulk = Enum.find(sites(source), &(&1.call_kind == :bulk))
+
+      assert match?({:ok, AshCredoFixtures.Blog.Post, _}, bulk.resolution)
+      assert bulk.action_name == :archive
+    end
+  end
+
+  describe "resource segment resolution" do
+    test "resolves __MODULE__ to the enclosing module" do
+      source = """
+      defmodule AshCredoFixtures.Blog.Post do
+        def f, do: Ash.read!(__MODULE__)
+      end
+      """
+
+      assert [site] = sites(source)
+      assert match?({:ok, AshCredoFixtures.Blog.Post, _}, site.resolution)
+    end
+
+    test "emits no site for a bare read of a non-resource module" do
+      source = """
+      defmodule M do
+        def f, do: Ash.read!(AshCredoFixtures.Plain)
+      end
+      """
+
+      assert [] = sites(source)
+    end
+  end
+end

--- a/test/ash_credo/introspection/compiled_test.exs
+++ b/test/ash_credo/introspection/compiled_test.exs
@@ -1,0 +1,98 @@
+defmodule AshCredo.Introspection.CompiledTest do
+  @moduledoc """
+  Tests the thin public accessors of the compiled-introspection gateway.
+  Checks consume the lower-level `inspect_module/1`, so the per-aspect
+  accessors (`actions/1`, `primary_key/1`, `authorizers/1`, ...) and their
+  error propagation are only exercised here. Each resolves against the
+  loadable `AshCredoFixtures.*` resources.
+  """
+  use ExUnit.Case, async: false
+
+  alias AshCredo.Introspection.Compiled
+
+  @post AshCredoFixtures.Blog.Post
+  @plain AshCredoFixtures.Plain
+
+  setup do
+    Compiled.clear_cache()
+    :ok
+  end
+
+  describe "resource aspect accessors" do
+    test "domain/1 returns the declared domain" do
+      assert Compiled.domain(@post) == {:ok, AshCredoFixtures.Blog}
+    end
+
+    test "interfaces/1 returns the code-interface entries" do
+      assert {:ok, interfaces} = Compiled.interfaces(@post)
+      assert Enum.any?(interfaces, &(&1.name == :archive))
+    end
+
+    test "calculation_interfaces/1 returns the calculation-interface entries" do
+      assert {:ok, [_ | _]} =
+               Compiled.calculation_interfaces(AshCredoFixtures.Blog.WithCalcInterface)
+    end
+
+    test "actions/1 returns the resolved action structs" do
+      assert {:ok, actions} = Compiled.actions(@post)
+      assert Enum.any?(actions, &(&1.name == :read and &1.type == :read))
+    end
+
+    test "attributes/1 returns the resolved attribute structs" do
+      assert {:ok, attributes} = Compiled.attributes(@post)
+      assert Enum.any?(attributes, &(&1.name == :id))
+    end
+
+    test "primary_key/1 returns the primary key attribute names" do
+      assert Compiled.primary_key(@post) == {:ok, [:id]}
+    end
+
+    test "identities/1 returns the declared identities" do
+      assert {:ok, identities} = Compiled.identities(AshCredoFixtures.Accounts.Profile)
+      assert Enum.any?(identities, &(&1.name == :unique_email))
+    end
+
+    test "authorizers/1 returns the declared authorizer modules" do
+      assert {:ok, authorizers} = Compiled.authorizers(AshCredoFixtures.Blog.WithAuthorizer)
+      assert Ash.Policy.Authorizer in authorizers
+    end
+
+    test "policies/1 returns policy entries, or [] without an authorizer" do
+      assert {:ok, [_ | _]} =
+               Compiled.policies(AshCredoFixtures.Blog.WithAuthorizerAndPolicies)
+
+      assert Compiled.policies(@post) == {:ok, []}
+    end
+  end
+
+  describe "action/2" do
+    test "returns the action struct for a known action" do
+      assert {:ok, action} = Compiled.action(@post, :read)
+      assert action.name == :read
+    end
+
+    test "returns :unknown_action for an undefined action" do
+      assert Compiled.action(@post, :nope) == {:error, :unknown_action}
+    end
+  end
+
+  describe "domain_resources/1" do
+    test "returns the resources registered in a domain" do
+      assert {:ok, resources} = Compiled.domain_resources(AshCredoFixtures.Blog)
+      assert @post in resources
+    end
+
+    test "returns :not_a_domain for a resource module" do
+      assert Compiled.domain_resources(@post) == {:error, :not_a_domain}
+    end
+  end
+
+  describe "error propagation through the accessors" do
+    test "a non-resource module yields :not_a_resource" do
+      assert Compiled.interfaces(@plain) == {:error, :not_a_resource}
+      assert Compiled.primary_key(@plain) == {:error, :not_a_resource}
+      assert Compiled.authorizers(@plain) == {:error, :not_a_resource}
+      assert Compiled.action(@plain, :read) == {:error, :not_a_resource}
+    end
+  end
+end

--- a/test/ash_credo/introspection_test.exs
+++ b/test/ash_credo/introspection_test.exs
@@ -1167,4 +1167,55 @@ defmodule AshCredo.IntrospectionTest do
       assert Introspection.embedded_resource?(context)
     end
   end
+
+  describe "fallback clauses and module-AST arities" do
+    test "ash_resource?/1 and ash_domain?/1 accept a bare module AST" do
+      resource = module_ast("defmodule P do\n  use Ash.Resource\nend")
+      domain = module_ast("defmodule D do\n  use Ash.Domain\nend")
+
+      assert Introspection.ash_resource?(resource)
+      refute Introspection.ash_domain?(resource)
+      assert Introspection.ash_domain?(domain)
+      refute Introspection.ash_resource?(domain)
+    end
+
+    test "use_opts/2 extracts options from a bare module AST" do
+      ast = module_ast("defmodule P do\n  use Ash.Resource, domain: MyApp.Blog\nend")
+      opts = Introspection.use_opts(ast, [:Ash, :Resource])
+
+      assert Keyword.has_key?(opts, :domain)
+    end
+
+    test "resource_data_layer/1 returns nil when the source has no `use`" do
+      sf = source_file("defmodule Plain do\n  def hi, do: :ok\nend")
+
+      assert Introspection.resource_data_layer(sf) == nil
+      refute Introspection.embedded_resource?(sf)
+      refute Introspection.has_data_layer?(sf)
+    end
+
+    test "module_line_count/1 returns nil for a non-defmodule input" do
+      assert Introspection.module_line_count(:not_a_module) == nil
+    end
+
+    test "resource_section/2 returns nil for a non-context input" do
+      assert Introspection.resource_section(:not_a_context, :attributes) == nil
+    end
+
+    test "entity_opts/1 returns [] for a non-entity input" do
+      assert Introspection.entity_opts(:not_a_tuple) == []
+    end
+
+    test "option_occurrences/2 returns [] for a non-entity input" do
+      assert Introspection.option_occurrences(:not_a_tuple, :anything) == []
+    end
+
+    test "option_values/2 reads a multi-argument option from an entity's do block" do
+      ast = module_ast("entity do\n  opt 1, 2\nend")
+
+      assert Introspection.option_values(ast, :opt) == [[1, 2]]
+    end
+  end
+
+  defp module_ast(src), do: Code.string_to_quoted!(src)
 end


### PR DESCRIPTION
## Motivation

The introspection layer that every check depends on was exercised only indirectly through the checks, leaving its alias resolution, resource/domain facade, call-site resolver, and compiled-introspection accessors with substantial untested surface. Several checks also asserted only an issue's message substring, so an AST-position regression (trigger or line number) would pass silently, and a few false-positive guards for malformed DSL were never reached.

## Changes

- Add direct unit tests for the introspection helpers: every `Aliases` fallback clause, the resource/domain facade's module-AST arities and nil fallbacks, the `AshCallResolver` lookup-key/builder/provenance-tracing branches, and the public accessor family of `Compiled`
- Pin the false-positive guards in the security checks: missing actions/attributes sections, non-list `accept`/`default_accept` values, a non-atom field/attribute name, and a regex pattern meeting a non-atom field
- Anchor `trigger` and `line_no` across the structurally distinct `OverlyPermissivePolicy` cases (plain policy, bypass, policy_group nesting, no-arg, list condition) and add the trigger assertion to `MissingDomain`
- Assert in the architecture test that every check declares a `category` and `base_priority` from Credo's known vocabularies, catching a typo before it crashes Credo at runtime
