### PR TITLE
ci: add hex.audit job to catch vulnerable dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,30 @@ jobs:
           persist-credentials: false
       - uses: crate-ci/typos@37bb98842b0d8c4ffebdb75301a13db0267cef89 # v1.47.2
 
+  audit:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1.24.0
+        id: beam
+        with:
+          otp-version: "29"
+          elixir-version: "1.20"
+      - uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
+        with:
+          path: |
+            deps
+            _build
+          key: mix-${{ steps.beam.outputs.otp-version }}-${{ steps.beam.outputs.elixir-version }}-${{ hashFiles('mix.lock') }}
+          restore-keys: |
+            mix-${{ steps.beam.outputs.otp-version }}-${{ steps.beam.outputs.elixir-version }}-
+      - run: mix deps.get
+      - run: mix hex.audit
+
   test:
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Motivation

Hex v2.5 added security advisory checking to `mix hex.audit`, so wiring it into CI catches known-vulnerable dependencies before they merge, closing a gap that dependabot-style version bumps alone don't cover.

## Changes

- Add an `audit` job to `ci.yml` that installs the latest Hex and runs `mix hex.audit`
