### PR TITLE
feat: add excluded_paths to UseCodeInterface

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ The following checks accept custom parameters:
 | `Refactor.RaisingCall` | `flag_bang_only_apis` | `false` | When `true`, also flag bangs whose non-bang counterpart doesn't exist (e.g. `Ash.stream!`, `Ash.Seed.seed!`) with a generic "ensure failures are properly handled" message. Default is `false` since the suggested non-bang twin wouldn't exist for these calls; opt in only if your team policy is "no bare bang calls anywhere" |
 | `Refactor.UseCodeInterface` | `enforce_code_interface_in_domain` | `true` | See [Adapting UseCodeInterface](#adapting-usecodeinterface-to-your-teams-conventions) below |
 | `Refactor.UseCodeInterface` | `enforce_code_interface_outside_domain` | `true` | See [Adapting UseCodeInterface](#adapting-usecodeinterface-to-your-teams-conventions) below |
+| `Refactor.UseCodeInterface` | `excluded_paths` | `[~r"/test/", "test"]` | Paths or regexes to skip. Binary entries match as path segments or full file paths. Defaults to test directories, where raw `Ash.*` calls are idiomatic setup code |
 | `Refactor.UseCodeInterface` | `prefer_interface_scope` | `:auto` | See [Adapting UseCodeInterface](#adapting-usecodeinterface-to-your-teams-conventions) below |
 | `Design.MissingCodeInterface` | `excluded_actions` | `[]` | List of `"Module.action_name"` strings whose missing interface should be suppressed (e.g. `AshAuthentication`-generated actions) |
 | `Design.MissingIdentity` | `identity_candidates` | `~w(email username slug handle phone)a` | Attribute names to suggest adding identities for |

--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ The following checks accept custom parameters:
 
 ### Adapting `UseCodeInterface` to your team's conventions
 
-`UseCodeInterface` accepts three params that map to common code-interface
+`UseCodeInterface` accepts params that map to common code-interface
 philosophies. The two `enforce_*` flags decide *which call sites* the check
 fires on; `prefer_interface_scope` decides *which interface* the suggestion
 points at. They compose freely.

--- a/lib/ash_credo/check/refactor/use_code_interface.ex
+++ b/lib/ash_credo/check/refactor/use_code_interface.ex
@@ -49,7 +49,7 @@ defmodule AshCredo.Check.Refactor.UseCodeInterface do
 
       ## Configuration
 
-      Three params let you adapt the check to a team's code-interface
+      These params adapt the check to a team's code-interface
       conventions:
 
         * `enforce_code_interface_in_domain` (default `true`) - when
@@ -113,26 +113,28 @@ defmodule AshCredo.Check.Refactor.UseCodeInterface do
   alias AshCredo.Introspection.Compiled, as: CompiledIntrospection
   alias AshCredo.PathFilter
 
+  # Path filtering lives here rather than in `run_compiled/2` so an
+  # excluded file cannot emit the Ash-missing diagnostic either - the
+  # guard consults `active?/2` before checking Ash availability.
   @impl AshCredo.CompiledCheck
-  def active?(_source_file, params) do
-    Params.get(params, :enforce_code_interface_in_domain, __MODULE__) or
-      Params.get(params, :enforce_code_interface_outside_domain, __MODULE__)
+  def active?(source_file, params) do
+    enforcing? =
+      Params.get(params, :enforce_code_interface_in_domain, __MODULE__) or
+        Params.get(params, :enforce_code_interface_outside_domain, __MODULE__)
+
+    excluded_paths = Params.get(params, :excluded_paths, __MODULE__)
+
+    enforcing? and not PathFilter.excluded?(source_file.filename, excluded_paths)
   end
 
   @impl AshCredo.CompiledCheck
   def run_compiled(source_file, params) do
-    excluded_paths = Params.get(params, :excluded_paths, __MODULE__)
+    issue_meta = IssueMeta.for(source_file, params)
+    config = load_config(params)
 
-    if PathFilter.excluded?(source_file.filename, excluded_paths) do
-      []
-    else
-      issue_meta = IssueMeta.for(source_file, params)
-      config = load_config(params)
-
-      source_file
-      |> AshCallResolver.sites()
-      |> Enum.flat_map(&check_site(&1, issue_meta, config))
-    end
+    source_file
+    |> AshCallResolver.sites()
+    |> Enum.flat_map(&check_site(&1, issue_meta, config))
   end
 
   defp load_config(params) do

--- a/lib/ash_credo/check/refactor/use_code_interface.ex
+++ b/lib/ash_credo/check/refactor/use_code_interface.ex
@@ -6,6 +6,7 @@ defmodule AshCredo.Check.Refactor.UseCodeInterface do
     param_defaults: [
       enforce_code_interface_in_domain: true,
       enforce_code_interface_outside_domain: true,
+      excluded_paths: [~r"/test/", "test"],
       prefer_interface_scope: :auto
     ],
     explanations: [
@@ -67,6 +68,9 @@ defmodule AshCredo.Check.Refactor.UseCodeInterface do
           always suggests a resource-level interface (useful if you only
           define code interfaces on resources). `:domain` always suggests a
           domain-level interface.
+        * `excluded_paths` (defaults to test directories) - raw `Ash.*`
+          calls in tests and factories are idiomatic setup code, not
+          missing interfaces. Override (e.g. to `[]`) to scan tests too.
 
       Example - a team that allows raw calls inside their domain and only
       defines interfaces on resources:
@@ -98,6 +102,8 @@ defmodule AshCredo.Check.Refactor.UseCodeInterface do
           "Flag raw `Ash.*` calls whose caller shares a domain with the resource. Set to `false` to leave same-domain callers alone (useful for teams that consider raw calls inside `Change`/`Preparation`/`Validation` modules acceptable).",
         enforce_code_interface_outside_domain:
           "Flag raw `Ash.*` calls whose caller is not in the resource's domain. This covers different known domains, plain callers (controller, LiveView, worker), callers that are an `Ash.Resource` with no `:domain`, and resources that cannot be loaded. Set to `false` to silence all of them.",
+        excluded_paths:
+          "Paths or regexes to skip. Defaults to test directories, where raw `Ash.*` calls are idiomatic setup code.",
         prefer_interface_scope:
           "Controls which interface the check points at. `:auto` (default) follows the \"in-domain → resource, outside-domain → domain\" heuristic. `:resource` always suggests a resource-level interface. `:domain` always suggests a domain-level interface."
       ]
@@ -105,6 +111,7 @@ defmodule AshCredo.Check.Refactor.UseCodeInterface do
 
   alias AshCredo.Introspection.{AshCallResolver, AshCallSite}
   alias AshCredo.Introspection.Compiled, as: CompiledIntrospection
+  alias AshCredo.PathFilter
 
   @impl AshCredo.CompiledCheck
   def active?(_source_file, params) do
@@ -114,12 +121,18 @@ defmodule AshCredo.Check.Refactor.UseCodeInterface do
 
   @impl AshCredo.CompiledCheck
   def run_compiled(source_file, params) do
-    issue_meta = IssueMeta.for(source_file, params)
-    config = load_config(params)
+    excluded_paths = Params.get(params, :excluded_paths, __MODULE__)
 
-    source_file
-    |> AshCallResolver.sites()
-    |> Enum.flat_map(&check_site(&1, issue_meta, config))
+    if PathFilter.excluded?(source_file.filename, excluded_paths) do
+      []
+    else
+      issue_meta = IssueMeta.for(source_file, params)
+      config = load_config(params)
+
+      source_file
+      |> AshCallResolver.sites()
+      |> Enum.flat_map(&check_site(&1, issue_meta, config))
+    end
   end
 
   defp load_config(params) do

--- a/test/ash_credo/check/refactor/use_code_interface_test.exs
+++ b/test/ash_credo/check/refactor/use_code_interface_test.exs
@@ -410,6 +410,39 @@ defmodule AshCredo.Check.Refactor.UseCodeInterfaceTest do
     end
   end
 
+  describe "excluded_paths" do
+    test "skips files under test directories by default" do
+      source = """
+      defmodule MyApp.Factory do
+        def post do
+          Ash.read!(AshCredoFixtures.Blog.Post, action: :published)
+        end
+      end
+      """
+
+      assert [] =
+               run_check(UseCodeInterface, source, __filename__: "test/support/factory.ex")
+    end
+
+    test "can be overridden to also scan test files" do
+      source = """
+      defmodule MyApp.Factory do
+        def post do
+          Ash.read!(AshCredoFixtures.Blog.Post, action: :published)
+        end
+      end
+      """
+
+      assert [issue] =
+               run_check(UseCodeInterface, source,
+                 __filename__: "test/support/factory.ex",
+                 excluded_paths: []
+               )
+
+      assert issue.message =~ "published_posts"
+    end
+  end
+
   # ── Long-tail suggestion families ──────────────────────────────────────────
   #
   # These exercise the message variants that only appear with specific

--- a/test/ash_credo/check/refactor/use_code_interface_test.exs
+++ b/test/ash_credo/check/refactor/use_code_interface_test.exs
@@ -424,6 +424,24 @@ defmodule AshCredo.Check.Refactor.UseCodeInterfaceTest do
                run_check(UseCodeInterface, source, __filename__: "test/support/factory.ex")
     end
 
+    test "an excluded file emits no Ash-missing diagnostic either" do
+      # The path filter lives in active?/2, which the compiled-check guard
+      # consults before the Ash-availability check - so excluded files
+      # stay fully silent even when Ash is not loadable.
+      Cache.put({CompiledIntrospection, :ash_available?}, false)
+
+      source = """
+      defmodule MyApp.Factory do
+        def post do
+          Ash.read!(AshCredoFixtures.Blog.Post, action: :published)
+        end
+      end
+      """
+
+      assert [] =
+               run_check(UseCodeInterface, source, __filename__: "test/support/factory.ex")
+    end
+
     test "can be overridden to also scan test files" do
       source = """
       defmodule MyApp.Factory do


### PR DESCRIPTION
## Motivation

Raw `Ash.*` calls in tests and factories are idiomatic setup code, not missing code interfaces, so `UseCodeInterface` nagging there is noise. The sibling checks that share this reality (`RaisingCall`, `AuthorizeFalse`, the accept checks) already skip test directories by default.

## Changes

- Add an `excluded_paths` param to `UseCodeInterface`, defaulting to test directories like its siblings; override with `[]` to scan tests too
- Document the param in the check explanation and the README table
