### PR TITLE
test: fail loudly when a check fixture does not parse

### DIFF
--- a/test/support/check_case.ex
+++ b/test/support/check_case.ex
@@ -9,9 +9,22 @@ defmodule AshCredo.CheckCase do
     end
   end
 
+  # Raises on unparseable source: Credo returns an `:invalid` SourceFile
+  # for broken code and this suite's AST-walking checks then report zero
+  # issues, so a syntax typo in a fixture heredoc would make negative
+  # tests pass vacuously.
   def source_file(source_code, filename \\ "test_file.ex") do
-    source_code
-    |> Credo.SourceFile.parse(filename)
+    source_file = Credo.SourceFile.parse(source_code, filename)
+
+    if source_file.status != :valid do
+      raise """
+      fixture source failed to parse (#{filename}, status: #{inspect(source_file.status)}):
+
+      #{source_code}
+      """
+    end
+
+    source_file
   end
 
   def run_check(check_module, source_code, params \\ []) do

--- a/test/support/check_case.ex
+++ b/test/support/check_case.ex
@@ -9,7 +9,7 @@ defmodule AshCredo.CheckCase do
     end
   end
 
-  # Raises on unparseable source: Credo returns an `:invalid` SourceFile
+  # Raises on unparsable source: Credo returns an `:invalid` SourceFile
   # for broken code and this suite's AST-walking checks then report zero
   # issues, so a syntax typo in a fixture heredoc would make negative
   # tests pass vacuously.


### PR DESCRIPTION
## Motivation

`Credo.SourceFile.parse/2` returns an `:invalid` SourceFile with an empty AST for broken source, and this suite's AST-walking checks then report zero issues. A syntax typo in a fixture heredoc therefore makes negative assertions (`assert [] = run_check(...)`) pass without testing anything.

## Changes

- Raise in `AshCredo.CheckCase.source_file/2` when the parsed fixture is not `:valid`, printing the offending source in the error message
