### PR TITLE
fix: skip argument-backed fields in RedundantValidation

### DIFF
--- a/lib/ash_credo/check/warning/redundant_validation.ex
+++ b/lib/ash_credo/check/warning/redundant_validation.ex
@@ -31,7 +31,18 @@ defmodule AshCredo.Check.Warning.RedundantValidation do
       Fields opened up via `allow_nil_input` on an action are skipped:
       there the attribute may legitimately be nil at validation time (for
       example filled by the data layer during an upsert), so `present` does
-      add a real constraint. Validations in read and generic actions are
+      add a real constraint. Fields shadowed by a same-named `argument` on
+      an update or destroy action are skipped too. In the atomic execution
+      path - the default for those action types (`require_atomic?`
+      defaults to `true`) - `Ash.Resource.Validation.Present` validates
+      the argument instead of the attribute, so the validation enforces
+      "the caller supplied the argument" regardless of the attribute
+      constraint. (The non-atomic path falls back to the attribute when
+      the argument is nil, where the validation is indeed vacuous - but
+      advising removal would silently drop the atomic-path constraint, so
+      the check stays silent.) Create actions never execute atomically, so
+      a same-named argument on a create does not rescue the validation and
+      no escape applies there. Validations in read and generic actions are
       also skipped, because `present` resolves against action arguments
       there, not attributes.
 
@@ -189,22 +200,41 @@ defmodule AshCredo.Check.Warning.RedundantValidation do
 
   defp redundant?(%{fields: fields, scope: scope}, non_nullable, actions) do
     Enum.all?(fields, &MapSet.member?(non_nullable, &1)) and
-      no_nullable_inputs?(fields, scope, actions)
+      no_input_overrides?(fields, scope, actions)
   end
 
-  defp no_nullable_inputs?(fields, {:action, action_name}, actions) do
+  # An action-level input can make `present` meaningful again despite the
+  # attribute constraint: `allow_nil_input` reopens the attribute, and a
+  # same-named `argument` redirects `present` to validate the argument in
+  # the atomic path (Ash.Resource.Validation.Present.atomic/3; the
+  # non-atomic path falls back to the attribute, but removal would drop
+  # the atomic-path constraint, so skip conservatively). Only update and
+  # destroy actions have an atomic path (`require_atomic?` exists on
+  # neither create struct nor create execution), so on creates the
+  # argument never rescues the validation and no escape applies.
+  defp no_input_overrides?(fields, {:action, action_name}, actions) do
     case Enum.find(actions, &(&1.name == action_name)) do
       # Source names an action the compiled module does not have (stale
       # build or fragment drift) - do not flag what we cannot resolve.
       nil -> false
-      action -> Enum.all?(fields, &(&1 not in nullable_inputs(action)))
+      action -> Enum.all?(fields, &(&1 not in overriding_inputs(action)))
     end
   end
 
-  defp no_nullable_inputs?(fields, :global, actions) do
-    nullable = Enum.flat_map(actions, &nullable_inputs/1)
-    Enum.all?(fields, &(&1 not in nullable))
+  defp no_input_overrides?(fields, :global, actions) do
+    overriding = Enum.flat_map(actions, &overriding_inputs/1)
+    Enum.all?(fields, &(&1 not in overriding))
   end
+
+  defp overriding_inputs(action), do: argument_names(action) ++ nullable_inputs(action)
+
+  @atomic_action_types ~w(update destroy)a
+
+  defp argument_names(%{type: type} = action) when type in @atomic_action_types do
+    action |> Map.get(:arguments) |> List.wrap() |> Enum.map(& &1.name)
+  end
+
+  defp argument_names(_action), do: []
 
   defp nullable_inputs(action), do: List.wrap(Map.get(action, :allow_nil_input) || [])
 

--- a/test/ash_credo/check/warning/redundant_validation_test.exs
+++ b/test/ash_credo/check/warning/redundant_validation_test.exs
@@ -166,6 +166,80 @@ defmodule AshCredo.Check.Warning.RedundantValidationTest do
     assert [] = run_check(RedundantValidation, source)
   end
 
+  test "no issue when an update action defines a same-named argument" do
+    # The compiled :reslug action defines `argument :slug`, so `present`
+    # validates the argument, not the attribute, in the atomic path
+    # (Ash.Resource.Validation.Present.atomic/3) - a real constraint
+    # despite the attribute's allow_nil? false.
+    source = """
+    defmodule AshCredoFixtures.Blog.Contact do
+      use Ash.Resource, domain: AshCredoFixtures.Blog
+
+      actions do
+        update :reslug do
+          validate present(:slug)
+        end
+      end
+    end
+    """
+
+    assert [] = run_check(RedundantValidation, source)
+  end
+
+  test "reports present when a create action defines a same-named argument" do
+    # Creates never execute atomically, so the non-atomic fallback to the
+    # attribute always applies and the validation stays redundant - the
+    # argument escape must not fire for create actions.
+    source = """
+    defmodule AshCredoFixtures.Blog.Contact do
+      use Ash.Resource, domain: AshCredoFixtures.Blog
+
+      actions do
+        create :import_slugged do
+          validate present(:slug)
+        end
+      end
+    end
+    """
+
+    assert [issue] = run_check(RedundantValidation, source)
+    assert issue.message =~ ":slug"
+  end
+
+  test "reports present on the same attribute in an action without the argument" do
+    source = """
+    defmodule AshCredoFixtures.Blog.Contact do
+      use Ash.Resource, domain: AshCredoFixtures.Blog
+
+      actions do
+        update :rename do
+          validate present(:slug)
+        end
+      end
+    end
+    """
+
+    assert [issue] = run_check(RedundantValidation, source)
+    assert issue.message =~ ":slug"
+  end
+
+  test "no issue for a global validation when an update action defines a same-named argument" do
+    source = """
+    defmodule AshCredoFixtures.Blog.Contact do
+      use Ash.Resource, domain: AshCredoFixtures.Blog
+
+      validations do
+        validate present(:slug)
+      end
+    end
+    """
+
+    # The compiled :reslug update action defines `argument :slug`, so the
+    # global validation is load-bearing for that action's atomic path.
+    # (The create :import_slugged argument alone would not suppress it.)
+    assert [] = run_check(RedundantValidation, source)
+  end
+
   test "no issue for present in read actions (checks arguments, not attributes)" do
     source = """
     defmodule AshCredoFixtures.Blog.Contact do

--- a/test/support/fixtures/ash_fixtures.ex
+++ b/test/support/fixtures/ash_fixtures.ex
@@ -376,10 +376,15 @@ end
 
 defmodule AshCredoFixtures.Blog.Contact do
   @moduledoc """
-  `RedundantValidation` fixture: `:name` and `:handle` carry
+  `RedundantValidation` fixture: `:name`, `:handle`, and `:slug` carry
   `allow_nil? false`, `:nickname` stays nullable, and the `:import` create
   action reopens `:name` (but not `:handle`) via `allow_nil_input` - the
   escape hatch under which a `present` validation is NOT redundant.
+  The `:reslug` update action defines an `argument :slug` shadowing the
+  attribute - there `present` validates the argument in the atomic path,
+  the other escape hatch under which the validation is NOT redundant.
+  The `:import_slugged` create action defines the same argument - creates
+  never run atomically, so the escape must NOT apply there.
   """
 
   use Ash.Resource,
@@ -401,6 +406,16 @@ defmodule AshCredoFixtures.Blog.Contact do
       accept [:name, :nickname]
       allow_nil_input [:name]
     end
+
+    update :reslug do
+      argument :slug, :string
+      accept []
+    end
+
+    create :import_slugged do
+      argument :slug, :string
+      accept []
+    end
   end
 
   attributes do
@@ -408,6 +423,7 @@ defmodule AshCredoFixtures.Blog.Contact do
     attribute :name, :string, allow_nil?: false, public?: true
     attribute :handle, :string, allow_nil?: false, default: "anon", public?: true
     attribute :nickname, :string, public?: true
+    attribute :slug, :string, allow_nil?: false, default: "slug", public?: true
   end
 end
 


### PR DESCRIPTION
## Motivation

When an update or destroy action defines an argument with the same name as a `validate present(...)` field, the atomic execution path - the default for those action types (`require_atomic?` defaults to `true`) - validates the argument instead of the attribute (`Ash.Resource.Validation.Present.atomic/3`). The validation then enforces "the caller supplied the argument" regardless of the attribute's `allow_nil? false`, yet the check called it redundant and advised removal, which would silently drop that constraint. Create actions never execute atomically, so the escape must not apply there.

## Changes

- Skip `present` fields shadowed by a same-named argument on update/destroy actions, in both per-action and global scopes
- Keep flagging argument-shadowed fields on create actions, where the non-atomic attribute fallback always applies
- Extend the `Contact` fixture with a `:slug` attribute plus `:reslug` (update) and `:import_slugged` (create) actions covering both sides
