### PR TITLE
test: cover the UseCodeInterface long-tail suggestion families

### DIFF
--- a/test/ash_credo/check/refactor/use_code_interface_test.exs
+++ b/test/ash_credo/check/refactor/use_code_interface_test.exs
@@ -415,6 +415,115 @@ defmodule AshCredo.Check.Refactor.UseCodeInterfaceTest do
     end
   end
 
+  # ── Long-tail suggestion families ──────────────────────────────────────────
+  #
+  # These exercise the message variants that only appear with specific
+  # interface configurations on `AshCredoFixtures.Accounts.Account`,
+  # `AshCredoFixtures.Blog.Article`, and `AshCredoFixtures.Standalone`.
+
+  describe "suggestion long tail" do
+    test "Ash.get! with a map lookup matches a get_by_identity interface via its identity keys" do
+      source = """
+      defmodule MyApp.Signups do
+        def find(email) do
+          Ash.get!(AshCredoFixtures.Accounts.Account, %{email: email})
+        end
+      end
+      """
+
+      assert [issue] = run_check(UseCodeInterface, source)
+      assert issue.trigger == "Ash.get!"
+      assert issue.line_no == 3
+
+      assert issue.message =~
+               "AshCredoFixtures.Accounts.Account.get_account_by_email!(email, not_found_error?: false)"
+
+      refute issue.message =~ "fetch_account_by_id"
+    end
+
+    test "an interface with not_found_error?: false is suggested without the trailing option" do
+      source = """
+      defmodule MyApp.Signups do
+        def find(id) do
+          Ash.get(AshCredoFixtures.Accounts.Account, id)
+        end
+      end
+      """
+
+      assert [issue] = run_check(UseCodeInterface, source)
+      assert issue.trigger == "Ash.get"
+      assert issue.line_no == 3
+      assert issue.message =~ "AshCredoFixtures.Accounts.Account.fetch_account_by_id(id)"
+      refute issue.message =~ "not_found_error?"
+    end
+
+    test "Ash.ActionInput.for_action suggests the input_to_* helper" do
+      source = """
+      defmodule MyApp.Signups do
+        def activation_input do
+          Ash.ActionInput.for_action(AshCredoFixtures.Accounts.Account, :activate)
+        end
+      end
+      """
+
+      assert [issue] = run_check(UseCodeInterface, source)
+      assert issue.trigger == "Ash.ActionInput.for_action"
+      assert issue.line_no == 3
+      assert issue.message =~ "AshCredoFixtures.Accounts.Account.input_to_activate"
+    end
+
+    test "outside-domain Ash.get! without any interface suggests a get-by define on the domain" do
+      source = """
+      defmodule MyApp.Web.ArticleController do
+        def show(id) do
+          Ash.get!(AshCredoFixtures.Blog.Article, id)
+        end
+      end
+      """
+
+      assert [issue] = run_check(UseCodeInterface, source)
+      assert issue.trigger == "Ash.get!"
+      assert issue.line_no == 3
+      assert issue.message =~ "Prefer a get-by code interface on `AshCredoFixtures.Blog`"
+      assert issue.message =~ "define :get_by_id, action: :read, get_by: [:id]"
+
+      assert issue.message =~
+               "`resource AshCredoFixtures.Blog.Article do ... end` block of the domain"
+    end
+
+    test "a domainless resource falls back to a resource-level define under :auto" do
+      source = """
+      defmodule MyApp.Web.StandaloneController do
+        def list do
+          Ash.read!(AshCredoFixtures.Standalone)
+        end
+      end
+      """
+
+      assert [issue] = run_check(UseCodeInterface, source)
+      assert issue.trigger == "Ash.read!"
+      assert issue.line_no == 3
+      assert issue.message =~ "Prefer a code interface on `AshCredoFixtures.Standalone`"
+      assert issue.message =~ "define :read"
+      assert issue.message =~ "inside the resource's `code_interface` block"
+    end
+
+    test "a domainless resource falls back to a resource-level define even under :domain scope" do
+      source = """
+      defmodule MyApp.Web.StandaloneController do
+        def list do
+          Ash.read!(AshCredoFixtures.Standalone)
+        end
+      end
+      """
+
+      assert [issue] = run_check(UseCodeInterface, source, prefer_interface_scope: :domain)
+      assert issue.message =~ "Prefer a code interface on `AshCredoFixtures.Standalone`"
+      assert issue.message =~ "inside the resource's `code_interface` block"
+      refute issue.message =~ "domain"
+    end
+  end
+
   # ── Implicit submodule alias ───────────────────────────────────────────────
 
   describe "implicit submodule alias" do

--- a/test/support/fixtures/ash_fixtures.ex
+++ b/test/support/fixtures/ash_fixtures.ex
@@ -164,6 +164,67 @@ defmodule AshCredoFixtures.Accounts.EmbeddedContact do
   end
 end
 
+defmodule AshCredoFixtures.Accounts.Account do
+  @moduledoc """
+  `UseCodeInterface` fixture for the long-tail suggestion families:
+
+    * `get_account_by_email` uses `get_by_identity: :unique_email` - the
+      suggestion must resolve the identity to its keys to match a
+      `Ash.get!(Account, %{email: ...})` lookup.
+    * `fetch_account_by_id` sets `not_found_error?: false` - the suggested
+      call must NOT carry the trailing `not_found_error?: false` argument.
+    * `:activate` is a generic action with an interface - builder calls via
+      `Ash.ActionInput.for_action/3` must suggest the `input_to_*` helper.
+  """
+
+  use Ash.Resource,
+    domain: AshCredoFixtures.Accounts,
+    validate_domain_inclusion?: false
+
+  code_interface do
+    define :get_account_by_email, action: :read, get_by_identity: :unique_email
+    define :fetch_account_by_id, action: :read, get_by: [:id], not_found_error?: false
+    define :activate
+  end
+
+  actions do
+    defaults [:read]
+    default_accept []
+
+    action :activate do
+      run fn _input, _ -> :ok end
+    end
+  end
+
+  attributes do
+    uuid_primary_key :id
+    attribute :email, :string, public?: true
+  end
+
+  identities do
+    identity :unique_email, [:email]
+  end
+end
+
+defmodule AshCredoFixtures.Standalone do
+  @moduledoc """
+  Resource without a domain: `UseCodeInterface` has no domain interface to
+  point at, so both the `:auto` and the `prefer_interface_scope: :domain`
+  paths must fall back to suggesting a resource-level interface.
+  """
+
+  use Ash.Resource, domain: nil, validate_domain_inclusion?: false
+
+  actions do
+    defaults [:read]
+    default_accept []
+  end
+
+  attributes do
+    uuid_primary_key :id
+  end
+end
+
 defmodule AshCredoFixtures.Accounts do
   @moduledoc "Fixture domain for cross-domain tests."
 
@@ -173,6 +234,7 @@ defmodule AshCredoFixtures.Accounts do
     resource AshCredoFixtures.Accounts.User
     resource AshCredoFixtures.Accounts.Member
     resource AshCredoFixtures.Accounts.Profile
+    resource AshCredoFixtures.Accounts.Account
   end
 end
 


### PR DESCRIPTION
## Motivation

Several `UseCodeInterface` suggestion variants had no test coverage: resolving a `get_by_identity:` interface through its identity's keys, trimming the trailing `not_found_error?: false` argument when the interface already sets it, the `input_to_*` helper for `Ash.ActionInput.for_action` builder calls, the domain-level get-by define message, and the fallbacks for resources without a domain. A regression in any of these message paths would have shipped silently.

## Changes

- Add the `AshCredoFixtures.Accounts.Account` fixture carrying a `get_by_identity:` interface, a `not_found_error?: false` interface, and a generic action with an interface
- Add the domainless `AshCredoFixtures.Standalone` fixture
- Add a "suggestion long tail" test group covering identity-key matching, `not_found_error?` trimming, `input_to_*` suggestions, the domain get-by define message, and both domainless fallbacks (`:auto` and `prefer_interface_scope: :domain`)
