### PR TITLE
fix: correct OverlyPermissivePolicy scoping and guard detection

### DIFF
--- a/lib/ash_credo/check/warning/overly_permissive_policy.ex
+++ b/lib/ash_credo/check/warning/overly_permissive_policy.ex
@@ -11,7 +11,25 @@ defmodule AshCredo.Check.Warning.OverlyPermissivePolicy do
       A policy is unscoped when its condition is `always()` or `expr(true)`,
       when every element of a list condition is one of those, when it has no
       condition at all (Ash defaults the condition to true), or when its only
-      body-level `condition` is `always()`/`expr(true)`.
+      body-level `condition` is `always()`/`expr(true)`. Conditions on
+      enclosing `policy_group`s count: Ash adds them to every policy the
+      group contains, so a policy inside `policy_group actor_attribute_equals(:role, :admin)`
+      is scoped even without a condition of its own.
+
+      Entity options do not scope: `policy description: "..." do` still
+      applies everywhere, and the condition is recognised whether passed
+      positionally or via the `condition:` option.
+
+      Checks apply top to bottom and the first one that reaches a decision
+      wins, so `authorize_if always()` preceded by a `forbid_if`/`forbid_unless`
+      is the deliberate allow-all-except pattern and is not flagged.
+      Guards that can never fire (`forbid_if never()`, `forbid_unless always()`,
+      boolean literals) do not count:
+
+          policy always() do
+            forbid_if actor_attribute_equals(:banned, true)
+            authorize_if always()
+          end
 
       Scope permissive policies to specific actions or action types:
 
@@ -36,10 +54,12 @@ defmodule AshCredo.Check.Warning.OverlyPermissivePolicy do
 
   defp check_policies(policies_ast, issue_meta) do
     policies_ast
-    |> Introspection.policy_entities()
-    |> Enum.filter(&has_authorize_if_always?/1)
-    |> Enum.reject(&scoped_policy?/1)
-    |> Enum.map(fn {kind, meta, _} ->
+    |> Introspection.policy_entities_with_conditions()
+    |> Enum.filter(fn {entity, _conditions} -> unguarded_authorize_always?(entity) end)
+    |> Enum.reject(fn {entity, inherited_conditions} ->
+      scoped_policy?(entity) or Enum.any?(inherited_conditions, &scoped_condition?/1)
+    end)
+    |> Enum.map(fn {{kind, meta, _}, _conditions} ->
       label = if kind == :bypass, do: "Bypass", else: "Unscoped policy"
 
       format_issue(issue_meta,
@@ -51,21 +71,46 @@ defmodule AshCredo.Check.Warning.OverlyPermissivePolicy do
     end)
   end
 
-  defp has_authorize_if_always?({kind, _, _} = policy_ast) when kind in [:policy, :bypass] do
-    Enum.any?(Introspection.entity_body(policy_ast), fn
-      {:authorize_if, _, [{:always, _, _}]} -> true
-      _ -> false
+  # Checks apply top to bottom and the first decision wins, so
+  # `authorize_if always()` only grants unconditional access when no
+  # earlier `forbid_if`/`forbid_unless` can deny first - with one, this is
+  # the deliberate allow-all-except pattern. Guards that can never fire
+  # (`forbid_if never()`/`expr(false)`/`false`, `forbid_unless
+  # always()`/`expr(true)`/`true`) do not count. Checks accept a trailing
+  # options list (`forbid_if never(), name: "..."`), which does not change
+  # the check itself.
+  defp unguarded_authorize_always?({kind, _, _} = policy_ast) when kind in [:policy, :bypass] do
+    policy_ast
+    |> Introspection.entity_body()
+    |> Enum.reduce_while(false, fn
+      {forbid, _, [check | _opts]}, acc when forbid in [:forbid_if, :forbid_unless] ->
+        if noop_forbid?(forbid, check), do: {:cont, acc}, else: {:halt, false}
+
+      {forbid, _, _}, _acc when forbid in [:forbid_if, :forbid_unless] ->
+        {:halt, false}
+
+      {:authorize_if, _, [{:always, _, _}]}, _acc ->
+        {:halt, true}
+
+      _other, acc ->
+        {:cont, acc}
     end)
   end
 
-  defp has_authorize_if_always?(_), do: false
+  defp unguarded_authorize_always?(_), do: false
+
+  defp noop_forbid?(:forbid_if, {:never, _, _}), do: true
+  defp noop_forbid?(:forbid_if, {:expr, _, [false]}), do: true
+  defp noop_forbid?(:forbid_if, false), do: true
+  defp noop_forbid?(:forbid_unless, check), do: unscoped_condition?(check)
+  defp noop_forbid?(_forbid, _check), do: false
 
   defp scoped_policy?({kind, _, args} = policy_ast) when kind in [:policy, :bypass] do
     case Enum.reject(args, &do_block?/1) do
       # policy do ... end - Ash defaults the condition to static true, so the
       # policy is only scoped if its body declares a restrictive `condition`
       [] -> scoped_body_condition?(policy_ast)
-      [condition | _] -> scoped_condition?(condition)
+      [condition_or_opts | _] -> scoped_condition_arg?(condition_or_opts, policy_ast)
     end
   end
 
@@ -73,6 +118,28 @@ defmodule AshCredo.Check.Warning.OverlyPermissivePolicy do
 
   defp do_block?([{:do, _} | _]), do: true
   defp do_block?(_), do: false
+
+  # The condition arg is optional and the entity takes options
+  # (`policy description: "..." do`), so a keyword list of known policy
+  # option keys is options, not a condition - the condition, if any, is
+  # its `:condition` key.
+  @policy_option_keys ~w(description access_type condition error_message)a
+
+  defp scoped_condition_arg?(arg, policy_ast) do
+    if policy_opts?(arg) do
+      case Keyword.fetch(arg, :condition) do
+        {:ok, condition} -> scoped_condition?(condition)
+        :error -> scoped_body_condition?(policy_ast)
+      end
+    else
+      scoped_condition?(arg)
+    end
+  end
+
+  defp policy_opts?(arg) do
+    Keyword.keyword?(arg) and arg != [] and
+      Enum.all?(arg, fn {key, _} -> key in @policy_option_keys end)
+  end
 
   defp scoped_body_condition?(policy_ast) do
     Enum.any?(Introspection.entity_body(policy_ast), fn
@@ -88,9 +155,11 @@ defmodule AshCredo.Check.Warning.OverlyPermissivePolicy do
 
   defp scoped_condition?(condition), do: not unscoped_condition?(condition)
 
-  # always() applies to everything; expr(true) is effectively unscoped.
-  # Anything else - action_type(:read), action([...]), actor checks - scopes.
+  # always() applies to everything; expr(true) and a bare `true` literal
+  # (Ash accepts booleans as checks) are effectively unscoped. Anything
+  # else - action_type(:read), action([...]), actor checks - scopes.
   defp unscoped_condition?({:always, _, _}), do: true
   defp unscoped_condition?({:expr, _, [true]}), do: true
+  defp unscoped_condition?(true), do: true
   defp unscoped_condition?(_), do: false
 end

--- a/lib/ash_credo/introspection.ex
+++ b/lib/ash_credo/introspection.ex
@@ -399,23 +399,45 @@ defmodule AshCredo.Introspection do
     end)
   end
 
-  @doc "Returns all `policy` and `bypass` entities from a policies section, including inside `policy_group`."
+  @doc "Returns all `policy` and `bypass` entities from a policies section, including inside `policy_group`s at any depth."
   def policy_entities(policies_ast) do
-    entries = section_entries(policies_ast)
-
-    top_level =
-      filter_entities(entries, :policy) ++ filter_entities(entries, :bypass)
-
-    nested =
-      entries
-      |> filter_entities(:policy_group)
-      |> Enum.flat_map(fn group ->
-        group_body = Block.do_block_entries(group)
-        filter_entities(group_body, :policy) ++ filter_entities(group_body, :bypass)
-      end)
-
-    top_level ++ nested
+    policies_ast
+    |> policy_entities_with_conditions()
+    |> Enum.map(&elem(&1, 0))
   end
+
+  @doc """
+  Returns `{entity, inherited_conditions}` pairs for all `policy` and
+  `bypass` entities in a policies section, in source order.
+
+  `policy_group`s are descended at any depth (`policy_group` is declared
+  `recursive_as: :policies` in Ash) and their condition arguments are
+  accumulated, outermost first: Ash adds the group conditions to each
+  policy the group contains, so `inherited_conditions` is part of every
+  contained policy's effective condition.
+  """
+  def policy_entities_with_conditions(policies_ast) do
+    policies_ast
+    |> section_entries()
+    |> collect_policy_entities([])
+  end
+
+  defp collect_policy_entities(entries, inherited) do
+    Enum.flat_map(entries, fn
+      {kind, _, _} = entity when kind in [:policy, :bypass] ->
+        [{entity, inherited}]
+
+      {:policy_group, _, args} = group ->
+        conditions = Enum.reject(List.wrap(args), &do_block?/1)
+        collect_policy_entities(Block.do_block_entries(group), inherited ++ conditions)
+
+      _other ->
+        []
+    end)
+  end
+
+  defp do_block?([{:do, _} | _]), do: true
+  defp do_block?(_), do: false
 
   @doc "Extracts the body statements from an entity's do block."
   def entity_body(ast), do: Block.do_block_entries(ast)

--- a/test/ash_credo/check/warning/overly_permissive_policy_test.exs
+++ b/test/ash_credo/check/warning/overly_permissive_policy_test.exs
@@ -96,6 +96,280 @@ defmodule AshCredo.Check.Warning.OverlyPermissivePolicyTest do
     assert issue.line_no == 6
   end
 
+  test "no issue when the enclosing policy_group has a restrictive condition" do
+    # Ash adds the group condition to every policy the group contains, so
+    # the inner policy is effectively scoped to admins.
+    source = """
+    defmodule MyApp.Post do
+      use Ash.Resource, domain: MyApp.Blog, authorizers: [Ash.Policy.Authorizer]
+
+      policies do
+        policy_group actor_attribute_equals(:role, :admin) do
+          policy do
+            authorize_if always()
+          end
+        end
+      end
+    end
+    """
+
+    assert [] = run_check(OverlyPermissivePolicy, source)
+  end
+
+  test "reports issue when the enclosing policy_group condition is always()" do
+    source = """
+    defmodule MyApp.Post do
+      use Ash.Resource, domain: MyApp.Blog, authorizers: [Ash.Policy.Authorizer]
+
+      policies do
+        policy_group always() do
+          policy always() do
+            authorize_if always()
+          end
+        end
+      end
+    end
+    """
+
+    assert [issue] = run_check(OverlyPermissivePolicy, source)
+    assert issue.message =~ "Unscoped policy"
+  end
+
+  test "no issue when a nested policy_group carries the restrictive condition" do
+    # policy_group is recursive; the inner group's condition scopes the policy.
+    source = """
+    defmodule MyApp.Post do
+      use Ash.Resource, domain: MyApp.Blog, authorizers: [Ash.Policy.Authorizer]
+
+      policies do
+        policy_group always() do
+          policy_group actor_attribute_equals(:role, :admin) do
+            policy do
+              authorize_if always()
+            end
+          end
+        end
+      end
+    end
+    """
+
+    assert [] = run_check(OverlyPermissivePolicy, source)
+  end
+
+  test "reports issue for an unscoped policy nested two policy_groups deep" do
+    source = """
+    defmodule MyApp.Post do
+      use Ash.Resource, domain: MyApp.Blog, authorizers: [Ash.Policy.Authorizer]
+
+      policies do
+        policy_group always() do
+          policy_group expr(true) do
+            policy do
+              authorize_if always()
+            end
+          end
+        end
+      end
+    end
+    """
+
+    assert [issue] = run_check(OverlyPermissivePolicy, source)
+    assert issue.line_no == 7
+  end
+
+  test "no issue for the allow-all-except pattern (forbid_if before authorize_if always())" do
+    # Checks apply top to bottom and the first decision wins, so the
+    # forbid_if guards the authorize_if always().
+    source = """
+    defmodule MyApp.Post do
+      use Ash.Resource, domain: MyApp.Blog, authorizers: [Ash.Policy.Authorizer]
+
+      policies do
+        policy always() do
+          forbid_if actor_attribute_equals(:banned, true)
+          authorize_if always()
+        end
+      end
+    end
+    """
+
+    assert [] = run_check(OverlyPermissivePolicy, source)
+  end
+
+  test "no issue when forbid_unless precedes authorize_if always()" do
+    source = """
+    defmodule MyApp.Post do
+      use Ash.Resource, domain: MyApp.Blog, authorizers: [Ash.Policy.Authorizer]
+
+      policies do
+        policy always() do
+          forbid_unless actor_present()
+          authorize_if always()
+        end
+      end
+    end
+    """
+
+    assert [] = run_check(OverlyPermissivePolicy, source)
+  end
+
+  test "reports issue when the only guard is a forbid that can never fire" do
+    # forbid_unless always()/expr(true) never forbids; forbid_if
+    # never()/expr(false) never fires - these are not real guards.
+    for guard <- [
+          "forbid_unless always()",
+          "forbid_unless expr(true)",
+          "forbid_if never()",
+          "forbid_if expr(false)"
+        ] do
+      source = """
+      defmodule MyApp.Post do
+        use Ash.Resource, domain: MyApp.Blog, authorizers: [Ash.Policy.Authorizer]
+
+        policies do
+          policy always() do
+            #{guard}
+            authorize_if always()
+          end
+        end
+      end
+      """
+
+      assert [issue] = run_check(OverlyPermissivePolicy, source)
+      assert issue.message =~ "Unscoped policy"
+    end
+  end
+
+  test "reports issue when the no-op guard carries a trailing options list" do
+    # Checks accept options (`name:`); they do not make a dead guard real.
+    source = """
+    defmodule MyApp.Post do
+      use Ash.Resource, domain: MyApp.Blog, authorizers: [Ash.Policy.Authorizer]
+
+      policies do
+        policy always() do
+          forbid_if never(), name: "documentation no-op"
+          authorize_if always()
+        end
+      end
+    end
+    """
+
+    assert [issue] = run_check(OverlyPermissivePolicy, source)
+    assert issue.message =~ "Unscoped policy"
+  end
+
+  test "no issue when a real guard carries a trailing options list" do
+    source = """
+    defmodule MyApp.Post do
+      use Ash.Resource, domain: MyApp.Blog, authorizers: [Ash.Policy.Authorizer]
+
+      policies do
+        policy always() do
+          forbid_if actor_attribute_equals(:banned, true), name: "no banned actors"
+          authorize_if always()
+        end
+      end
+    end
+    """
+
+    assert [] = run_check(OverlyPermissivePolicy, source)
+  end
+
+  test "reports issue when the guard is a bare boolean no-op" do
+    # Ash accepts booleans as checks; forbid_if false and forbid_unless true
+    # never forbid anything.
+    for guard <- ["forbid_if false", "forbid_unless true"] do
+      source = """
+      defmodule MyApp.Post do
+        use Ash.Resource, domain: MyApp.Blog, authorizers: [Ash.Policy.Authorizer]
+
+        policies do
+          policy always() do
+            #{guard}
+            authorize_if always()
+          end
+        end
+      end
+      """
+
+      assert [issue] = run_check(OverlyPermissivePolicy, source)
+      assert issue.message =~ "Unscoped policy"
+    end
+  end
+
+  test "reports issue for an unconditioned policy declared with entity options" do
+    # `policy description: "..." do` passes options, not a condition - the
+    # policy still defaults to applying everywhere.
+    source = """
+    defmodule MyApp.Post do
+      use Ash.Resource, domain: MyApp.Blog, authorizers: [Ash.Policy.Authorizer]
+
+      policies do
+        policy description: "everyone can do everything" do
+          authorize_if always()
+        end
+      end
+    end
+    """
+
+    assert [issue] = run_check(OverlyPermissivePolicy, source)
+    assert issue.message =~ "Unscoped policy"
+  end
+
+  test "no issue when the condition is passed via the condition option" do
+    source = """
+    defmodule MyApp.Post do
+      use Ash.Resource, domain: MyApp.Blog, authorizers: [Ash.Policy.Authorizer]
+
+      policies do
+        policy condition: actor_attribute_equals(:role, :admin), description: "admins" do
+          authorize_if always()
+        end
+      end
+    end
+    """
+
+    assert [] = run_check(OverlyPermissivePolicy, source)
+  end
+
+  test "reports issue when the condition option is itself unscoped" do
+    source = """
+    defmodule MyApp.Post do
+      use Ash.Resource, domain: MyApp.Blog, authorizers: [Ash.Policy.Authorizer]
+
+      policies do
+        policy condition: always(), description: "everyone" do
+          authorize_if always()
+        end
+      end
+    end
+    """
+
+    assert [issue] = run_check(OverlyPermissivePolicy, source)
+    assert issue.message =~ "Unscoped policy"
+  end
+
+  test "reports issue when authorize_if always() precedes the forbid check" do
+    # The authorize_if always() decides first; the forbid_if below it never
+    # runs, so the policy is genuinely all-permissive.
+    source = """
+    defmodule MyApp.Post do
+      use Ash.Resource, domain: MyApp.Blog, authorizers: [Ash.Policy.Authorizer]
+
+      policies do
+        policy always() do
+          authorize_if always()
+          forbid_if actor_attribute_equals(:banned, true)
+        end
+      end
+    end
+    """
+
+    assert [issue] = run_check(OverlyPermissivePolicy, source)
+    assert issue.message =~ "Unscoped policy"
+  end
+
   test "no issue for scoped bypass" do
     source = """
     defmodule MyApp.Post do

--- a/test/ash_credo/introspection_test.exs
+++ b/test/ash_credo/introspection_test.exs
@@ -1083,6 +1083,42 @@ defmodule AshCredo.IntrospectionTest do
     end
   end
 
+  describe "policy_entities_with_conditions/1" do
+    test "accumulates group conditions across nested policy_groups, outermost first" do
+      source = """
+      defmodule Foo do
+        use Ash.Resource
+
+        policies do
+          policy action_type(:read) do
+            authorize_if always()
+          end
+
+          policy_group actor_attribute_equals(:role, :admin) do
+            policy_group actor_present() do
+              policy do
+                authorize_if always()
+              end
+            end
+          end
+        end
+      end
+      """
+
+      policies = first_resource_section(source, :policies)
+
+      assert [
+               {{:policy, _, _}, []},
+               {{:policy, _, _},
+                [{:actor_attribute_equals, _, [:role, :admin]}, {:actor_present, _, _}]}
+             ] = Introspection.policy_entities_with_conditions(policies)
+    end
+
+    test "returns empty list for nil" do
+      assert [] == Introspection.policy_entities_with_conditions(nil)
+    end
+  end
+
   describe "entity_body/1" do
     test "extracts body statements from entity with do block" do
       actions = first_resource_section(@ash_resource, :actions)


### PR DESCRIPTION
## Motivation

The check evaluated each policy in isolation and matched only literal shapes, misjudging several documented Ash semantics. Conditions on enclosing `policy_group`s (which Ash flattens onto every contained policy at compile time) were ignored, so scoped policies were flagged; groups nest via `recursive_as: :policies`, but policies more than one group deep were invisible; the allow-all-except pattern (`forbid_if ...` before `authorize_if always()`, where checks apply top to bottom and the first decision wins) was flagged as granting everything; and keyword entity options (`policy description: "..." do`) were mistaken for a scoping condition, hiding genuinely unscoped policies.

## Changes

- Carry `policy_group` conditions onto contained policies and descend groups at any depth, via the new `Introspection.policy_entities_with_conditions/1`
- Treat `authorize_if always()` preceded by an effective `forbid_if`/`forbid_unless` as the deliberate allow-all-except pattern; guards that can never fire (`never()`, `expr(false)`, bare booleans, `forbid_unless always()`) do not count, and trailing check options (`name:`) are ignored
- Distinguish entity options from the condition argument, honouring conditions passed via the `condition:` option and flagging unconditioned option-only policies
