### PR TITLE
test: assert a user-enabled compiled check delivers issues end-to-end

### DIFF
--- a/test/integration/fixtures/plugin_smoke/.credo.exs
+++ b/test/integration/fixtures/plugin_smoke/.credo.exs
@@ -11,7 +11,14 @@
       strict: true,
       parse_timeout: 5000,
       color: false,
-      checks: %{}
+      checks: %{
+        extra: [
+          # Default-off in the plugin's embedded config; enabled here the way
+          # a user would, so the integration test can assert that a
+          # user-enabled compiled check delivers issues end-to-end.
+          {AshCredo.Check.Design.MissingCodeInterface, []}
+        ]
+      }
     }
   ]
 }

--- a/test/integration/fixtures/plugin_smoke/lib/post.ex
+++ b/test/integration/fixtures/plugin_smoke/lib/post.ex
@@ -1,0 +1,15 @@
+defmodule AshCredoFixtures.Blog.Post do
+  @moduledoc """
+  Fixture exercised by `AshCredo.PluginIntegrationTest` for the compiled
+  introspection path. The body here is deliberately minimal: the real
+  definition lives in `test/support/fixtures/ash_fixtures.ex` and is compiled
+  into the test VM. `MissingCodeInterface` can only learn about the
+  interface-less actions (e.g. `:draft`) from `Ash.Resource.Info` on that
+  compiled module, so any issue it reports proves compiled-introspection
+  results survive the whole Credo pipeline (regression guard for issue #187).
+  """
+
+  use Ash.Resource,
+    domain: AshCredoFixtures.Blog,
+    validate_domain_inclusion?: false
+end

--- a/test/integration/plugin_test.exs
+++ b/test/integration/plugin_test.exs
@@ -5,8 +5,10 @@ defmodule AshCredo.PluginIntegrationTest do
   Boots Credo programmatically against `test/integration/fixtures/plugin_smoke/`,
   pointing at that fixture's own `.credo.exs` (which uses `{AshCredo, []}`).
   Verifies the plugin's wiring as a whole: `register_default_config` is honored,
-  the embedded check on/off toggles in `lib/ash_credo.ex` are applied, and the
-  enabled checks actually run end-to-end.
+  the embedded check on/off toggles in `lib/ash_credo.ex` are applied, the
+  enabled checks actually run end-to-end, and a user-enabled compiled check
+  delivers issues built from `Ash.Resource.Info` introspection through the
+  whole pipeline (regression guard for issue #187).
 
   This complements the per-check unit tests under `test/ash_credo/check/`,
   which all bypass `Credo.Plugin` orchestration by calling
@@ -26,7 +28,7 @@ defmodule AshCredo.PluginIntegrationTest do
     :ok
   end
 
-  test "plugin registers, default-on checks fire, default-off checks don't" do
+  test "plugin registers, default-on checks fire, default-off checks don't, compiled checks deliver" do
     # Credo writes per-issue lines via a globally-registered GenServer
     # (`Credo.CLI.Output.Shell`) whose group leader was set at app boot, so
     # `ExUnit.CaptureIO` cannot intercept them. The shell exposes
@@ -79,6 +81,34 @@ defmodule AshCredo.PluginIntegrationTest do
            `UseCodeInterface` is `false` in the plugin's embedded config and
            must not fire by default.
            Triggered checks: #{inspect(MapSet.to_list(triggered))}
+           """
+
+    # User-enabled compiled check: the fixture's `.credo.exs` enables
+    # `MissingCodeInterface` (default-off in the plugin's embedded config) via
+    # `checks: %{extra: [...]}`, the way a user would. The fixture's
+    # `lib/post.ex` has a deliberately minimal body - the interface-less
+    # actions the check reports on (e.g. `:draft`) exist only on the compiled
+    # `AshCredoFixtures.Blog.Post` from `test/support/fixtures/`. Issues
+    # naming them prove that compiled-introspection results survive the whole
+    # Credo pipeline (regression guard for issue #187, which alleged they are
+    # silently dropped).
+    code_interface_issues =
+      Enum.filter(issues, &(&1.check == AshCredo.Check.Design.MissingCodeInterface))
+
+    assert code_interface_issues != [],
+           """
+           Expected the user-enabled compiled check `MissingCodeInterface` to
+           deliver issues end-to-end through the plugin pipeline.
+           Triggered checks: #{inspect(MapSet.to_list(triggered))}
+           Issues: #{inspect(Enum.map(issues, &{&1.check, &1.message}))}
+           """
+
+    assert Enum.any?(code_interface_issues, &(&1.message =~ ":draft")),
+           """
+           Expected an issue for action `:draft`, which is visible only via
+           `Ash.Resource.Info` on the compiled fixture module - not in the
+           analyzed source file.
+           Messages: #{inspect(Enum.map(code_interface_issues, & &1.message))}
            """
 
     # `AshCredo.ClearCacheTask` is appended to the `:halt_execution` pipeline


### PR DESCRIPTION
## Motivation

Issue #187 alleges that compiled-introspection checks silently no-op through the normal `mix credo` pipeline while direct `run/2` calls work. The report is not reproducible, but the plugin integration test could not disprove that failure class either: it only asserts that a default-on AST check fires and a default-off check stays quiet. No test proves that a user-enabled compiled check delivers issues built from `Ash.Resource.Info` introspection through the full Credo plugin pipeline. This locks that behavior in.

## Changes

- Enable `MissingCodeInterface` (default-off in the plugin's embedded config) in the smoke fixture's `.credo.exs` via `checks: %{extra: [...]}`, the way a user would
- Add `lib/post.ex` to the fixture with a deliberately minimal `AshCredoFixtures.Blog.Post` body; the interface-less actions the check reports on exist only on the compiled test/support module
- Assert the check delivers issues end-to-end, including one naming `:draft`, which is visible only via compiled introspection and not in the analyzed source AST
