### PR TITLE
fix: flag call-time actor on aggregate functions

### DIFF
--- a/lib/ash_credo/check/warning/actor_on_call_options.ex
+++ b/lib/ash_credo/check/warning/actor_on_call_options.ex
@@ -46,7 +46,7 @@ defmodule AshCredo.Check.Warning.ActorOnCallOptions do
   # required argument that happens to be a keyword-shaped list - e.g. the
   # aggregate specs in `Ash.aggregate(query, [{:actor, :count}])` - is
   # never mistaken for the opts.
-  @subject_opts_funs ~w(read read! read_one read_one! first first! stream! count count! exists exists? create create! update update! destroy destroy! run_action run_action!)a
+  @subject_opts_funs ~w(read read! read_one read_one! read_first read_first! first first! stream! count count! exists exists? create create! update update! destroy destroy! run_action run_action! data_layer_query data_layer_query!)a
   @aggregate_funs ~w(aggregate aggregate! sum sum! avg avg! min min! max max! list list!)a
   @bulk_funs ~w(bulk_update bulk_update! bulk_destroy bulk_destroy!)a
   @action_funs @subject_opts_funs ++ @aggregate_funs ++ @bulk_funs

--- a/lib/ash_credo/check/warning/actor_on_call_options.ex
+++ b/lib/ash_credo/check/warning/actor_on_call_options.ex
@@ -39,10 +39,17 @@ defmodule AshCredo.Check.Warning.ActorOnCallOptions do
   alias AshCredo.Introspection.AshCallScanner
 
   # Ash action-invocation functions taking a query/changeset/input subject
-  # plus an options list. The aggregate family (`Ash.sum/3` and friends)
-  # belongs here too: their opts merge Ash's global options, so they take
-  # `actor:`/`tenant:` at call time just like `Ash.read!/2`.
-  @action_funs ~w(read read! read_one read_one! first first! stream! count count! exists exists? create create! update update! destroy destroy! run_action run_action! aggregate aggregate! sum sum! avg avg! min min! max max! list list!)a
+  # plus an options list. The aggregate and bulk families belong here too:
+  # their opts merge Ash's global options, so they take `actor:`/`tenant:`
+  # at call time just like `Ash.read!/2`. They are grouped by how many
+  # arguments precede the optional trailing opts (subject included), so a
+  # required argument that happens to be a keyword-shaped list - e.g. the
+  # aggregate specs in `Ash.aggregate(query, [{:actor, :count}])` - is
+  # never mistaken for the opts.
+  @subject_opts_funs ~w(read read! read_one read_one! first first! stream! count count! exists exists? create create! update update! destroy destroy! run_action run_action!)a
+  @aggregate_funs ~w(aggregate aggregate! sum sum! avg avg! min min! max max! list list!)a
+  @bulk_funs ~w(bulk_update bulk_update! bulk_destroy bulk_destroy!)a
+  @action_funs @subject_opts_funs ++ @aggregate_funs ++ @bulk_funs
 
   # Builders that establish the action context; actor/tenant belong in their
   # options.
@@ -67,7 +74,7 @@ defmodule AshCredo.Check.Warning.ActorOnCallOptions do
 
     with true <- fun_name in @action_funs,
          [subject | _] <- call_info.args,
-         keys when keys != [] <- flagged_keys(call_info.args),
+         keys when keys != [] <- flagged_keys(call_info.args, required_args(fun_name)),
          true <- builder_subject?(subject, call_info, MapSet.new()) do
       Enum.map(keys, &flagged_key_issue(&1, fun_name, meta, issue_meta))
     else
@@ -77,15 +84,27 @@ defmodule AshCredo.Check.Warning.ActorOnCallOptions do
 
   defp check_call(_call_info, _issue_meta), do: []
 
-  # Walks to the final argument (the options of an Ash call) in one pass
-  # with no intermediate list - the descent is what `List.last/1` does
-  # internally, with the keyword-list shape check fused in.
-  defp flagged_keys([opts]) when is_list(opts) do
+  # Number of arguments (subject included, after pipe normalization) that
+  # precede the optional trailing opts. Only a trailing keyword list beyond
+  # that count is the options of the call.
+  defp required_args(fun_name) when fun_name in @aggregate_funs, do: 2
+  defp required_args(fun_name) when fun_name in @bulk_funs, do: 3
+  defp required_args(_fun_name), do: 1
+
+  # Descends past the required arguments, then walks to the final argument
+  # in one pass with no intermediate list, with the keyword-list shape
+  # check fused in. A call with no argument beyond the required ones has
+  # no options to scan.
+  defp flagged_keys([_arg | rest], required_args) when required_args > 0 do
+    flagged_keys(rest, required_args - 1)
+  end
+
+  defp flagged_keys([opts], 0) when is_list(opts) do
     for {key, _value} <- opts, is_atom(key), key in @flagged_keys, do: key
   end
 
-  defp flagged_keys([_arg | rest]), do: flagged_keys(rest)
-  defp flagged_keys(_args), do: []
+  defp flagged_keys([_arg | rest], 0), do: flagged_keys(rest, 0)
+  defp flagged_keys(_args, _required_args), do: []
 
   # True when the call subject visibly went through a `for_*` builder:
   # directly, anywhere in a pipe chain, or via simple variable bindings

--- a/lib/ash_credo/check/warning/actor_on_call_options.ex
+++ b/lib/ash_credo/check/warning/actor_on_call_options.ex
@@ -39,8 +39,10 @@ defmodule AshCredo.Check.Warning.ActorOnCallOptions do
   alias AshCredo.Introspection.AshCallScanner
 
   # Ash action-invocation functions taking a query/changeset/input subject
-  # plus an options list.
-  @action_funs ~w(read read! read_one read_one! first first! stream! count count! exists exists? create create! update update! destroy destroy! run_action run_action!)a
+  # plus an options list. The aggregate family (`Ash.sum/3` and friends)
+  # belongs here too: their opts merge Ash's global options, so they take
+  # `actor:`/`tenant:` at call time just like `Ash.read!/2`.
+  @action_funs ~w(read read! read_one read_one! first first! stream! count count! exists exists? create create! update update! destroy destroy! run_action run_action! aggregate aggregate! sum sum! avg avg! min min! max max! list list!)a
 
   # Builders that establish the action context; actor/tenant belong in their
   # options.

--- a/test/ash_credo/check/warning/actor_on_call_options_test.exs
+++ b/test/ash_credo/check/warning/actor_on_call_options_test.exs
@@ -140,6 +140,38 @@ defmodule AshCredo.Check.Warning.ActorOnCallOptionsTest do
     assert [] = run_check(ActorOnCallOptions, source)
   end
 
+  test "reports actor: on read_first after a for_read pipe" do
+    source = """
+    defmodule MyApp.Posts do
+      def newest(current_user) do
+        MyApp.Post
+        |> Ash.Query.for_read(:read, %{})
+        |> Ash.read_first(actor: current_user)
+      end
+    end
+    """
+
+    assert [issue] = run_check(ActorOnCallOptions, source)
+    assert issue.trigger == "actor"
+    assert issue.message =~ "Ash.read_first"
+  end
+
+  test "reports actor: on data_layer_query (delegates to read)" do
+    source = """
+    defmodule MyApp.Posts do
+      def raw_query(current_user) do
+        MyApp.Post
+        |> Ash.Query.for_read(:read, %{})
+        |> Ash.data_layer_query(actor: current_user)
+      end
+    end
+    """
+
+    assert [issue] = run_check(ActorOnCallOptions, source)
+    assert issue.trigger == "actor"
+    assert issue.message =~ "Ash.data_layer_query"
+  end
+
   test "reports actor: on bulk_update after a for_read pipe" do
     source = """
     defmodule MyApp.Posts do

--- a/test/ash_credo/check/warning/actor_on_call_options_test.exs
+++ b/test/ash_credo/check/warning/actor_on_call_options_test.exs
@@ -81,6 +81,49 @@ defmodule AshCredo.Check.Warning.ActorOnCallOptionsTest do
     assert issue.message =~ "Ash.create!"
   end
 
+  test "reports actor: on an aggregate call after a for_read pipe" do
+    source = """
+    defmodule MyApp.Posts do
+      def total_likes(current_user) do
+        MyApp.Post
+        |> Ash.Query.for_read(:read, %{})
+        |> Ash.sum(:likes, actor: current_user)
+      end
+    end
+    """
+
+    assert [issue] = run_check(ActorOnCallOptions, source)
+    assert issue.trigger == "actor"
+    assert issue.message =~ "Ash.sum"
+  end
+
+  test "reports tenant: on Ash.aggregate! when the query is bound to a variable" do
+    source = """
+    defmodule MyApp.Posts do
+      def stats(tenant) do
+        query = Ash.Query.for_read(MyApp.Post, :read, %{})
+        Ash.aggregate!(query, {:count, :count}, tenant: tenant)
+      end
+    end
+    """
+
+    assert [issue] = run_check(ActorOnCallOptions, source)
+    assert issue.trigger == "tenant"
+    assert issue.message =~ "Ash.aggregate!"
+  end
+
+  test "no issue for an aggregate without a pre-built subject (sanctioned form)" do
+    source = """
+    defmodule MyApp.Posts do
+      def total_likes(current_user) do
+        Ash.sum(MyApp.Post, :likes, actor: current_user)
+      end
+    end
+    """
+
+    assert [] = run_check(ActorOnCallOptions, source)
+  end
+
   test "resolves aliased builder modules" do
     source = """
     defmodule MyApp.Posts do

--- a/test/ash_credo/check/warning/actor_on_call_options_test.exs
+++ b/test/ash_credo/check/warning/actor_on_call_options_test.exs
@@ -124,6 +124,69 @@ defmodule AshCredo.Check.Warning.ActorOnCallOptionsTest do
     assert [] = run_check(ActorOnCallOptions, source)
   end
 
+  test "no issue for a 2-arg aggregate whose spec list names an :actor aggregate" do
+    # Without a trailing opts argument, the aggregate-spec list is a
+    # required argument, not the options of the call.
+    source = """
+    defmodule MyApp.Posts do
+      def stats do
+        MyApp.Post
+        |> Ash.Query.for_read(:read, %{})
+        |> Ash.aggregate([{:actor, :count}])
+      end
+    end
+    """
+
+    assert [] = run_check(ActorOnCallOptions, source)
+  end
+
+  test "reports actor: on bulk_update after a for_read pipe" do
+    source = """
+    defmodule MyApp.Posts do
+      def archive_all(current_user) do
+        MyApp.Post
+        |> Ash.Query.for_read(:read, %{})
+        |> Ash.bulk_update(:archive, %{archived: true}, actor: current_user)
+      end
+    end
+    """
+
+    assert [issue] = run_check(ActorOnCallOptions, source)
+    assert issue.trigger == "actor"
+    assert issue.message =~ "Ash.bulk_update"
+  end
+
+  test "reports tenant: on bulk_destroy! when the query is bound to a variable" do
+    source = """
+    defmodule MyApp.Posts do
+      def purge(tenant) do
+        query = Ash.Query.for_read(MyApp.Post, :read, %{})
+        Ash.bulk_destroy!(query, :destroy, %{}, tenant: tenant)
+      end
+    end
+    """
+
+    assert [issue] = run_check(ActorOnCallOptions, source)
+    assert issue.trigger == "tenant"
+    assert issue.message =~ "Ash.bulk_destroy!"
+  end
+
+  test "no issue for a bulk_update whose keyword input names an :actor field" do
+    # Without a trailing opts argument, the input keyword list is a
+    # required argument, not the options of the call.
+    source = """
+    defmodule MyApp.Posts do
+      def reassign(new_actor) do
+        MyApp.Post
+        |> Ash.Query.for_read(:read, %{})
+        |> Ash.bulk_update(:reassign, [actor: new_actor])
+      end
+    end
+    """
+
+    assert [] = run_check(ActorOnCallOptions, source)
+  end
+
   test "resolves aliased builder modules" do
     source = """
     defmodule MyApp.Posts do


### PR DESCRIPTION
## Motivation

`ActorOnCallOptions` flags `actor:`/`tenant:` passed at call time when the subject visibly went through a `for_*` builder. Several Ash entry points were missing from its action function list, so calls like `query |> Ash.sum(:likes, actor: user)` went unflagged even though these functions merge Ash's global options and accept `actor:`/`tenant:` at call time exactly like `Ash.read!/2`: the aggregate family (`Ash.aggregate/sum/avg/min/max/list` and bangs), the bulk family (`Ash.bulk_update`/`Ash.bulk_destroy` and bangs), `Ash.read_first`/`Ash.read_first!` (validated through the read-one opts schema), and `Ash.data_layer_query`/`Ash.data_layer_query!` (which delegate directly to `read`).

Covering functions with required arguments between the subject and the options also exposed a latent trap in the opts scan, which read whatever the final argument was as the options: in a 2-arg `Ash.aggregate(query, [{:actor, :count}])` call the aggregate-spec list is the final argument, and a spec literally named `:actor` would have been flagged. The scan is now positional.

## Changes

- Add the aggregate family, the bulk family, `read_first`/`read_first!`, and `data_layer_query`/`data_layer_query!` to the action functions checked by `ActorOnCallOptions`
- Group the action functions by how many required arguments precede the optional trailing opts, and descend past those before scanning, so a keyword-shaped required argument (aggregate specs, bulk input) is never mistaken for the options of the call
- `Ash.get`/`Ash.get!` stay uncovered on purpose: they take a resource module, never a built query, so no builder subject can reach them
