### PR TITLE
test: pin lines, triggers, and shapes in count-only assertions

### DIFF
--- a/test/ash_credo/check/design/missing_code_interface_test.exs
+++ b/test/ash_credo/check/design/missing_code_interface_test.exs
@@ -1,8 +1,7 @@
 defmodule AshCredo.Check.Design.MissingCodeInterfaceTest do
-  use AshCredo.CheckCase
+  use AshCredo.CheckCase, clear_cache: true
 
   alias AshCredo.Check.Design.MissingCodeInterface
-  alias AshCredo.Introspection.Compiled, as: CompiledIntrospection
 
   # Tests reference real fixture modules from `test/support/fixtures/ash_fixtures.ex`:
   #
@@ -16,11 +15,6 @@ defmodule AshCredo.Check.Design.MissingCodeInterfaceTest do
   #
   #   * `AshCredoFixtures.Accounts.User` - has `:create`, `:read`, `:update`,
   #     `:destroy` (via defaults). ZERO interfaces. All 4 actions should be flagged.
-
-  setup do
-    CompiledIntrospection.clear_cache()
-    :ok
-  end
 
   test "reports one issue per action without an interface" do
     source = """

--- a/test/ash_credo/check/design/missing_identity_test.exs
+++ b/test/ash_credo/check/design/missing_identity_test.exs
@@ -1,8 +1,7 @@
 defmodule AshCredo.Check.Design.MissingIdentityTest do
-  use AshCredo.CheckCase
+  use AshCredo.CheckCase, clear_cache: true
 
   alias AshCredo.Check.Design.MissingIdentity
-  alias AshCredo.Introspection.Compiled, as: CompiledIntrospection
 
   # Tests reference real fixture modules from `test/support/fixtures/ash_fixtures.ex`:
   #
@@ -10,11 +9,6 @@ defmodule AshCredo.Check.Design.MissingIdentityTest do
   #     attributes, no identities. Failure-path fixture for the migration.
   #   * `AshCredoFixtures.Accounts.Profile` - has `:email` attribute AND
   #     `:unique_email` identity covering it. Happy-path fixture.
-
-  setup do
-    CompiledIntrospection.clear_cache()
-    :ok
-  end
 
   test "reports an issue per uncovered candidate attribute" do
     source = """

--- a/test/ash_credo/check/design/missing_identity_test.exs
+++ b/test/ash_credo/check/design/missing_identity_test.exs
@@ -19,8 +19,7 @@ defmodule AshCredo.Check.Design.MissingIdentityTest do
 
     issues = run_check(MissingIdentity, source)
 
-    triggers = issues |> MapSet.new(& &1.trigger)
-    assert MapSet.equal?(triggers, MapSet.new(~w(email username)))
+    assert MapSet.equal?(trigger_set(issues), MapSet.new(~w(email username)))
 
     for issue <- issues do
       assert issue.message =~ "AshCredoFixtures.Accounts.Member"

--- a/test/ash_credo/check/design/missing_primary_action_test.exs
+++ b/test/ash_credo/check/design/missing_primary_action_test.exs
@@ -1,8 +1,7 @@
 defmodule AshCredo.Check.Design.MissingPrimaryActionTest do
-  use AshCredo.CheckCase
+  use AshCredo.CheckCase, clear_cache: true
 
   alias AshCredo.Check.Design.MissingPrimaryAction
-  alias AshCredo.Introspection.Compiled, as: CompiledIntrospection
 
   # Tests reference real fixture modules from `test/support/fixtures/ash_fixtures.ex`
   # so that compiled-introspection (`Ash.Resource.Info.actions/1`) returns the
@@ -15,11 +14,6 @@ defmodule AshCredo.Check.Design.MissingPrimaryActionTest do
   #     `create :create_with_slug`, neither primary. Failure-path fixture.
   #   * `AshCredoFixtures.Accounts.User` - `defaults [:create, :read, :update, :destroy]`,
   #     single action of each type. Happy-path fixture.
-
-  setup do
-    CompiledIntrospection.clear_cache()
-    :ok
-  end
 
   test "no issue for a resource with a single primary action per type" do
     source = """

--- a/test/ash_credo/check/design/missing_timestamps_test.exs
+++ b/test/ash_credo/check/design/missing_timestamps_test.exs
@@ -1,18 +1,12 @@
 defmodule AshCredo.Check.Design.MissingTimestampsTest do
-  use AshCredo.CheckCase
+  use AshCredo.CheckCase, clear_cache: true
 
   alias AshCredo.Check.Design.MissingTimestamps
-  alias AshCredo.Introspection.Compiled, as: CompiledIntrospection
 
   # Tests reference real fixture modules from `test/support/fixtures/ash_fixtures.ex`:
   #
   #   * `AshCredoFixtures.Blog.Post`    - has no timestamps (failure-path).
   #   * `AshCredoFixtures.Blog.Article` - uses `timestamps()` (happy-path).
-
-  setup do
-    CompiledIntrospection.clear_cache()
-    :ok
-  end
 
   # Note: the test source needs `data_layer:` set so the AST-level
   # `has_data_layer?/1` guard fires. The check then introspects the real

--- a/test/ash_credo/check/readability/action_missing_description_test.exs
+++ b/test/ash_credo/check/readability/action_missing_description_test.exs
@@ -56,6 +56,8 @@ defmodule AshCredo.Check.Readability.ActionMissingDescriptionTest do
 
     issues = run_check(ActionMissingDescription, source)
     assert [_, _] = issues
+    assert issues |> Enum.map(& &1.line_no) |> Enum.sort() == [5, 9]
+    assert Enum.all?(issues, &(&1.message =~ "description"))
   end
 
   test "no issue when inline description option is present" do

--- a/test/ash_credo/check/readability/action_missing_description_test.exs
+++ b/test/ash_credo/check/readability/action_missing_description_test.exs
@@ -56,7 +56,7 @@ defmodule AshCredo.Check.Readability.ActionMissingDescriptionTest do
 
     issues = run_check(ActionMissingDescription, source)
     assert [_, _] = issues
-    assert issues |> Enum.map(& &1.line_no) |> Enum.sort() == [5, 9]
+    assert sorted_lines(issues) == [5, 9]
     assert Enum.all?(issues, &(&1.message =~ "description"))
   end
 

--- a/test/ash_credo/check/refactor/anonymous_function_in_dsl_test.exs
+++ b/test/ash_credo/check/refactor/anonymous_function_in_dsl_test.exs
@@ -99,8 +99,7 @@ defmodule AshCredo.Check.Refactor.AnonymousFunctionInDslTest do
     issues = run_check(AnonymousFunctionInDsl, source)
     assert [_, _, _] = issues
     assert MapSet.equal?(trigger_set(issues), MapSet.new(~w(change validate prepare)))
-    assert issues |> Enum.map(& &1.line_no) |> Enum.sort() == [5, 9, 13]
-    assert issues |> Enum.map(& &1.line_no) |> Enum.sort() == [5, 9, 13]
+    assert sorted_lines(issues) == [5, 9, 13]
   end
 
   test "reports anonymous functions inside pipeline bodies" do

--- a/test/ash_credo/check/refactor/anonymous_function_in_dsl_test.exs
+++ b/test/ash_credo/check/refactor/anonymous_function_in_dsl_test.exs
@@ -99,6 +99,8 @@ defmodule AshCredo.Check.Refactor.AnonymousFunctionInDslTest do
     issues = run_check(AnonymousFunctionInDsl, source)
     assert [_, _, _] = issues
     assert MapSet.equal?(trigger_set(issues), MapSet.new(~w(change validate prepare)))
+    assert issues |> Enum.map(& &1.line_no) |> Enum.sort() == [5, 9, 13]
+    assert issues |> Enum.map(& &1.line_no) |> Enum.sort() == [5, 9, 13]
   end
 
   test "reports anonymous functions inside pipeline bodies" do

--- a/test/ash_credo/check/refactor/directive_in_function_body_test.exs
+++ b/test/ash_credo/check/refactor/directive_in_function_body_test.exs
@@ -114,9 +114,8 @@ defmodule AshCredo.Check.Refactor.DirectiveInFunctionBodyTest do
       end
       """
 
-      assert issues = run_check(DirectiveInFunctionBody, source)
-      assert [_, _, _] = issues
-      assert Enum.all?(issues, &(&1.trigger == "Ash.Query"))
+      issues = run_check(DirectiveInFunctionBody, source)
+      assert sorted_triggers(issues) == ["Ash.Query", "Ash.Query", "Ash.Query"]
       assert sorted_lines(issues) == [3, 8, 13]
     end
 

--- a/test/ash_credo/check/refactor/directive_in_function_body_test.exs
+++ b/test/ash_credo/check/refactor/directive_in_function_body_test.exs
@@ -117,7 +117,7 @@ defmodule AshCredo.Check.Refactor.DirectiveInFunctionBodyTest do
       assert issues = run_check(DirectiveInFunctionBody, source)
       assert [_, _, _] = issues
       assert Enum.all?(issues, &(&1.trigger == "Ash.Query"))
-      assert issues |> Enum.map(& &1.line_no) |> Enum.sort() == [3, 8, 13]
+      assert sorted_lines(issues) == [3, 8, 13]
     end
 
     test "flags `require Ash.Expr` inside a function body (included in default)" do

--- a/test/ash_credo/check/refactor/directive_in_function_body_test.exs
+++ b/test/ash_credo/check/refactor/directive_in_function_body_test.exs
@@ -117,6 +117,7 @@ defmodule AshCredo.Check.Refactor.DirectiveInFunctionBodyTest do
       assert issues = run_check(DirectiveInFunctionBody, source)
       assert [_, _, _] = issues
       assert Enum.all?(issues, &(&1.trigger == "Ash.Query"))
+      assert issues |> Enum.map(& &1.line_no) |> Enum.sort() == [3, 8, 13]
     end
 
     test "flags `require Ash.Expr` inside a function body (included in default)" do

--- a/test/ash_credo/check/refactor/raising_call_test.exs
+++ b/test/ash_credo/check/refactor/raising_call_test.exs
@@ -113,7 +113,9 @@ defmodule AshCredo.Check.Refactor.RaisingCallTest do
     end
     """
 
-    assert [_] = run_check(RaisingCall, source)
+    assert [issue] = run_check(RaisingCall, source)
+    assert issue.trigger == "Ash.read!"
+    assert issue.line_no == 2
     assert [] = run_check(RaisingCall, source, excluded_functions: [{Ash, :read!}])
   end
 
@@ -297,7 +299,8 @@ defmodule AshCredo.Check.Refactor.RaisingCallTest do
       end
       """
 
-      assert [_] = run_check(RaisingCall, source, __filename__: "lib/my_app/accounts.ex")
+      assert [issue] = run_check(RaisingCall, source, __filename__: "lib/my_app/accounts.ex")
+      assert issue.trigger == "Ash.read!"
     end
 
     test "respects an empty excluded_paths override" do
@@ -305,11 +308,13 @@ defmodule AshCredo.Check.Refactor.RaisingCallTest do
       Ash.read!(MyApp.User)
       """
 
-      assert [_] =
+      assert [issue] =
                run_check(RaisingCall, source,
                  __filename__: "test/my_app/user_test.exs",
                  excluded_paths: []
                )
+
+      assert issue.trigger == "Ash.read!"
     end
 
     test "respects a custom excluded_paths list" do

--- a/test/ash_credo/check/refactor/raising_call_test.exs
+++ b/test/ash_credo/check/refactor/raising_call_test.exs
@@ -1,8 +1,7 @@
 defmodule AshCredo.Check.Refactor.RaisingCallTest do
-  use AshCredo.CheckCase
+  use AshCredo.CheckCase, clear_cache: true
 
   alias AshCredo.Check.Refactor.RaisingCall
-  alias AshCredo.Introspection.Compiled, as: CompiledIntrospection
 
   test "reports issue for Ash.read!" do
     source = """
@@ -386,11 +385,6 @@ defmodule AshCredo.Check.Refactor.RaisingCallTest do
   end
 
   describe "code-interface bang detection (compiled pass)" do
-    setup do
-      CompiledIntrospection.clear_cache()
-      :ok
-    end
-
     test "flags resource-defined code-interface bang where name == action" do
       source = """
       defmodule MyApp.Worker do
@@ -641,11 +635,6 @@ defmodule AshCredo.Check.Refactor.RaisingCallTest do
   end
 
   describe "bang-only APIs (no non-bang counterpart)" do
-    setup do
-      CompiledIntrospection.clear_cache()
-      :ok
-    end
-
     test "skips bangs whose module exports no non-bang twin" do
       source = """
       defmodule MyApp.Seeds do

--- a/test/ash_credo/check/refactor/use_code_interface_test.exs
+++ b/test/ash_credo/check/refactor/use_code_interface_test.exs
@@ -1,5 +1,5 @@
 defmodule AshCredo.Check.Refactor.UseCodeInterfaceTest do
-  use AshCredo.CheckCase
+  use AshCredo.CheckCase, clear_cache: true
 
   alias AshCredo.Cache
   alias AshCredo.Check.Refactor.UseCodeInterface
@@ -16,11 +16,6 @@ defmodule AshCredo.Check.Refactor.UseCodeInterfaceTest do
   #
   # The check resolves each referenced name to an atom and then queries the
   # compiled-BEAM introspection, exercising the real classification path.
-
-  setup do
-    CompiledIntrospection.clear_cache()
-    :ok
-  end
 
   # ── AST short-circuits (no introspection needed) ──────────────────────────
 

--- a/test/ash_credo/check/warning/actor_on_call_options_test.exs
+++ b/test/ash_credo/check/warning/actor_on_call_options_test.exs
@@ -50,8 +50,7 @@ defmodule AshCredo.Check.Warning.ActorOnCallOptionsTest do
     assert [_, _] = issues
     assert find_by_trigger(issues, "actor")
     assert find_by_trigger(issues, "tenant")
-    assert Enum.all?(issues, &(&1.line_no == 5))
-    assert Enum.all?(issues, &(&1.line_no == 5))
+    assert sorted_lines(issues) == [5, 5]
   end
 
   test "reports actor: when the built query is bound to a variable" do

--- a/test/ash_credo/check/warning/actor_on_call_options_test.exs
+++ b/test/ash_credo/check/warning/actor_on_call_options_test.exs
@@ -50,6 +50,8 @@ defmodule AshCredo.Check.Warning.ActorOnCallOptionsTest do
     assert [_, _] = issues
     assert find_by_trigger(issues, "actor")
     assert find_by_trigger(issues, "tenant")
+    assert Enum.all?(issues, &(&1.line_no == 5))
+    assert Enum.all?(issues, &(&1.line_no == 5))
   end
 
   test "reports actor: when the built query is bound to a variable" do

--- a/test/ash_credo/check/warning/authorize_false_test.exs
+++ b/test/ash_credo/check/warning/authorize_false_test.exs
@@ -236,7 +236,7 @@ defmodule AshCredo.Check.Warning.AuthorizeFalseTest do
     issues = run_check(AuthorizeFalse, source)
     assert [_, _] = issues
     assert Enum.all?(issues, &(&1.trigger == "authorize?: false"))
-    assert issues |> Enum.map(& &1.line_no) |> Enum.sort() == [5, 6]
+    assert sorted_lines(issues) == [5, 6]
   end
 
   test "no issue for action with authorize?: true" do

--- a/test/ash_credo/check/warning/authorize_false_test.exs
+++ b/test/ash_credo/check/warning/authorize_false_test.exs
@@ -233,7 +233,10 @@ defmodule AshCredo.Check.Warning.AuthorizeFalseTest do
     end
     """
 
-    assert [_, _] = run_check(AuthorizeFalse, source)
+    issues = run_check(AuthorizeFalse, source)
+    assert [_, _] = issues
+    assert Enum.all?(issues, &(&1.trigger == "authorize?: false"))
+    assert issues |> Enum.map(& &1.line_no) |> Enum.sort() == [5, 6]
   end
 
   test "no issue for action with authorize?: true" do
@@ -357,7 +360,8 @@ defmodule AshCredo.Check.Warning.AuthorizeFalseTest do
       end
       """
 
-      assert [_] = run_check(AuthorizeFalse, source, __filename__: "lib/my_app/accounts.ex")
+      assert [issue] = run_check(AuthorizeFalse, source, __filename__: "lib/my_app/accounts.ex")
+      assert issue.trigger == "authorize?: false"
     end
 
     test "respects an empty excluded_paths override" do
@@ -365,11 +369,13 @@ defmodule AshCredo.Check.Warning.AuthorizeFalseTest do
       Ash.read!(MyApp.User, authorize?: false)
       """
 
-      assert [_] =
+      assert [issue] =
                run_check(AuthorizeFalse, source,
                  __filename__: "test/my_app/user_test.exs",
                  excluded_paths: []
                )
+
+      assert issue.trigger == "authorize?: false"
     end
 
     test "respects a custom excluded_paths list" do

--- a/test/ash_credo/check/warning/authorize_false_test.exs
+++ b/test/ash_credo/check/warning/authorize_false_test.exs
@@ -234,8 +234,7 @@ defmodule AshCredo.Check.Warning.AuthorizeFalseTest do
     """
 
     issues = run_check(AuthorizeFalse, source)
-    assert [_, _] = issues
-    assert Enum.all?(issues, &(&1.trigger == "authorize?: false"))
+    assert sorted_triggers(issues) == ["authorize?: false", "authorize?: false"]
     assert sorted_lines(issues) == [5, 6]
   end
 

--- a/test/ash_credo/check/warning/authorizer_without_policies_test.exs
+++ b/test/ash_credo/check/warning/authorizer_without_policies_test.exs
@@ -1,8 +1,7 @@
 defmodule AshCredo.Check.Warning.AuthorizerWithoutPoliciesTest do
-  use AshCredo.CheckCase
+  use AshCredo.CheckCase, clear_cache: true
 
   alias AshCredo.Check.Warning.AuthorizerWithoutPolicies
-  alias AshCredo.Introspection.Compiled, as: CompiledIntrospection
 
   # Tests reference real fixture modules from `test/support/fixtures/ash_fixtures.ex`:
   #
@@ -12,11 +11,6 @@ defmodule AshCredo.Check.Warning.AuthorizerWithoutPoliciesTest do
   #     Happy-path fixture (check should silently skip).
   #   * `AshCredoFixtures.Blog.WithAuthorizerAndPolicies` - declares the
   #     authorizer AND a non-empty `policies` block. Happy-path fixture.
-
-  setup do
-    CompiledIntrospection.clear_cache()
-    :ok
-  end
 
   test "reports an issue when Ash.Policy.Authorizer is declared but no policies exist" do
     source = """

--- a/test/ash_credo/check/warning/missing_builtin_wrapper_test.exs
+++ b/test/ash_credo/check/warning/missing_builtin_wrapper_test.exs
@@ -60,6 +60,8 @@ defmodule AshCredo.Check.Warning.MissingBuiltinWrapperTest do
       issues = run_check(MissingBuiltinWrapper, source)
       assert [_, _] = issues
       assert Enum.all?(issues, &(&1.trigger == "set_attribute"))
+      assert issues |> Enum.map(& &1.line_no) |> Enum.sort() == [6, 10]
+      assert issues |> Enum.map(& &1.line_no) |> Enum.sort() == [6, 10]
     end
 
     test "reports multiple naked builtins of mixed families in one action" do
@@ -85,6 +87,10 @@ defmodule AshCredo.Check.Warning.MissingBuiltinWrapperTest do
                trigger_set(issues),
                MapSet.new(~w(set_attribute manage_relationship present))
              )
+
+      assert issues |> Enum.map(& &1.line_no) |> Enum.sort() == [7, 8, 9]
+
+      assert issues |> Enum.map(& &1.line_no) |> Enum.sort() == [7, 8, 9]
 
       assert find_by_trigger(issues, "present").message =~ "`validate` wrapper"
       assert find_by_trigger(issues, "set_attribute").message =~ "`change` wrapper"
@@ -212,6 +218,8 @@ defmodule AshCredo.Check.Warning.MissingBuiltinWrapperTest do
       assert [_, _] = issues
       assert find_by_trigger(issues, "present")
       assert find_by_trigger(issues, "compare").message =~ "validate compare(...)"
+      assert issues |> Enum.map(& &1.line_no) |> Enum.sort() == [7, 11]
+      assert issues |> Enum.map(& &1.line_no) |> Enum.sort() == [7, 11]
     end
   end
 
@@ -273,6 +281,8 @@ defmodule AshCredo.Check.Warning.MissingBuiltinWrapperTest do
       assert [_, _] = issues
       assert Enum.all?(issues, &(&1.trigger == "set_context"))
       assert Enum.all?(issues, &(&1.message =~ "`prepare` wrapper"))
+      assert issues |> Enum.map(& &1.line_no) |> Enum.sort() == [6, 10]
+      assert issues |> Enum.map(& &1.line_no) |> Enum.sort() == [6, 10]
     end
 
     test "set_context in create/update/destroy gets change advice" do
@@ -335,6 +345,8 @@ defmodule AshCredo.Check.Warning.MissingBuiltinWrapperTest do
       assert find_by_trigger(issues, "set_attribute").message =~ "`change` wrapper"
       assert find_by_trigger(issues, "present").message =~ "`validate` wrapper"
       assert find_by_trigger(issues, "build").message =~ "`prepare` wrapper"
+      assert issues |> Enum.map(& &1.line_no) |> Enum.sort() == [6, 7, 8]
+      assert issues |> Enum.map(& &1.line_no) |> Enum.sort() == [6, 7, 8]
     end
 
     test "set_context in a pipeline gets change advice and is flagged exactly once" do
@@ -393,6 +405,8 @@ defmodule AshCredo.Check.Warning.MissingBuiltinWrapperTest do
       assert find_by_trigger(issues, "set_attribute").message =~ "`change` wrapper"
       assert find_by_trigger(issues, "set_context").message =~ "`change` wrapper"
       assert find_by_trigger(issues, "present").message =~ "`validate` wrapper"
+      assert issues |> Enum.map(& &1.line_no) |> Enum.sort() == [5, 6, 7]
+      assert issues |> Enum.map(& &1.line_no) |> Enum.sort() == [5, 6, 7]
     end
 
     test "reports naked validation builtin in the validations section" do
@@ -428,6 +442,8 @@ defmodule AshCredo.Check.Warning.MissingBuiltinWrapperTest do
       assert [_, _] = issues
       assert find_by_trigger(issues, "build").message =~ "`prepare` wrapper"
       assert find_by_trigger(issues, "set_context").message =~ "`prepare` wrapper"
+      assert issues |> Enum.map(& &1.line_no) |> Enum.sort() == [5, 6]
+      assert issues |> Enum.map(& &1.line_no) |> Enum.sort() == [5, 6]
     end
 
     test "no issue for wrapped entities in global sections" do

--- a/test/ash_credo/check/warning/missing_builtin_wrapper_test.exs
+++ b/test/ash_credo/check/warning/missing_builtin_wrapper_test.exs
@@ -60,8 +60,7 @@ defmodule AshCredo.Check.Warning.MissingBuiltinWrapperTest do
       issues = run_check(MissingBuiltinWrapper, source)
       assert [_, _] = issues
       assert Enum.all?(issues, &(&1.trigger == "set_attribute"))
-      assert issues |> Enum.map(& &1.line_no) |> Enum.sort() == [6, 10]
-      assert issues |> Enum.map(& &1.line_no) |> Enum.sort() == [6, 10]
+      assert sorted_lines(issues) == [6, 10]
     end
 
     test "reports multiple naked builtins of mixed families in one action" do
@@ -88,9 +87,9 @@ defmodule AshCredo.Check.Warning.MissingBuiltinWrapperTest do
                MapSet.new(~w(set_attribute manage_relationship present))
              )
 
-      assert issues |> Enum.map(& &1.line_no) |> Enum.sort() == [7, 8, 9]
+      assert sorted_lines(issues) == [7, 8, 9]
 
-      assert issues |> Enum.map(& &1.line_no) |> Enum.sort() == [7, 8, 9]
+      assert sorted_lines(issues) == [7, 8, 9]
 
       assert find_by_trigger(issues, "present").message =~ "`validate` wrapper"
       assert find_by_trigger(issues, "set_attribute").message =~ "`change` wrapper"
@@ -218,8 +217,7 @@ defmodule AshCredo.Check.Warning.MissingBuiltinWrapperTest do
       assert [_, _] = issues
       assert find_by_trigger(issues, "present")
       assert find_by_trigger(issues, "compare").message =~ "validate compare(...)"
-      assert issues |> Enum.map(& &1.line_no) |> Enum.sort() == [7, 11]
-      assert issues |> Enum.map(& &1.line_no) |> Enum.sort() == [7, 11]
+      assert sorted_lines(issues) == [7, 11]
     end
   end
 
@@ -281,8 +279,7 @@ defmodule AshCredo.Check.Warning.MissingBuiltinWrapperTest do
       assert [_, _] = issues
       assert Enum.all?(issues, &(&1.trigger == "set_context"))
       assert Enum.all?(issues, &(&1.message =~ "`prepare` wrapper"))
-      assert issues |> Enum.map(& &1.line_no) |> Enum.sort() == [6, 10]
-      assert issues |> Enum.map(& &1.line_no) |> Enum.sort() == [6, 10]
+      assert sorted_lines(issues) == [6, 10]
     end
 
     test "set_context in create/update/destroy gets change advice" do
@@ -345,8 +342,7 @@ defmodule AshCredo.Check.Warning.MissingBuiltinWrapperTest do
       assert find_by_trigger(issues, "set_attribute").message =~ "`change` wrapper"
       assert find_by_trigger(issues, "present").message =~ "`validate` wrapper"
       assert find_by_trigger(issues, "build").message =~ "`prepare` wrapper"
-      assert issues |> Enum.map(& &1.line_no) |> Enum.sort() == [6, 7, 8]
-      assert issues |> Enum.map(& &1.line_no) |> Enum.sort() == [6, 7, 8]
+      assert sorted_lines(issues) == [6, 7, 8]
     end
 
     test "set_context in a pipeline gets change advice and is flagged exactly once" do
@@ -405,8 +401,7 @@ defmodule AshCredo.Check.Warning.MissingBuiltinWrapperTest do
       assert find_by_trigger(issues, "set_attribute").message =~ "`change` wrapper"
       assert find_by_trigger(issues, "set_context").message =~ "`change` wrapper"
       assert find_by_trigger(issues, "present").message =~ "`validate` wrapper"
-      assert issues |> Enum.map(& &1.line_no) |> Enum.sort() == [5, 6, 7]
-      assert issues |> Enum.map(& &1.line_no) |> Enum.sort() == [5, 6, 7]
+      assert sorted_lines(issues) == [5, 6, 7]
     end
 
     test "reports naked validation builtin in the validations section" do
@@ -442,8 +437,7 @@ defmodule AshCredo.Check.Warning.MissingBuiltinWrapperTest do
       assert [_, _] = issues
       assert find_by_trigger(issues, "build").message =~ "`prepare` wrapper"
       assert find_by_trigger(issues, "set_context").message =~ "`prepare` wrapper"
-      assert issues |> Enum.map(& &1.line_no) |> Enum.sort() == [5, 6]
-      assert issues |> Enum.map(& &1.line_no) |> Enum.sort() == [5, 6]
+      assert sorted_lines(issues) == [5, 6]
     end
 
     test "no issue for wrapped entities in global sections" do

--- a/test/ash_credo/check/warning/missing_builtin_wrapper_test.exs
+++ b/test/ash_credo/check/warning/missing_builtin_wrapper_test.exs
@@ -58,8 +58,7 @@ defmodule AshCredo.Check.Warning.MissingBuiltinWrapperTest do
       """
 
       issues = run_check(MissingBuiltinWrapper, source)
-      assert [_, _] = issues
-      assert Enum.all?(issues, &(&1.trigger == "set_attribute"))
+      assert sorted_triggers(issues) == ["set_attribute", "set_attribute"]
       assert sorted_lines(issues) == [6, 10]
     end
 
@@ -276,8 +275,7 @@ defmodule AshCredo.Check.Warning.MissingBuiltinWrapperTest do
       """
 
       issues = run_check(MissingBuiltinWrapper, source)
-      assert [_, _] = issues
-      assert Enum.all?(issues, &(&1.trigger == "set_context"))
+      assert sorted_triggers(issues) == ["set_context", "set_context"]
       assert Enum.all?(issues, &(&1.message =~ "`prepare` wrapper"))
       assert sorted_lines(issues) == [6, 10]
     end

--- a/test/ash_credo/check/warning/missing_macro_directive_test.exs
+++ b/test/ash_credo/check/warning/missing_macro_directive_test.exs
@@ -1,13 +1,7 @@
 defmodule AshCredo.Check.Warning.MissingMacroDirectiveTest do
-  use AshCredo.CheckCase
+  use AshCredo.CheckCase, clear_cache: true
 
   alias AshCredo.Check.Warning.MissingMacroDirective
-  alias AshCredo.Introspection.Compiled, as: CompiledIntrospection
-
-  setup do
-    CompiledIntrospection.clear_cache()
-    :ok
-  end
 
   describe "Ash.Query" do
     test "flags Ash.Query.filter without require" do

--- a/test/ash_credo/check/warning/pinned_time_in_expression_test.exs
+++ b/test/ash_credo/check/warning/pinned_time_in_expression_test.exs
@@ -22,8 +22,7 @@ defmodule AshCredo.Check.Warning.PinnedTimeInExpressionTest do
 
     issues = run_check(PinnedTimeInExpression, source)
     assert [_, _] = issues
-    assert issues |> Enum.map(& &1.line_no) |> Enum.sort() == [8, 9]
-    assert issues |> Enum.map(& &1.line_no) |> Enum.sort() == [8, 9]
+    assert sorted_lines(issues) == [8, 9]
 
     Enum.each(issues, fn issue ->
       assert issue.message =~ "today()"

--- a/test/ash_credo/check/warning/pinned_time_in_expression_test.exs
+++ b/test/ash_credo/check/warning/pinned_time_in_expression_test.exs
@@ -22,6 +22,8 @@ defmodule AshCredo.Check.Warning.PinnedTimeInExpressionTest do
 
     issues = run_check(PinnedTimeInExpression, source)
     assert [_, _] = issues
+    assert issues |> Enum.map(& &1.line_no) |> Enum.sort() == [8, 9]
+    assert issues |> Enum.map(& &1.line_no) |> Enum.sort() == [8, 9]
 
     Enum.each(issues, fn issue ->
       assert issue.message =~ "today()"

--- a/test/ash_credo/check/warning/redundant_validation_test.exs
+++ b/test/ash_credo/check/warning/redundant_validation_test.exs
@@ -1,8 +1,7 @@
 defmodule AshCredo.Check.Warning.RedundantValidationTest do
-  use AshCredo.CheckCase
+  use AshCredo.CheckCase, clear_cache: true
 
   alias AshCredo.Check.Warning.RedundantValidation
-  alias AshCredo.Introspection.Compiled, as: CompiledIntrospection
 
   # Tests resolve attributes against the compiled fixture
   # `AshCredoFixtures.Blog.Contact` (test/support/fixtures/ash_fixtures.ex):
@@ -10,11 +9,6 @@ defmodule AshCredo.Check.Warning.RedundantValidationTest do
   # and the `:import` create action lists `:name` in `allow_nil_input` -
   # which also shields GLOBAL validations on `:name`, so the global-scope
   # happy-path tests use `:handle`.
-
-  setup do
-    CompiledIntrospection.clear_cache()
-    :ok
-  end
 
   test "reports redundant present on a non-nullable attribute in a create action" do
     source = """

--- a/test/ash_credo/check/warning/sensitive_attribute_exposed_test.exs
+++ b/test/ash_credo/check/warning/sensitive_attribute_exposed_test.exs
@@ -54,7 +54,7 @@ defmodule AshCredo.Check.Warning.SensitiveAttributeExposedTest do
     issues = run_check(SensitiveAttributeExposed, source)
     assert [_, _, _] = issues
     assert sorted_triggers(issues) == ~w(api_key password token)
-    assert issues |> Enum.map(& &1.line_no) |> Enum.sort() == [6, 7, 8]
+    assert sorted_lines(issues) == [6, 7, 8]
   end
 
   test "ignores non-sensitive attributes" do

--- a/test/ash_credo/check/warning/sensitive_attribute_exposed_test.exs
+++ b/test/ash_credo/check/warning/sensitive_attribute_exposed_test.exs
@@ -53,6 +53,8 @@ defmodule AshCredo.Check.Warning.SensitiveAttributeExposedTest do
 
     issues = run_check(SensitiveAttributeExposed, source)
     assert [_, _, _] = issues
+    assert sorted_triggers(issues) == ~w(api_key password token)
+    assert issues |> Enum.map(& &1.line_no) |> Enum.sort() == [6, 7, 8]
   end
 
   test "ignores non-sensitive attributes" do

--- a/test/ash_credo/check/warning/sensitive_field_in_accept_test.exs
+++ b/test/ash_credo/check/warning/sensitive_field_in_accept_test.exs
@@ -35,10 +35,7 @@ defmodule AshCredo.Check.Warning.SensitiveFieldInAcceptTest do
     """
 
     issues = run_check(SensitiveFieldInAccept, source)
-    assert [_, _] = issues
-    triggers = Enum.map(issues, & &1.trigger)
-    assert "is_admin" in triggers
-    assert "permissions" in triggers
+    assert sorted_triggers(issues) == ~w(is_admin permissions)
     assert sorted_lines(issues) == [6, 6]
   end
 
@@ -154,10 +151,7 @@ defmodule AshCredo.Check.Warning.SensitiveFieldInAcceptTest do
     """
 
     issues = run_check(SensitiveFieldInAccept, source, dangerous_fields: [~r/_token$/])
-    assert [_, _] = issues
-    triggers = Enum.map(issues, & &1.trigger)
-    assert "reset_token" in triggers
-    assert "api_token" in triggers
+    assert sorted_triggers(issues) == ~w(api_token reset_token)
     assert sorted_lines(issues) == [6, 6]
   end
 
@@ -175,9 +169,7 @@ defmodule AshCredo.Check.Warning.SensitiveFieldInAcceptTest do
     """
 
     issues = run_check(SensitiveFieldInAccept, source, dangerous_fields: [:is_admin, ~r/_token$/])
-    triggers = Enum.map(issues, & &1.trigger)
-    assert "is_admin" in triggers
-    assert "reset_token" in triggers
+    assert sorted_triggers(issues) == ~w(is_admin reset_token)
   end
 
   test "no issue for safe fields" do

--- a/test/ash_credo/check/warning/sensitive_field_in_accept_test.exs
+++ b/test/ash_credo/check/warning/sensitive_field_in_accept_test.exs
@@ -39,8 +39,7 @@ defmodule AshCredo.Check.Warning.SensitiveFieldInAcceptTest do
     triggers = Enum.map(issues, & &1.trigger)
     assert "is_admin" in triggers
     assert "permissions" in triggers
-    assert Enum.all?(issues, &(&1.line_no == 6))
-    assert Enum.all?(issues, &(&1.line_no == 6))
+    assert sorted_lines(issues) == [6, 6]
   end
 
   test "reports issue for inline accept with dangerous fields" do
@@ -159,8 +158,7 @@ defmodule AshCredo.Check.Warning.SensitiveFieldInAcceptTest do
     triggers = Enum.map(issues, & &1.trigger)
     assert "reset_token" in triggers
     assert "api_token" in triggers
-    assert Enum.all?(issues, &(&1.line_no == 6))
-    assert Enum.all?(issues, &(&1.line_no == 6))
+    assert sorted_lines(issues) == [6, 6]
   end
 
   test "regex and atom entries can be mixed" do

--- a/test/ash_credo/check/warning/sensitive_field_in_accept_test.exs
+++ b/test/ash_credo/check/warning/sensitive_field_in_accept_test.exs
@@ -39,6 +39,8 @@ defmodule AshCredo.Check.Warning.SensitiveFieldInAcceptTest do
     triggers = Enum.map(issues, & &1.trigger)
     assert "is_admin" in triggers
     assert "permissions" in triggers
+    assert Enum.all?(issues, &(&1.line_no == 6))
+    assert Enum.all?(issues, &(&1.line_no == 6))
   end
 
   test "reports issue for inline accept with dangerous fields" do
@@ -157,6 +159,8 @@ defmodule AshCredo.Check.Warning.SensitiveFieldInAcceptTest do
     triggers = Enum.map(issues, & &1.trigger)
     assert "reset_token" in triggers
     assert "api_token" in triggers
+    assert Enum.all?(issues, &(&1.line_no == 6))
+    assert Enum.all?(issues, &(&1.line_no == 6))
   end
 
   test "regex and atom entries can be mixed" do

--- a/test/ash_credo/check/warning/unknown_action_test.exs
+++ b/test/ash_credo/check/warning/unknown_action_test.exs
@@ -1,19 +1,13 @@
 defmodule AshCredo.Check.Warning.UnknownActionTest do
-  use AshCredo.CheckCase
+  use AshCredo.CheckCase, clear_cache: true
 
   alias AshCredo.Check.Warning.UnknownAction
-  alias AshCredo.Introspection.Compiled, as: CompiledIntrospection
 
   # Tests reference the real fixture `AshCredoFixtures.Blog.Post`, which has
   # actions `:read` (primary), `:published`, `:draft`, `:publish`, `:archive`,
   # `:create`, `:update`, `:destroy`. The check resolves the resource via
   # `Compiled.inspect_module/1` and then asks `Compiled.action/2` whether
   # the literal action exists.
-
-  setup do
-    CompiledIntrospection.clear_cache()
-    :ok
-  end
 
   describe "unknown action detection" do
     test "emits an issue with a jaro-distance suggestion for a near-miss typo" do

--- a/test/ash_credo/check/warning/wildcard_accept_on_action_test.exs
+++ b/test/ash_credo/check/warning/wildcard_accept_on_action_test.exs
@@ -123,8 +123,7 @@ defmodule AshCredo.Check.Warning.WildcardAcceptOnActionTest do
     assert [_, _] = issues
     assert find_by_message(issues, "Default `create` action")
     assert find_by_message(issues, "Default `update` action")
-    assert Enum.all?(issues, &(&1.line_no == 5))
-    assert Enum.all?(issues, &(&1.line_no == 5))
+    assert sorted_lines(issues) == [5, 5]
   end
 
   test "reports issue for inline accept: :* on create" do

--- a/test/ash_credo/check/warning/wildcard_accept_on_action_test.exs
+++ b/test/ash_credo/check/warning/wildcard_accept_on_action_test.exs
@@ -123,6 +123,8 @@ defmodule AshCredo.Check.Warning.WildcardAcceptOnActionTest do
     assert [_, _] = issues
     assert find_by_message(issues, "Default `create` action")
     assert find_by_message(issues, "Default `update` action")
+    assert Enum.all?(issues, &(&1.line_no == 5))
+    assert Enum.all?(issues, &(&1.line_no == 5))
   end
 
   test "reports issue for inline accept: :* on create" do

--- a/test/ash_credo/introspection/ash_call_resolver_test.exs
+++ b/test/ash_credo/introspection/ash_call_resolver_test.exs
@@ -7,15 +7,9 @@ defmodule AshCredo.Introspection.AshCallResolverTest do
   call shapes below. They all resolve against the loadable fixture
   `AshCredoFixtures.Blog.Post` (primary key `:id`, primary `:read` action).
   """
-  use AshCredo.CheckCase
+  use AshCredo.CheckCase, clear_cache: true
 
   alias AshCredo.Introspection.AshCallResolver
-  alias AshCredo.Introspection.Compiled, as: CompiledIntrospection
-
-  setup do
-    CompiledIntrospection.clear_cache()
-    :ok
-  end
 
   defp sites(source), do: source |> source_file() |> AshCallResolver.sites()
 

--- a/test/ash_credo/introspection/compiled_test.exs
+++ b/test/ash_credo/introspection/compiled_test.exs
@@ -6,17 +6,12 @@ defmodule AshCredo.Introspection.CompiledTest do
   error propagation are only exercised here. Each resolves against the
   loadable `AshCredoFixtures.*` resources.
   """
-  use ExUnit.Case, async: false
+  use AshCredo.CheckCase, clear_cache: true
 
   alias AshCredo.Introspection.Compiled
 
   @post AshCredoFixtures.Blog.Post
   @plain AshCredoFixtures.Plain
-
-  setup do
-    Compiled.clear_cache()
-    :ok
-  end
 
   describe "resource aspect accessors" do
     test "domain/1 returns the declared domain" do

--- a/test/ash_credo/introspection_test.exs
+++ b/test/ash_credo/introspection_test.exs
@@ -233,7 +233,7 @@ defmodule AshCredo.IntrospectionTest do
       """
 
       calls = AshCallScanner.calls(source_file(source))
-      assert [_] = calls
+      assert [{{:., _, [{:__aliases__, _, [:Ash]}, :read!]}, _, [_]}] = calls
     end
 
     test "finds direct Ash calls" do
@@ -246,7 +246,7 @@ defmodule AshCredo.IntrospectionTest do
       """
 
       calls = AshCallScanner.calls(source_file(source))
-      assert [_] = calls
+      assert [{{:., _, [{:__aliases__, _, [:Ash]}, :read!]}, _, [_]}] = calls
     end
 
     test "finds aliased Ash calls" do
@@ -261,7 +261,8 @@ defmodule AshCredo.IntrospectionTest do
       """
 
       calls = AshCallScanner.calls(source_file(source))
-      assert [_] = calls
+      # The raw AST keeps the alias spelling; expansion happens at detection.
+      assert [{{:., _, [{:__aliases__, _, [:A]}, :read!]}, _, [_]}] = calls
     end
 
     test "finds function-local aliases before the call site" do
@@ -275,7 +276,7 @@ defmodule AshCredo.IntrospectionTest do
       """
 
       calls = AshCallScanner.calls(source_file(source))
-      assert [_] = calls
+      assert [{{:., _, [{:__aliases__, _, [:A]}, :read!]}, _, [_]}] = calls
     end
 
     test "finds calls aliased via require ... as:" do
@@ -325,7 +326,8 @@ defmodule AshCredo.IntrospectionTest do
       """
 
       calls = AshCallScanner.calls(source_file(source))
-      assert [_] = calls
+      # Only the call after the alias is visible; `before_alias` is not.
+      assert [{{:., _, [{:__aliases__, _, [:A]}, :read!]}, _, [_]}] = calls
     end
 
     test "does not find non-Ash calls" do
@@ -357,7 +359,11 @@ defmodule AshCredo.IntrospectionTest do
       """
 
       calls = AshCallScanner.calls(source_file(source))
-      assert [_, _] = calls
+
+      assert [
+               {{:., _, [{:__aliases__, _, [:Ash]}, :read!]}, _, _},
+               {{:., _, [{:__aliases__, _, [:Ash]}, :create!]}, _, _}
+             ] = calls
     end
   end
 
@@ -400,7 +406,7 @@ defmodule AshCredo.IntrospectionTest do
       """
 
       calls = AshCallScanner.calls_with_module(source_file(source))
-      assert [_] = calls
+      assert [{{{:., _, [{:__aliases__, _, [:A]}, :read!]}, _, _}, [:Ash]}] = calls
     end
   end
 
@@ -559,7 +565,7 @@ defmodule AshCredo.IntrospectionTest do
     test "finds all attribute entities" do
       attrs = first_resource_section(@ash_resource, :attributes)
       attributes = Introspection.entities(attrs, :attribute)
-      assert [_, _] = attributes
+      assert [{:attribute, _, [:title | _]}, {:attribute, _, [:body | _]}] = attributes
     end
 
     test "returns empty list for nil section" do
@@ -746,8 +752,11 @@ defmodule AshCredo.IntrospectionTest do
 
       actions = first_resource_section(source, :actions)
 
-      assert [_, _] = Introspection.action_entities(actions, [:read, :create])
-      assert [_, _, _] = Introspection.action_entities(actions)
+      typed = Introspection.action_entities(actions, [:read, :create])
+      assert Enum.map(typed, &Introspection.entity_name/1) == [:read, :create]
+
+      all = Introspection.action_entities(actions)
+      assert Enum.map(all, &Introspection.entity_name/1) == [:create, :read, :custom]
     end
   end
 
@@ -1020,7 +1029,7 @@ defmodule AshCredo.IntrospectionTest do
 
       policies = first_resource_section(source, :policies)
       entities = Introspection.policy_entities(policies)
-      assert [_, _] = entities
+      assert [{:policy, _, _}, {:bypass, _, _}] = entities
     end
 
     test "finds policies nested inside policy_group" do
@@ -1040,7 +1049,7 @@ defmodule AshCredo.IntrospectionTest do
 
       policies = first_resource_section(source, :policies)
       entities = Introspection.policy_entities(policies)
-      assert [_] = entities
+      assert [{:policy, _, _}] = entities
     end
 
     test "returns empty list for nil" do

--- a/test/support/check_case.ex
+++ b/test/support/check_case.ex
@@ -1,13 +1,29 @@
 defmodule AshCredo.CheckCase do
   @moduledoc false
 
-  defmacro __using__(_opts) do
+  alias AshCredo.Introspection.Compiled
+
+  # `clear_cache: true` resets the compiled-introspection cache before each
+  # test - the shared setup for every test module exercising checks that
+  # query compiled fixture modules. The setup body calls through the
+  # imported helper below so the quoted code stays alias-free.
+  defmacro __using__(opts) do
     quote do
       use ExUnit.Case
 
       import AshCredo.CheckCase
+
+      if unquote(opts[:clear_cache]) do
+        setup do
+          clear_compiled_cache()
+          :ok
+        end
+      end
     end
   end
+
+  # The `clear_cache: true` setup target.
+  def clear_compiled_cache, do: Compiled.clear_cache()
 
   # Raises on unparsable source: Credo returns an `:invalid` SourceFile
   # for broken code and this suite's AST-walking checks then report zero
@@ -54,4 +70,9 @@ defmodule AshCredo.CheckCase do
   # Returns the issue triggers as a sorted list - convenient for ordered
   # equality assertions when the exact issue ordering is irrelevant.
   def sorted_triggers(entries), do: entries |> Enum.map(& &1.trigger) |> Enum.sort()
+
+  # Returns the issue line numbers as a sorted list. Comparing against the
+  # full expected list pins both the anchors and the issue count - prefer
+  # `sorted_lines(issues) == [5, 5]` over an `Enum.all?` on `line_no`.
+  def sorted_lines(records), do: records |> Enum.map(& &1.line_no) |> Enum.sort()
 end


### PR DESCRIPTION
## Motivation

Multi-issue tests asserted shapes like `assert [_, _]`, which prove the issue count and nothing else - a check that fired on the wrong line, with the wrong trigger, or returned the wrong AST node still passed. Pinning the identifying fields makes these tests fail on the actual regression they exist to catch. Doing that surfaced two repetitions worth hoisting into `CheckCase`: the sorted line-number pipeline (22 call sites) and the identical `clear_cache` setup block (twelve test modules).

## Changes

- Pin `line_no` (and triggers where missing) in every multi-issue check test across eleven test files
- Bind and assert trigger/line on the count-only single-issue assertions in `RaisingCall` and `AuthorizeFalse`
- Assert the returned call AST shapes in the `AshCallScanner` tests, including that raw ASTs keep the alias spelling
- Assert entity names instead of counts for `entities/2`, `action_entities/2`, and `policy_entities/1`
- Add `CheckCase.sorted_lines/1` mirroring `sorted_triggers/1`; comparing the full expected list also pins the issue count, so it replaces both the inline pipelines and the weaker `Enum.all?` on `line_no`
- Convert trigger membership checks and per-trigger `Enum.all?` sites to exact `sorted_triggers/1` comparisons, and use `trigger_set/1` where an inline `MapSet.new` duplicated it
- Add a `clear_cache: true` option to `CheckCase.__using__/1` and drop the duplicated setup block from twelve test modules; `compiled_check_test` keeps its custom `on_exit` variant
- Leave `cache_test`'s exactly-one-winner race assertion count-only on purpose: there the count is the semantics
