### PR TITLE
fix: flag frozen Ash.UUIDv7.generate() defaults in CompileTimeDefault

### DIFF
--- a/lib/ash_credo/check/warning/compile_time_default.ex
+++ b/lib/ash_credo/check/warning/compile_time_default.ex
@@ -48,6 +48,7 @@ defmodule AshCredo.Check.Warning.CompileTimeDefault do
     {[:NaiveDateTime], :utc_now},
     {[:Time], :utc_now},
     {[:Ash, :UUID], :generate},
+    {[:Ash, :UUIDv7], :generate},
     {[:Ecto, :UUID], :generate}
   ]
 

--- a/test/ash_credo/check/warning/compile_time_default_test.exs
+++ b/test/ash_credo/check/warning/compile_time_default_test.exs
@@ -71,6 +71,22 @@ defmodule AshCredo.Check.Warning.CompileTimeDefaultTest do
     assert issue.trigger == "Ash.UUID.generate()"
   end
 
+  test "reports frozen Ash.UUIDv7.generate() default" do
+    source = """
+    defmodule MyApp.Post do
+      use Ash.Resource, domain: MyApp.Blog
+
+      attributes do
+        attribute :id, :uuid_v7, default: Ash.UUIDv7.generate()
+      end
+    end
+    """
+
+    assert [issue] = run_check(CompileTimeDefault, source)
+    assert issue.trigger == "Ash.UUIDv7.generate()"
+    assert issue.message =~ "default: &Ash.UUIDv7.generate/0"
+  end
+
   test "reports frozen default on an action argument" do
     source = """
     defmodule MyApp.Post do


### PR DESCRIPTION
## Motivation

`default: Ash.UUIDv7.generate()` is evaluated once while the module compiles, baking a single UUID literal into the resource so every record gets the same "unique" id - the exact bug class `CompileTimeDefault` exists to catch - but only `Ash.UUID` and `Ecto.UUID` were in the frozen-call list. Ash's own `uuid_v7_primary_key` builtin defaults to the `&Ash.UUIDv7.generate/0` capture the check recommends.

## Changes

- Add `{[:Ash, :UUIDv7], :generate}` to `@frozen_calls`
