### PR TITLE
fix: check accept lists on soft destroy actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ If you have any compiled-introspection checks enabled, run `mix compile` before 
 | `SensitiveAttributeExposed` | Warning | High | No | Flags sensitive attributes (password, token, secret, ...) not marked `sensitive?: true` |
 | `SensitiveFieldInAccept` | Warning | High | No | Flags privilege-escalation fields (`is_admin`, `permissions`, ...) in `accept` lists |
 | `UnknownAction` | Warning | High | No | Flags `Ash.*` calls referencing actions that do not exist on the resolved resource, with a fuzzy `Did you mean` hint. **Requires compiled project.** |
-| `WildcardAcceptOnAction` | Warning | High | No | Detects `accept :*` on `create`/`update` actions (mass-assignment risk) |
+| `WildcardAcceptOnAction` | Warning | High | No | Detects `accept :*` on `create`/`update`/soft `destroy` actions (mass-assignment risk) |
 | `AnonymousFunctionInDsl` | Refactor | Normal | No | Flags `fn`/`&` captures passed to `change`/`validate`/`prepare`/`calculate` - anonymous functions can never be atomic (changes/validations) or supply an expression (calculations); extract them into callback modules |
 | `DirectiveInFunctionBody` | Refactor | Normal | No | Flags `require`/`import`/`alias` of configured modules (default `Ash.Query`, `Ash.Expr`) declared inside function bodies instead of at module level |
 | `LargeResource` | Refactor | Low | No | Flags resource files exceeding 400 lines |

--- a/lib/ash_credo/check/warning/sensitive_field_in_accept.ex
+++ b/lib/ash_credo/check/warning/sensitive_field_in_accept.ex
@@ -19,6 +19,10 @@ defmodule AshCredo.Check.Warning.SensitiveFieldInAccept do
             change set_attribute(:role, :user)
           end
 
+      Create, update, and soft destroy actions are checked. Hard destroy
+      actions are not: Ash resets their `accept` to `[]` at compile time,
+      so an accept list there takes no input.
+
       Test directories are excluded by default, since test factories and seeds
       often accept these fields on purpose. Override `excluded_paths` to scope
       the check differently.
@@ -38,7 +42,9 @@ defmodule AshCredo.Check.Warning.SensitiveFieldInAccept do
   alias AshCredo.{Introspection, PathFilter}
   alias AshCredo.Introspection.ResourceContext
 
-  @writable_action_types ~w(create update)a
+  # For the `defaults` list only: `defaults [destroy: :*]` raises a DslError
+  # in Ash, so keyword defaults entries can never carry a destroy accept.
+  @default_writable_action_types ~w(create update)a
 
   @impl true
   def run(%SourceFile{} = source_file, params) do
@@ -69,7 +75,7 @@ defmodule AshCredo.Check.Warning.SensitiveFieldInAccept do
   defp check_actions(actions_ast, dangerous, issue_meta) do
     action_issues =
       actions_ast
-      |> Introspection.action_entities(@writable_action_types)
+      |> Introspection.accepting_action_entities()
       |> Enum.flat_map(&find_dangerous_accepts(&1, dangerous, issue_meta))
 
     defaults_issues = find_dangerous_defaults(actions_ast, dangerous, issue_meta)
@@ -113,7 +119,8 @@ defmodule AshCredo.Check.Warning.SensitiveFieldInAccept do
     defaults_ast
     |> Introspection.default_action_entries()
     |> Enum.flat_map(fn
-      {type, default_fields} when type in @writable_action_types and is_list(default_fields) ->
+      {type, default_fields}
+      when type in @default_writable_action_types and is_list(default_fields) ->
         default_fields
         |> Enum.filter(&dangerous_field?(&1, dangerous))
         |> Enum.map(fn field ->

--- a/lib/ash_credo/check/warning/wildcard_accept_on_action.ex
+++ b/lib/ash_credo/check/warning/wildcard_accept_on_action.ex
@@ -8,13 +8,18 @@ defmodule AshCredo.Check.Warning.WildcardAcceptOnAction do
     ],
     explanations: [
       check: """
-      Using `accept :*` on create or update actions accepts all public
-      attributes, which is a mass-assignment vulnerability. Explicitly
-      list the accepted attributes instead.
+      Using `accept :*` on create, update, or soft destroy actions accepts
+      all public attributes, which is a mass-assignment vulnerability.
+      Explicitly list the accepted attributes instead.
 
           create :create do
             accept [:title, :body]
           end
+
+      Hard destroy actions are not checked: Ash resets their `accept` to
+      `[]` at compile time, so an accept list there takes no input. Soft
+      destroys are updates under the hood and honor `accept` like any
+      other writable action.
 
       Test directories are excluded by default, since test factories and seeds
       often use `accept :*` on purpose. Override `excluded_paths` to scope the
@@ -31,7 +36,9 @@ defmodule AshCredo.Check.Warning.WildcardAcceptOnAction do
   alias AshCredo.{Introspection, PathFilter}
   alias AshCredo.Orchestration
 
-  @writable_action_types ~w(create update)a
+  # For the `defaults` list only: `defaults [destroy: :*]` raises a DslError
+  # in Ash, so keyword defaults entries can never carry a destroy accept.
+  @default_writable_action_types ~w(create update)a
 
   @impl true
   def run(%SourceFile{} = source_file, params) do
@@ -56,7 +63,7 @@ defmodule AshCredo.Check.Warning.WildcardAcceptOnAction do
     source_file = IssueMeta.source_file(issue_meta)
 
     actions_ast
-    |> Introspection.action_entities(@writable_action_types)
+    |> Introspection.accepting_action_entities()
     |> Enum.flat_map(fn {type, _meta, _} = entity ->
       entity
       |> Introspection.option_occurrences(:accept)
@@ -102,7 +109,7 @@ defmodule AshCredo.Check.Warning.WildcardAcceptOnAction do
   end
 
   defp wildcard_default_actions({:defaults, meta, _} = defaults_ast) do
-    @writable_action_types
+    @default_writable_action_types
     |> Enum.filter(&Introspection.default_action_has_value?(defaults_ast, &1, :*))
     |> Enum.map(&{&1, meta})
   end

--- a/lib/ash_credo/introspection.ex
+++ b/lib/ash_credo/introspection.ex
@@ -246,6 +246,23 @@ defmodule AshCredo.Introspection do
     Enum.flat_map(action_types, &filter_entities(entries, &1))
   end
 
+  @doc """
+  Returns the explicit action entities whose `accept` option is honored at
+  runtime: creates, updates, and soft destroys. Ash's `DefaultAccept`
+  transformer resets `accept` to `[]` on hard destroys (`soft?` false), so
+  an accept list there is dead configuration rather than an input surface.
+  """
+  def accepting_action_entities(actions_ast) do
+    action_entities(actions_ast, ~w(create update)a) ++
+      soft_destroy_entities(actions_ast)
+  end
+
+  defp soft_destroy_entities(actions_ast) do
+    actions_ast
+    |> action_entities([:destroy])
+    |> Enum.filter(&entity_has_opt?(&1, :soft?, true))
+  end
+
   @doc "Returns the line number of a section's opening."
   def section_line({_name, meta, _}), do: meta[:line]
   def section_line(_), do: nil

--- a/test/ash_credo/check/warning/sensitive_field_in_accept_test.exs
+++ b/test/ash_credo/check/warning/sensitive_field_in_accept_test.exs
@@ -73,6 +73,41 @@ defmodule AshCredo.Check.Warning.SensitiveFieldInAcceptTest do
     assert issue.message =~ "is_admin"
   end
 
+  test "reports issue for dangerous fields accepted by a soft destroy" do
+    source = """
+    defmodule MyApp.User do
+      use Ash.Resource, domain: MyApp.Accounts
+
+      actions do
+        destroy :archive do
+          soft? true
+          accept [:archived_reason, :is_admin]
+        end
+      end
+    end
+    """
+
+    assert [issue] = run_check(SensitiveFieldInAccept, source)
+    assert issue.message =~ "is_admin"
+    assert issue.line_no == 7
+  end
+
+  test "no issue for dangerous fields on a hard destroy (Ash resets its accept)" do
+    source = """
+    defmodule MyApp.User do
+      use Ash.Resource, domain: MyApp.Accounts
+
+      actions do
+        destroy :purge do
+          accept [:is_admin]
+        end
+      end
+    end
+    """
+
+    assert [] = run_check(SensitiveFieldInAccept, source)
+  end
+
   test "reports issue for dangerous fields in defaults" do
     source = """
     defmodule MyApp.User do

--- a/test/ash_credo/check/warning/wildcard_accept_on_action_test.exs
+++ b/test/ash_credo/check/warning/wildcard_accept_on_action_test.exs
@@ -40,6 +40,57 @@ defmodule AshCredo.Check.Warning.WildcardAcceptOnActionTest do
     assert issue.column != nil
   end
 
+  test "reports issue for accept :* on a soft destroy" do
+    source = """
+    defmodule MyApp.Post do
+      use Ash.Resource, domain: MyApp.Blog
+
+      actions do
+        destroy :archive do
+          soft? true
+          accept :*
+        end
+      end
+    end
+    """
+
+    assert [issue] = run_check(WildcardAcceptOnAction, source)
+    assert issue.message =~ "`archive`"
+    assert issue.line_no == 7
+  end
+
+  test "reports issue for accept :* on an inline soft?: true destroy" do
+    source = """
+    defmodule MyApp.Post do
+      use Ash.Resource, domain: MyApp.Blog
+
+      actions do
+        destroy :archive, soft?: true, accept: :*
+      end
+    end
+    """
+
+    assert [issue] = run_check(WildcardAcceptOnAction, source)
+    assert issue.message =~ "`archive`"
+    assert issue.line_no == 5
+  end
+
+  test "no issue for accept :* on a hard destroy (Ash resets its accept)" do
+    source = """
+    defmodule MyApp.Post do
+      use Ash.Resource, domain: MyApp.Blog
+
+      actions do
+        destroy :purge do
+          accept :*
+        end
+      end
+    end
+    """
+
+    assert [] = run_check(WildcardAcceptOnAction, source)
+  end
+
   test "no issue for explicit accept list" do
     source = """
     defmodule MyApp.Post do

--- a/test/ash_credo/introspection_test.exs
+++ b/test/ash_credo/introspection_test.exs
@@ -846,6 +846,35 @@ defmodule AshCredo.IntrospectionTest do
     end
   end
 
+  describe "accepting_action_entities/1" do
+    test "returns creates, updates, and soft destroys but not hard destroys" do
+      # Ash's DefaultAccept transformer resets `accept` to [] on destroys
+      # unless `soft?` is true, so only soft destroys have a live accept.
+      source = """
+      defmodule Foo do
+        use Ash.Resource
+
+        actions do
+          read :read
+          create :create
+          update :update
+          destroy :hard_destroy
+          destroy :archive do
+            soft? true
+          end
+          destroy :archive_inline, soft?: true
+        end
+      end
+      """
+
+      actions = first_resource_section(source, :actions)
+      entities = Introspection.accepting_action_entities(actions)
+
+      names = Enum.map(entities, &Introspection.entity_name/1)
+      assert names == [:create, :update, :archive, :archive_inline]
+    end
+  end
+
   describe "option_occurrences/2" do
     test "returns normalized inline and body option values" do
       ast =


### PR DESCRIPTION
## Motivation

Destroy actions take `accept` lists too, but `WildcardAcceptOnAction` and `SensitiveFieldInAccept` only scanned create and update entities, so `accept :*` or a privilege-escalation field on a destroy went unflagged. The runtime surface is narrower than it looks: Ash's `DefaultAccept` transformer resets `accept` to `[]` on hard destroys at compile time, so only soft destroys (which are updates under the hood) actually take that input. Verified against a compiled resource: a soft destroy with `accept [:is_admin]` mass-assigns `is_admin` through the destroy input, while the same accept on a hard destroy is dead configuration.

## Changes

- Add `Introspection.accepting_action_entities/1` returning the action entities whose `accept` is honored at runtime: creates, updates, and destroys with `soft? true`
- Use it in `WildcardAcceptOnAction` and `SensitiveFieldInAccept` in place of the hard-coded create/update entity scan
- Keep the `defaults` keyword-list paths create/update-only, since `defaults [destroy: :*]` raises a DslError in Ash
- Document the soft/hard destroy distinction in both check explanations and the README check table
