### PR TITLE
chore: add hex dependency cooldown

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -13,6 +13,7 @@ defmodule AshCredo.MixProject do
       start_permanent: Mix.env() == :prod,
       aliases: aliases(),
       deps: deps(),
+      hex: [cooldown: "7d"],
       elixirc_paths: elixirc_paths(Mix.env()),
       test_ignore_filters: [~r{^test/integration/fixtures/}],
       test_coverage: [ignore_modules: [~r/AshCredoFixtures\./, AshCredo.CheckCase]],


### PR DESCRIPTION
## Motivation

Hex v2.5 added a release-age cooldown that withholds newly published dependency versions from resolution until they reach a minimum age, guarding against supply-chain attacks where a compromised version is published and later yanked within days.

## Changes

- Set `hex: [cooldown: "7d"]` in `mix.exs` so new dependency releases must be at least a week old before `mix deps.get`/`deps.update` will pick them up
