### PR TITLE
fix: emit the missing-table hint exactly once under concurrent access

### DIFF
--- a/lib/ash_credo/cache.ex
+++ b/lib/ash_credo/cache.ex
@@ -187,13 +187,27 @@ defmodule AshCredo.Cache do
 
   # One hint per VM, tracked outside the (missing) table: a no-plugin run
   # would otherwise repeat the message once per accessor call per file.
-  # Concurrent first callers may rarely both emit; best-effort is fine here.
+  # The flag check and set are not atomic on their own, and Credo dispatches
+  # its first wave of check tasks simultaneously - many processes can pass
+  # the flag check before any of them sets it. Serialize the first emission
+  # through a :global lock and re-check the flag inside the critical section;
+  # after the flag is set, callers take the lock-free fast path.
   defp warn_missing_table do
-    if not :persistent_term.get(@hint_emitted_key, false) do
+    if not hint_emitted?() do
+      :global.trans({@hint_emitted_key, self()}, &emit_hint_if_first/0)
+    end
+
+    :ok
+  end
+
+  defp emit_hint_if_first do
+    if not hint_emitted?() do
       :persistent_term.put(@hint_emitted_key, true)
       IO.puts(:stderr, @missing_table_hint)
     end
   end
+
+  defp hint_emitted?, do: :persistent_term.get(@hint_emitted_key, false)
 
   # ── GenServer callbacks ──
 

--- a/test/ash_credo/cache_test.exs
+++ b/test/ash_credo/cache_test.exs
@@ -182,6 +182,44 @@ defmodule AshCredo.CacheTest do
                Cache.member?(:k)
              end) == ""
     end
+
+    test "concurrent first accesses emit the hint exactly once" do
+      Cache.reset_missing_table_hint()
+
+      # Mimics Credo's start-of-run burst: many check tasks hit a missing
+      # table at the same instant. Release all callers through a barrier so
+      # they race the first emission; the hint must still appear only once.
+      output =
+        capture_io(:stderr, fn ->
+          parent = self()
+
+          pids =
+            for _ <- 1..50 do
+              spawn_link(fn ->
+                receive do
+                  :go -> Cache.get(:k)
+                end
+
+                send(parent, {:done, self()})
+              end)
+            end
+
+          Enum.each(pids, &send(&1, :go))
+
+          Enum.each(pids, fn pid ->
+            assert_receive {:done, ^pid}, 5_000
+          end)
+        end)
+
+      occurrences =
+        output
+        |> String.split("ash_credo plugin not registered")
+        |> length()
+        |> Kernel.-(1)
+
+      assert occurrences == 1,
+             "expected exactly one missing-table hint, got #{occurrences}:\n#{output}"
+    end
   end
 
   describe "missing-table hint with the table present" do


### PR DESCRIPTION
## Motivation

In a run without the plugin registered, every cache accessor degrades gracefully and emits a one-time stderr hint suggesting the plugin registration. The hint's check-then-set on `:persistent_term` is not atomic, and Credo dispatches its first wave of check tasks simultaneously, so many workers pass the flag check before any of them sets it. In practice the "one-time" hint prints up to 8 times per run.

## Changes

- Serialize the first emission in `AshCredo.Cache.warn_missing_table/0` through a `:global` lock with a re-check of the flag inside the critical section; once the flag is set, callers keep the lock-free fast path
- Add a barrier-released concurrent regression test asserting the hint appears exactly once across 50 simultaneous first accesses
