### PR TITLE
fix: treat require ... as: as the alias it creates

### DIFF
--- a/lib/ash_credo/introspection/aliases.ex
+++ b/lib/ash_credo/introspection/aliases.ex
@@ -3,7 +3,11 @@ defmodule AshCredo.Introspection.Aliases do
 
   alias AshCredo.Introspection.Block
 
-  @doc "Returns top-level alias mappings in a module body, optionally filtered by `:before_line`."
+  @doc """
+  Returns top-level alias mappings in a module body, optionally filtered by
+  `:before_line`. Covers `alias` directives and `require ..., as:` (which
+  sets up the same alias).
+  """
   def module_aliases(module_ast, opts \\ [])
 
   def module_aliases({:defmodule, _, _} = module_ast, opts) do
@@ -12,9 +16,9 @@ defmodule AshCredo.Introspection.Aliases do
     module_ast
     |> Block.module_body()
     |> Enum.flat_map(fn
-      {:alias, meta, _} = alias_ast ->
+      {directive, meta, _} = directive_ast when directive in [:alias, :require] ->
         if alias_before?(meta[:line], before_line) do
-          alias_entries(alias_ast)
+          alias_entries(directive_ast)
         else
           []
         end
@@ -131,6 +135,18 @@ defmodule AshCredo.Introspection.Aliases do
       )
       when is_list(suffix_aliases) and is_list(opts) do
     grouped_alias_entries([self_ref], suffix_aliases)
+  end
+
+  # `require Mod, as: Alias` sets up the alias exactly like
+  # `alias Mod, as: Alias` (a documented `require` option, and the
+  # idiomatic one-liner for macro modules like `Ash.Query`). A `require`
+  # without `as:` creates no alias.
+  def alias_entries({:require, _, [{:__aliases__, _, target_segments}, opts]})
+      when is_list(opts) do
+    case Keyword.get(opts, :as) do
+      {:__aliases__, _, alias_segments} -> [{alias_segments, target_segments}]
+      _ -> []
+    end
   end
 
   def alias_entries(_), do: []

--- a/lib/ash_credo/introspection/ash_call_scanner.ex
+++ b/lib/ash_credo/introspection/ash_call_scanner.ex
@@ -83,7 +83,10 @@ defmodule AshCredo.Introspection.AshCallScanner do
     {ast, maybe_enter_lexical_scope(state, node_name)}
   end
 
-  defp enter_node({:alias, _, _} = ast, state, _collect_fn) do
+  # `require ..., as:` sets up an alias too; `alias_entries/1` yields
+  # entries only for the shapes that actually create one.
+  defp enter_node({directive, _, _} = ast, state, _collect_fn)
+       when directive in [:alias, :require] do
     {ast, put_aliases(state, Aliases.alias_entries(ast))}
   end
 

--- a/lib/ash_credo/introspection/lexical_scope_walker.ex
+++ b/lib/ash_credo/introspection/lexical_scope_walker.ex
@@ -219,7 +219,11 @@ defmodule AshCredo.Introspection.LexicalScopeWalker do
   # is also in `lexical_scope_nodes`) is handled by exactly one clause -
   # follow each clause's chain to confirm.
 
-  defp enter({:alias, _, _} = node, {user, scope}, on_enter, options) do
+  # `require ..., as:` sets up an alias too; `capture_alias/3` delegates
+  # to `alias_entries/1`, which yields entries only for the shapes that
+  # actually create one.
+  defp enter({directive, _, _} = node, {user, scope}, on_enter, options)
+       when directive in [:alias, :require] do
     scope = capture_alias(scope, node, options)
     {node, {on_enter.(node, scope, user), scope}}
   end
@@ -264,7 +268,8 @@ defmodule AshCredo.Introspection.LexicalScopeWalker do
   # Leave: callback runs with current scope, then we pop. Mirror the enter
   # clauses so each push has a matching pop.
 
-  defp leave({:alias, _, _} = node, {user, scope}, on_leave, _options) do
+  defp leave({directive, _, _} = node, {user, scope}, on_leave, _options)
+       when directive in [:alias, :require] do
     {node, {on_leave.(node, scope, user), scope}}
   end
 

--- a/test/ash_credo/check/warning/unknown_action_test.exs
+++ b/test/ash_credo/check/warning/unknown_action_test.exs
@@ -75,6 +75,25 @@ defmodule AshCredo.Check.Warning.UnknownActionTest do
       assert issue.trigger == "Ash.Query.for_read"
     end
 
+    test "fires for a builder aliased via require ... as:" do
+      # `require Ash.Query, as: Query` sets up the alias like
+      # `alias Ash.Query, as: Query`, so the call must resolve the same way.
+      source = """
+      defmodule AshCredoFixtures.Blog do
+        require Ash.Query, as: Query
+
+        def query do
+          Query.for_read(AshCredoFixtures.Blog.Post, :nope)
+        end
+      end
+      """
+
+      assert [issue] = run_check(UnknownAction, source)
+      assert issue.message =~ "Unknown action"
+      assert issue.message =~ ":nope"
+      assert issue.trigger == "Ash.Query.for_read"
+    end
+
     test "fires for an Ash.Changeset.for_create builder (pattern D)" do
       source = """
       defmodule AshCredoFixtures.Blog do

--- a/test/ash_credo/introspection/aliases_test.exs
+++ b/test/ash_credo/introspection/aliases_test.exs
@@ -15,6 +15,15 @@ defmodule AshCredo.Introspection.AliasesTest do
       assert Aliases.module_aliases(quoted("alias Ash.Query")) == [{[:Query], [:Ash, :Query]}]
     end
 
+    test "collects require ... as: from a module body" do
+      assert Aliases.module_aliases(quoted("require Ash.Query, as: Query")) ==
+               [{[:Query], [:Ash, :Query]}]
+    end
+
+    test "ignores require without as:" do
+      assert Aliases.module_aliases(quoted("require Ash.Query")) == []
+    end
+
     test "returns [] for a non-defmodule AST" do
       assert Aliases.module_aliases({:def, [], []}) == []
       assert Aliases.module_aliases(:not_an_ast) == []
@@ -141,6 +150,16 @@ defmodule AshCredo.Introspection.AliasesTest do
     test "handles an empty target segment list" do
       ast = {:alias, [], [{:__aliases__, [], []}]}
       assert Aliases.alias_entries(ast) == [{[nil], []}]
+    end
+
+    test "maps require ... as: like the equivalent alias" do
+      ast = Code.string_to_quoted!("require Ash.Query, as: Query")
+      assert Aliases.alias_entries(ast) == [{[:Query], [:Ash, :Query]}]
+    end
+
+    test "returns [] for require without as: and for non-alias as: values" do
+      assert Aliases.alias_entries(Code.string_to_quoted!("require Ash.Query")) == []
+      assert Aliases.alias_entries(Code.string_to_quoted!("require Ash.Query, warn: false")) == []
     end
 
     test "returns [] for anything that is not an alias node" do

--- a/test/ash_credo/introspection_test.exs
+++ b/test/ash_credo/introspection_test.exs
@@ -274,6 +274,37 @@ defmodule AshCredo.IntrospectionTest do
       assert [_] = calls
     end
 
+    test "finds calls aliased via require ... as:" do
+      # `require Ash.Query, as: Query` sets up the alias exactly like
+      # `alias Ash.Query, as: Query` - the idiomatic one-liner since
+      # Ash.Query.filter/2 is a macro and needs the require anyway.
+      source = """
+      defmodule MyApp.Accounts do
+        require Ash.Query, as: Query
+
+        def adults(q) do
+          Query.filter(q, age >= 18)
+        end
+      end
+      """
+
+      assert [{_ast, [:Ash, :Query]}] = AshCallScanner.calls_with_module(source_file(source))
+    end
+
+    test "a bare require does not create an alias" do
+      source = """
+      defmodule MyApp.Accounts do
+        require Ash.Query
+
+        def adults(q) do
+          Query.filter(q, age >= 18)
+        end
+      end
+      """
+
+      assert [] = AshCallScanner.calls_with_module(source_file(source))
+    end
+
     test "respects alias order at the call site" do
       source = """
       defmodule MyApp.Accounts do


### PR DESCRIPTION
## Motivation

`require Mod, as: Alias` sets up the alias exactly like `alias Mod, as: Alias` - a documented `require` option and the idiomatic one-liner for macro modules like `Ash.Query`, where the `require` is mandatory for `filter/2` anyway. The alias capture points only matched `alias` nodes, so calls through such aliases (`Query.filter(q, ...)`) were invisible to every alias-resolving consumer: `UseCodeInterface`, `ActorOnCallOptions`, `RaisingCall`, `AuthorizeFalse`, and `UnknownAction` all silently skipped those call sites.

## Changes

- Add an `alias_entries/1` clause for `require ... as:`; a bare `require` yields no entry since it creates no alias
- Register `require` nodes at both traversal capture points (`AshCallScanner.enter_node/3` and `LexicalScopeWalker`'s alias clause, with the matching `leave`) and in `Aliases.module_aliases/2`
