### PR TITLE
fix: stop PinnedTimeInExpression flagging expr in function bodies

### DIFF
--- a/lib/ash_credo/check/warning/pinned_time_in_expression.ex
+++ b/lib/ash_credo/check/warning/pinned_time_in_expression.ex
@@ -22,6 +22,11 @@ defmodule AshCredo.Check.Warning.PinnedTimeInExpression do
 
           # Good
           filter expr(inserted_at >= now())
+
+      Only DSL-position expressions are checked. Inside function bodies
+      and anonymous functions the pin is re-evaluated on every call
+      (`Ash.Expr.expr/1` splices the pinned code into its call site), so
+      it is not frozen and is not flagged.
       """
     ]
 
@@ -82,10 +87,27 @@ defmodule AshCredo.Check.Warning.PinnedTimeInExpression do
     |> Enum.flat_map(&expr_issues(&1, issue_meta))
   end
 
+  # Heads whose bodies run after compilation: the pinned call inside them
+  # is re-evaluated per invocation, so the freeze bug does not exist there.
+  @deferred_heads ~w(def defp defmacro defmacrop fn &)a
+
   defp expr_issues(ast, issue_meta) do
     Credo.Code.prewalk(
       ast,
       fn
+        # An immediately-invoked fn/capture runs while the DSL compiles, so
+        # its body is NOT deferred - unwrap it and keep walking the bodies.
+        # The call arguments evaluate at the call site too, so walk them
+        # as well (`(fn e -> e end).(expr(^DateTime.utc_now()))`).
+        {{:., _, [{:fn, _, clauses}]}, _meta, args}, acc when is_list(args) ->
+          {{:__block__, [], [clause_bodies(clauses) | args]}, acc}
+
+        {{:., _, [{:&, _, capture_body}]}, _meta, args}, acc when is_list(args) ->
+          {{:__block__, [], List.wrap(capture_body) ++ args}, acc}
+
+        {head, _meta, args}, acc when head in @deferred_heads and is_list(args) ->
+          {:pruned, acc}
+
         {:expr, _meta, [body]} = node, acc ->
           {node, find_pinned_time_calls(body, issue_meta) ++ acc}
 
@@ -95,4 +117,14 @@ defmodule AshCredo.Check.Warning.PinnedTimeInExpression do
       []
     )
   end
+
+  defp clause_bodies(clauses) when is_list(clauses) do
+    {:__block__, [],
+     Enum.map(clauses, fn
+       {:->, _, [_args, body]} -> body
+       other -> other
+     end)}
+  end
+
+  defp clause_bodies(other), do: other
 end

--- a/test/ash_credo/check/warning/pinned_time_in_expression_test.exs
+++ b/test/ash_credo/check/warning/pinned_time_in_expression_test.exs
@@ -176,6 +176,103 @@ defmodule AshCredo.Check.Warning.PinnedTimeInExpressionTest do
     assert [] = run_check(PinnedTimeInExpression, source)
   end
 
+  test "no issue for expr inside function bodies" do
+    # Ash.Expr.expr/1 splices the pinned code into its call site, so in a
+    # function the pin re-evaluates on every call and is not frozen.
+    source = """
+    defmodule MyApp.Post do
+      use Ash.Resource, domain: MyApp.Blog
+
+      import Ash.Expr
+
+      def stale_query, do: Ash.Query.filter(__MODULE__, ^stale_expr())
+      defp stale_expr, do: expr(inserted_at >= ^DateTime.utc_now())
+    end
+    """
+
+    assert [] = run_check(PinnedTimeInExpression, source)
+  end
+
+  test "no issue for expr inside anonymous functions in the DSL" do
+    source = """
+    defmodule MyApp.Session do
+      use Ash.Resource, domain: MyApp.Auth
+
+      actions do
+        read :active do
+          prepare fn query, _context ->
+            Ash.Query.filter(query, expr(expires_at >= ^DateTime.utc_now()))
+          end
+        end
+      end
+    end
+    """
+
+    assert [] = run_check(PinnedTimeInExpression, source)
+  end
+
+  test "reports pinned time in an immediately-invoked fn in DSL position" do
+    # The fn runs while the resource compiles, so the pin IS frozen here -
+    # unlike a stored fn, which runs per invocation.
+    source = """
+    defmodule MyApp.Session do
+      use Ash.Resource, domain: MyApp.Auth
+
+      actions do
+        read :active do
+          filter (fn -> expr(expires_at >= ^DateTime.utc_now()) end).()
+        end
+      end
+    end
+    """
+
+    assert [issue] = run_check(PinnedTimeInExpression, source)
+    assert issue.trigger == "^DateTime.utc_now()"
+  end
+
+  test "reports pinned time passed as an argument to an immediately-invoked fn" do
+    # The argument evaluates at the call site during compilation, so the
+    # pin is frozen even though it never appears inside the fn body.
+    for line <- [
+          "filter (fn e -> e end).(expr(expires_at >= ^DateTime.utc_now()))",
+          "filter (& &1).(expr(expires_at >= ^DateTime.utc_now()))"
+        ] do
+      source = """
+      defmodule MyApp.Session do
+        use Ash.Resource, domain: MyApp.Auth
+
+        actions do
+          read :active do
+            #{line}
+          end
+        end
+      end
+      """
+
+      assert [issue] = run_check(PinnedTimeInExpression, source)
+      assert issue.trigger == "^DateTime.utc_now()"
+    end
+  end
+
+  test "still reports pinned time in DSL position alongside function helpers" do
+    source = """
+    defmodule MyApp.Session do
+      use Ash.Resource, domain: MyApp.Auth
+
+      actions do
+        read :active do
+          filter expr(expires_at >= ^DateTime.utc_now())
+        end
+      end
+
+      def helper, do: expr(expires_at >= ^DateTime.utc_now())
+    end
+    """
+
+    assert [issue] = run_check(PinnedTimeInExpression, source)
+    assert issue.line_no == 6
+  end
+
   test "ignores expr calls inside nested modules" do
     source = """
     defmodule MyApp.Post do


### PR DESCRIPTION
## Motivation

`Ash.Expr.expr/1` splices pinned code into its call site, so `^DateTime.utc_now()` is only frozen where that call site runs at compile time - DSL position. Inside `def`/`defp`/`defmacro` bodies and stored anonymous functions the pin re-evaluates on every call, but this default-enabled check flagged those too, with a message wrongly claiming the value "never updates".

## Changes

- Prune `def`/`defp`/`defmacro`/`defmacrop` and stored `fn`/`&` subtrees when scanning for `expr(...)` calls
- Unwrap immediately-invoked fns and captures (clause bodies and call arguments), since those do run during compilation and their pins are frozen
- Document the DSL-position scope in the check explanation
