### PR TITLE
fix: compile before running the lint alias

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -31,6 +31,7 @@ defmodule AshCredo.MixProject do
   defp aliases do
     [
       lint: [
+        "compile",
         "format --check-formatted",
         "credo",
         "lint.no_emdash",


### PR DESCRIPTION
## Motivation

Running `mix lint` after editing sources could fail locally while CI stayed green. Tasks invoked through a mix alias skip the implicit compile that a direct `mix <task>` invocation performs, so `lint.credence` - which validates the analyzed sources against the loaded beams - saw fresh sources paired with stale `_build` beams and reported phantom undefined-function issues. CI never hits this because every job compiles from scratch before linting.

## Changes

- Prepend `compile` to the `lint` alias so every step runs against beams built from the sources being linted
