### PR TITLE
fix: model the alias a defmodule creates instead of guessing nesting

### DIFF
--- a/lib/ash_credo/introspection/aliases.ex
+++ b/lib/ash_credo/introspection/aliases.ex
@@ -70,6 +70,25 @@ defmodule AshCredo.Introspection.Aliases do
   def defmodule_literal_segments(_), do: nil
 
   @doc """
+  Registers the alias a `defmodule` itself creates in the enclosing
+  lexical scope: after `defmodule Post do ... end` inside `MyApp.Blog`,
+  `Post` refers to `MyApp.Blog.Post` for the rest of the enclosing body.
+  A dotted name aliases its first segment (`defmodule Blog.Article`
+  inside `MyApp` makes `Blog` mean `MyApp.Blog`). Non-literal names and
+  unknown absolute paths register nothing.
+  """
+  def define_defmodule_alias(%Macro.Env{} = env, defmodule_ast, child_absolute) do
+    with literal when is_list(literal) <- defmodule_literal_segments(defmodule_ast),
+         true <- atom_segments?(literal),
+         true <- is_list(child_absolute) and atom_segments?(child_absolute),
+         target when target != [] <- Enum.drop(child_absolute, -(length(literal) - 1)) do
+      define(env, :alias, [], Module.concat(target), [])
+    else
+      _ -> env
+    end
+  end
+
+  @doc """
   Resolves a literal `defmodule` name into absolute module segments through
   the visible env.
 

--- a/lib/ash_credo/introspection/ash_call_resolver.ex
+++ b/lib/ash_credo/introspection/ash_call_resolver.ex
@@ -186,7 +186,7 @@ defmodule AshCredo.Introspection.AshCallResolver do
   # explicit `Ash.read!(MyApp.Post, action: :read)` form, and so a `:not_loadable`
   # diagnostic still fires for projects that only ever call the bare shape.
   defp implicit_read_sites(segments, ctx) do
-    case resolve_resource(segments, ctx) do
+    case resolve_resource(segments) do
       {:ok, _resource, %{actions: actions}} = resolution ->
         case primary_read_action_name(actions) do
           nil -> []
@@ -301,44 +301,23 @@ defmodule AshCredo.Introspection.AshCallResolver do
   end
 
   defp build_site(segments, action_name, ctx) do
-    build_site_with(ctx, action_name, resolve_resource(segments, ctx))
+    build_site_with(ctx, action_name, resolve_resource(segments))
   end
 
-  defp resolve_resource(segments, ctx) do
+  # No enclosing-module fallback here: a bare `Post` inside
+  # `defmodule MyApp.Blog` is the top-level `Post` unless a nested
+  # `defmodule Post` (or an alias) precedes it, and the scanner registers
+  # that defmodule-created alias, so `segments` arrive fully resolved.
+  defp resolve_resource(segments) do
     resource = Module.concat(segments)
 
     case CompiledIntrospection.inspect_module(resource) do
-      {:ok, info} ->
-        {:ok, resource, info}
-
-      {:error, :not_a_resource} ->
-        :not_a_resource
-
-      {:error, :ash_missing} ->
-        :ash_missing
-
-      {:error, :not_loadable} ->
-        case try_implicit_resolution(segments, ctx) do
-          {:ok, atom, info} -> {:ok, atom, info}
-          :error -> {:not_loadable, resource}
-        end
+      {:ok, info} -> {:ok, resource, info}
+      {:error, :not_a_resource} -> :not_a_resource
+      {:error, :ash_missing} -> :ash_missing
+      {:error, :not_loadable} -> {:not_loadable, resource}
     end
   end
-
-  # Elixir implicitly aliases direct sub-modules: inside `defmodule MyApp.Blog`,
-  # `Post` refers to `MyApp.Blog.Post`. If the direct resolution of `segments`
-  # is not loadable, try prepending the enclosing defmodule's absolute segments.
-  defp try_implicit_resolution(segments, %{call_info: %{enclosing_module_segments: enclosing}})
-       when is_list(enclosing) and enclosing != [] do
-    candidate = Module.concat(enclosing ++ segments)
-
-    case CompiledIntrospection.inspect_module(candidate) do
-      {:ok, info} -> {:ok, candidate, info}
-      _ -> :error
-    end
-  end
-
-  defp try_implicit_resolution(_segments, _ctx), do: :error
 
   defp builder_prefix([:Ash, :Changeset]), do: :changeset_to
   defp builder_prefix([:Ash, :Query]), do: :query_to

--- a/lib/ash_credo/introspection/ash_call_scanner.ex
+++ b/lib/ash_credo/introspection/ash_call_scanner.ex
@@ -122,11 +122,19 @@ defmodule AshCredo.Introspection.AshCallScanner do
     {ast, maybe_record_binding(state, lhs, rhs)}
   end
 
+  # A defmodule aliases its (first literal) name in the enclosing scope
+  # for the rest of that body, so the alias is registered after the
+  # defmodule's own frames are gone and the parent frame is current again.
   defp leave_node({:defmodule, _, _} = ast, state) do
-    {ast,
-     state
-     |> pop_module_stack()
-     |> maybe_leave_lexical_scope(:defmodule)}
+    child_absolute = current_module_segments(state)
+
+    state =
+      state
+      |> pop_module_stack()
+      |> maybe_leave_lexical_scope(:defmodule)
+      |> register_defmodule_alias(ast, child_absolute)
+
+    {ast, state}
   end
 
   defp leave_node({node_name, _, _} = ast, state)
@@ -227,6 +235,11 @@ defmodule AshCredo.Introspection.AshCallScanner do
 
   defp capture_directive(%{env_frames: [head | rest]} = state, directive_ast) do
     updated = Aliases.apply_directive(head, directive_ast, current_module_segments(state))
+    %{state | env_frames: [updated | rest]}
+  end
+
+  defp register_defmodule_alias(%{env_frames: [head | rest]} = state, ast, child_absolute) do
+    updated = Aliases.define_defmodule_alias(head, ast, child_absolute)
     %{state | env_frames: [updated | rest]}
   end
 

--- a/lib/ash_credo/introspection/lexical_scope_walker.ex
+++ b/lib/ash_credo/introspection/lexical_scope_walker.ex
@@ -257,9 +257,18 @@ defmodule AshCredo.Introspection.LexicalScopeWalker do
     {node, {user, scope}}
   end
 
-  defp leave({:defmodule, _, _} = node, {user, scope}, on_leave, _options) do
+  # A defmodule aliases its (first literal) name in the enclosing scope
+  # for the rest of that body; the alias lands in the frame that is
+  # current after the module stack pops back to the parent.
+  defp leave({:defmodule, _, _} = node, {user, scope}, on_leave, options) do
     user = on_leave.(node, scope, user)
-    scope = pop_module_stack(scope)
+    child_absolute = current_module_segments(scope)
+
+    scope =
+      scope
+      |> pop_module_stack()
+      |> register_defmodule_alias(node, child_absolute, options)
+
     {node, {user, scope}}
   end
 
@@ -321,6 +330,26 @@ defmodule AshCredo.Introspection.LexicalScopeWalker do
 
   defp capture_directive(%Scope{env_frames: frames} = scope, node, _options) do
     updated = Aliases.apply_directive(env(scope), node, current_module_segments(scope))
+
+    case frames do
+      [_head | rest] -> %{scope | env_frames: [updated | rest]}
+      [] -> %{scope | env_frames: [updated]}
+    end
+  end
+
+  defp register_defmodule_alias(%Scope{quote_depth: depth} = scope, _node, _child_absolute, %{
+         track_quote: true,
+         track_aliases_in_quote: false
+       })
+       when depth > 0, do: scope
+
+  defp register_defmodule_alias(
+         %Scope{env_frames: frames} = scope,
+         node,
+         child_absolute,
+         _options
+       ) do
+    updated = Aliases.define_defmodule_alias(env(scope), node, child_absolute)
 
     case frames do
       [_head | rest] -> %{scope | env_frames: [updated | rest]}

--- a/test/ash_credo/check/refactor/raising_call_test.exs
+++ b/test/ash_credo/check/refactor/raising_call_test.exs
@@ -118,6 +118,24 @@ defmodule AshCredo.Check.Refactor.RaisingCallTest do
     assert [] = run_check(RaisingCall, source, excluded_functions: [{Ash, :read!}])
   end
 
+  test "a nested defmodule named Ash shadows the real Ash for later calls" do
+    # After `defmodule Ash do ... end` inside MyApp, `Ash.read!` is
+    # `MyApp.Ash.read!` - not an Ash API call, so nothing to flag.
+    source = """
+    defmodule MyApp do
+      defmodule Ash do
+        def read!(resource), do: resource
+      end
+
+      def go do
+        Ash.read!(MyApp.User)
+      end
+    end
+    """
+
+    assert [] = run_check(RaisingCall, source)
+  end
+
   describe "message shape varies with the counterpart's return type" do
     test "tuple-returning APIs (Ash.read!) get the tuple-matching message" do
       source = """

--- a/test/ash_credo/check/refactor/use_code_interface_test.exs
+++ b/test/ash_credo/check/refactor/use_code_interface_test.exs
@@ -521,10 +521,16 @@ defmodule AshCredo.Check.Refactor.UseCodeInterfaceTest do
 
   # ── Implicit submodule alias ───────────────────────────────────────────────
 
-  describe "implicit submodule alias" do
-    test "unqualified resource resolves to enclosing_module.Resource" do
+  describe "defmodule-created aliases" do
+    test "a nested defmodule aliases its name for the rest of the enclosing body" do
+      # After `defmodule Post do ... end` inside `AshCredoFixtures.Blog`,
+      # `Post` refers to `AshCredoFixtures.Blog.Post` - resolution goes to
+      # the compiled fixture of that name.
       source = """
       defmodule AshCredoFixtures.Blog do
+        defmodule Post do
+        end
+
         def list_published do
           Ash.read!(Post, action: :published)
         end
@@ -535,9 +541,41 @@ defmodule AshCredo.Check.Refactor.UseCodeInterfaceTest do
       assert issue.message =~ "AshCredoFixtures.Blog.Post.published_posts!"
     end
 
-    test "implicit alias is not applied when a matching top-level module exists" do
-      # `AshCredoFixtures.Blog.Post` is loadable directly, so the direct
-      # resolution wins and implicit lookup is not consulted.
+    test "a bare name without a nested defmodule is the top-level module" do
+      # Elixir does NOT alias `Post` merely because the code sits inside
+      # `defmodule AshCredoFixtures.Blog` - the ref is the top-level `Post`,
+      # which is not loadable here, so the config diagnostic fires instead
+      # of a suggestion borrowed from `AshCredoFixtures.Blog.Post`.
+      source = """
+      defmodule AshCredoFixtures.Blog do
+        def list_published do
+          Ash.read!(Post, action: :published)
+        end
+      end
+      """
+
+      assert [issue] = run_check(UseCodeInterface, source)
+      assert issue.message =~ "Could not load `Post`"
+    end
+
+    test "before the nested defmodule the bare name is still top-level" do
+      # The defmodule-created alias only exists after the definition.
+      source = """
+      defmodule AshCredoFixtures.Blog do
+        def list_published do
+          Ash.read!(Post, action: :published)
+        end
+
+        defmodule Post do
+        end
+      end
+      """
+
+      assert [issue] = run_check(UseCodeInterface, source)
+      assert issue.message =~ "Could not load `Post`"
+    end
+
+    test "a fully qualified ref resolves directly regardless of nesting" do
       source = """
       defmodule AshCredoFixtures.Accounts do
         def list_published do

--- a/test/ash_credo/introspection_test.exs
+++ b/test/ash_credo/introspection_test.exs
@@ -365,6 +365,63 @@ defmodule AshCredo.IntrospectionTest do
                {{:., _, [{:__aliases__, _, [:Ash]}, :create!]}, _, _}
              ] = calls
     end
+
+    test "a nested defmodule named Ash shadows the real Ash afterwards" do
+      # After `defmodule Ash do ... end` inside MyApp, `Ash` refers to
+      # `MyApp.Ash` for the rest of the body - the call is not an Ash
+      # API call and must not be collected.
+      source = """
+      defmodule MyApp do
+        defmodule Ash do
+          def read!(resource), do: resource
+        end
+
+        def go do
+          Ash.read!(MyApp.User)
+        end
+      end
+      """
+
+      assert AshCallScanner.calls(source_file(source)) == []
+    end
+
+    test "a dotted nested defmodule aliases its first segment" do
+      # `defmodule Ash.Helpers` inside MyApp defines `MyApp.Ash.Helpers`
+      # and aliases `Ash` to `MyApp.Ash`, so a later `Ash.read!` is
+      # `MyApp.Ash.read!`, not the real Ash.
+      source = """
+      defmodule MyApp do
+        defmodule Ash.Helpers do
+          def noop, do: :ok
+        end
+
+        def go do
+          Ash.read!(MyApp.User)
+        end
+      end
+      """
+
+      assert AshCallScanner.calls(source_file(source)) == []
+    end
+
+    test "the defmodule-created alias does not leak past the enclosing module" do
+      source = """
+      defmodule MyApp do
+        defmodule Ash do
+          def read!(resource), do: resource
+        end
+      end
+
+      defmodule MyApp.Accounts do
+        def go do
+          Ash.read!(MyApp.User)
+        end
+      end
+      """
+
+      assert [{{:., _, [{:__aliases__, _, [:Ash]}, :read!]}, _, _}] =
+               AshCallScanner.calls(source_file(source))
+    end
   end
 
   describe "ash_api_calls_with_module/1" do


### PR DESCRIPTION
## Motivation

`AshCallResolver` carried a fallback claiming Elixir "implicitly aliases direct sub-modules", resolving an unloadable bare `Post` inside `defmodule MyApp.Blog` to `MyApp.Blog.Post`. Elixir has no such rule, verified against a running compiler: a bare name is the top-level module unless a nested `defmodule Post` (or an explicit alias) precedes it, the alias exists only after that definition, and a dotted nested `defmodule Blog.Article` aliases just its first segment. The fallback therefore borrowed suggestions from the wrong module for genuinely top-level references, while the real defmodule-created alias went unmodeled everywhere - so a nested `defmodule Ash` left later `Ash.read!` calls misattributed to the real Ash API by every scanner-based check.

## Changes

- Add `Aliases.define_defmodule_alias/3`: registers the alias a `defmodule` creates in its enclosing scope, first-segment semantics included
- Register it in both traversal paths (`AshCallScanner` and `LexicalScopeWalker`, quote-depth guarded like other directives) when a definition ends, so the alias is visible for the rest of the enclosing body and nowhere else
- Drop `try_implicit_resolution` from `AshCallResolver`: names now arrive fully resolved, and genuinely unresolvable bare refs surface as the `:not_loadable` diagnostic they are
- Replace the tests pinning the old guess with ones pinning the real semantics: alias after the nested definition, top-level before it or without it, first-segment aliasing for dotted names, no leakage past the enclosing module, and shadowing coverage on both traversal paths
