### PR TITLE
fix: resolve alias __MODULE__.X instead of crashing the resolver

### DIFF
--- a/lib/ash_credo/introspection/aliases.ex
+++ b/lib/ash_credo/introspection/aliases.ex
@@ -49,6 +49,24 @@ defmodule AshCredo.Introspection.Aliases do
 
   def expand_alias(segments, _aliases), do: segments
 
+  @doc """
+  Substitutes `__MODULE__` elements in expanded alias segments with the
+  enclosing `defmodule`'s absolute segments (`alias __MODULE__.Post` targets
+  carry the raw `__MODULE__` AST tuple). Returns `{:ok, segments}` only when
+  every resulting segment is an atom - `Module.concat/1` raises on anything
+  else - and `:error` when substitution is impossible (no enclosing literal
+  module) or non-atom segments remain.
+  """
+  def resolve_module_self(segments, enclosing) when is_list(segments) do
+    resolved =
+      Enum.flat_map(segments, fn
+        {:__MODULE__, _, _} when is_list(enclosing) and enclosing != [] -> enclosing
+        other -> [other]
+      end)
+
+    if Enum.all?(resolved, &is_atom/1), do: {:ok, resolved}, else: :error
+  end
+
   @doc "Resolves a module reference or segments within a module or resource context."
   def resolved_module_ref(ref_or_segments, module_or_context, opts \\ [])
 
@@ -96,6 +114,23 @@ defmodule AshCredo.Introspection.Aliases do
       )
       when is_list(suffix_aliases) and is_list(opts) do
     grouped_alias_entries(prefix_segments, suffix_aliases)
+  end
+
+  # `alias __MODULE__.{Post, Comment}` - the prefix is the raw __MODULE__
+  # AST tuple, carried into the target segments for consumers to resolve
+  # via `resolve_module_self/2`.
+  def alias_entries(
+        {:alias, _, [{{:., _, [{:__MODULE__, _, _} = self_ref, :{}]}, _, suffix_aliases}]}
+      )
+      when is_list(suffix_aliases) do
+    grouped_alias_entries([self_ref], suffix_aliases)
+  end
+
+  def alias_entries(
+        {:alias, _, [{{:., _, [{:__MODULE__, _, _} = self_ref, :{}]}, _, suffix_aliases}, opts]}
+      )
+      when is_list(suffix_aliases) and is_list(opts) do
+    grouped_alias_entries([self_ref], suffix_aliases)
   end
 
   def alias_entries(_), do: []

--- a/lib/ash_credo/introspection/ash_call_resolver.ex
+++ b/lib/ash_credo/introspection/ash_call_resolver.ex
@@ -373,9 +373,14 @@ defmodule AshCredo.Introspection.AshCallResolver do
     end
   end
 
+  # Alias expansion can reintroduce non-atom segments even when `segs` is
+  # all atoms: `alias __MODULE__.Post` targets carry the `__MODULE__` AST
+  # tuple, so resolve it against the enclosing module before accepting.
   defp literal_segments({:__aliases__, _, segs}, context) when is_list(segs) do
     if Enum.all?(segs, &is_atom/1) do
-      {:ok, Aliases.expand_alias(segs, context.aliases)}
+      segs
+      |> Aliases.expand_alias(context.aliases)
+      |> Aliases.resolve_module_self(context.enclosing_module_segments)
     else
       :error
     end

--- a/lib/ash_credo/introspection/remote_bang_scanner.ex
+++ b/lib/ash_credo/introspection/remote_bang_scanner.ex
@@ -44,19 +44,17 @@ defmodule AshCredo.Introspection.RemoteBangScanner do
        )
        when is_list(args) and is_atom(fun_name) and is_list(segments) do
     if bang?(fun_name) do
-      expanded =
+      # `resolve_module_self/2` drops calls that cannot resolve to a
+      # concrete module (e.g. `__MODULE__` inside a non-literal
+      # `defmodule unquote(...)`) - `Module.concat/1` would raise on them.
+      resolved =
         segments
         |> Aliases.expand_alias(LexicalScopeWalker.aliases(scope))
-        |> resolve_module_self(LexicalScopeWalker.current_module_segments(scope))
+        |> Aliases.resolve_module_self(LexicalScopeWalker.current_module_segments(scope))
 
-      # After substituting `__MODULE__` with the enclosing module's segments,
-      # any remaining non-atoms (e.g. `__MODULE__` inside a non-literal
-      # `defmodule unquote(...)`) mean we still cannot resolve to a concrete
-      # module. `Module.concat/1` would raise, so drop the call.
-      if Enum.all?(expanded, &is_atom/1) do
-        %{state | calls: [{call_ast, expanded, fun_name} | state.calls]}
-      else
-        state
+      case resolved do
+        {:ok, expanded} -> %{state | calls: [{call_ast, expanded, fun_name} | state.calls]}
+        :error -> state
       end
     else
       state
@@ -64,15 +62,6 @@ defmodule AshCredo.Introspection.RemoteBangScanner do
   end
 
   defp on_enter(_node, _scope, state), do: state
-
-  defp resolve_module_self(segments, nil), do: segments
-
-  defp resolve_module_self(segments, enclosing) when is_list(enclosing) do
-    Enum.flat_map(segments, fn
-      {:__MODULE__, _, _} -> enclosing
-      other -> [other]
-    end)
-  end
 
   defp bang?(fun_name) do
     fun_name |> Atom.to_string() |> String.ends_with?("!")

--- a/test/ash_credo/introspection/aliases_test.exs
+++ b/test/ash_credo/introspection/aliases_test.exs
@@ -50,6 +50,30 @@ defmodule AshCredo.Introspection.AliasesTest do
     end
   end
 
+  describe "resolve_module_self/2" do
+    test "substitutes __MODULE__ with the enclosing segments" do
+      segments = [{:__MODULE__, [line: 2], nil}, :Post]
+
+      assert Aliases.resolve_module_self(segments, [:MyApp, :Blog]) ==
+               {:ok, [:MyApp, :Blog, :Post]}
+    end
+
+    test "passes through all-atom segments" do
+      assert Aliases.resolve_module_self([:MyApp, :Post], [:MyApp]) == {:ok, [:MyApp, :Post]}
+    end
+
+    test "errors when __MODULE__ has no enclosing module to resolve against" do
+      segments = [{:__MODULE__, [line: 2], nil}, :Post]
+      assert Aliases.resolve_module_self(segments, nil) == :error
+      assert Aliases.resolve_module_self(segments, []) == :error
+    end
+
+    test "errors when non-atom segments remain after substitution" do
+      segments = [{:unquote, [line: 2], [:x]}, :Post]
+      assert Aliases.resolve_module_self(segments, [:MyApp]) == :error
+    end
+  end
+
   describe "resolved_module_ref/3" do
     test "returns non-ref, non-segment input unchanged" do
       assert Aliases.resolved_module_ref(123, %{aliases: []}) == 123
@@ -91,6 +115,15 @@ defmodule AshCredo.Introspection.AliasesTest do
 
       assert Aliases.alias_entries(ast) ==
                [{[:Query], [:Ash, :Query]}, {[:Changeset], [:Ash, :Changeset]}]
+    end
+
+    test "expands a grouped alias with a __MODULE__ prefix" do
+      ast = Code.string_to_quoted!("alias __MODULE__.{Post, Comment}")
+
+      assert [
+               {[:Post], [{:__MODULE__, _, _}, :Post]},
+               {[:Comment], [{:__MODULE__, _, _}, :Comment]}
+             ] = Aliases.alias_entries(ast)
     end
 
     test "expands a grouped alias carrying trailing opts" do

--- a/test/ash_credo/introspection/ash_call_resolver_test.exs
+++ b/test/ash_credo/introspection/ash_call_resolver_test.exs
@@ -136,5 +136,37 @@ defmodule AshCredo.Introspection.AshCallResolverTest do
 
       assert [] = sites(source)
     end
+
+    test "resolves through alias __MODULE__.X without crashing" do
+      # Regression: the alias target carries the raw __MODULE__ AST tuple,
+      # which used to reach Module.concat/1 and raise FunctionClauseError.
+      source = """
+      defmodule AshCredoFixtures.Blog do
+        alias __MODULE__.Post
+
+        def f, do: Ash.read!(Post, action: :read)
+      end
+      """
+
+      assert [site] = sites(source)
+      assert match?({:ok, AshCredoFixtures.Blog.Post, _}, site.resolution)
+    end
+
+    test "resolves through multi-alias __MODULE__.{X} without crashing" do
+      # The grouped __MODULE__ prefix yields a real alias entry (see
+      # Aliases.alias_entries/1), so this resolves via resolve_module_self;
+      # the implicit nested-module fallback would coincidentally find the
+      # same module here, but the alias path is what this exercises.
+      source = """
+      defmodule AshCredoFixtures.Blog do
+        alias __MODULE__.{Post}
+
+        def f, do: Ash.Changeset.for_create(Post, :create)
+      end
+      """
+
+      assert [site] = sites(source)
+      assert match?({:ok, AshCredoFixtures.Blog.Post, _}, site.resolution)
+    end
   end
 end


### PR DESCRIPTION
## Motivation

`AshCallResolver.literal_segments/2` validated segments before alias expansion, so an alias target carrying the raw `__MODULE__` AST tuple - the common `alias __MODULE__.Post` idiom - reached `Module.concat/1` and raised `FunctionClauseError`. Since the resolver is memoized per file, every consuming check (`UseCodeInterface`, `UnknownAction`) errored for any file using that pattern. `RemoteBangScanner` already solved the same problem privately.

## Changes

- Add shared `Aliases.resolve_module_self/2` that substitutes `__MODULE__` with the enclosing module's segments after expansion and returns `:error` when non-atom segments remain
- Apply it in `AshCallResolver.literal_segments/2` and replace `RemoteBangScanner`'s private equivalent with it
- Register grouped `alias __MODULE__.{X, Y}` targets in `Aliases.alias_entries/1` so they resolve through the same path
