### PR TITLE
fix: skip identity suggestion for a sole primary-key attribute

### DIFF
--- a/lib/ash_credo/check/design/missing_identity.ex
+++ b/lib/ash_credo/check/design/missing_identity.ex
@@ -15,6 +15,10 @@ defmodule AshCredo.Check.Design.MissingIdentity do
             identity :unique_email, [:email]
           end
 
+      An attribute that is the sole primary key is already unique and is
+      not flagged. Members of a composite primary key still are: only the
+      key tuple is unique there, not the attribute itself.
+
       This check uses Ash's runtime introspection (`Ash.Resource.Info`) to
       see the fully-resolved attribute and identity lists - including
       contributions from extensions like `AshAuthentication`, which adds an
@@ -58,7 +62,7 @@ defmodule AshCredo.Check.Design.MissingIdentity do
 
   defp flag_missing_identities(
          resource,
-         %{attributes: attributes, identities: identities},
+         %{attributes: attributes, identities: identities, primary_key: primary_key},
          context,
          candidates,
          issue_meta
@@ -68,9 +72,14 @@ defmodule AshCredo.Check.Design.MissingIdentity do
 
     attributes
     |> Enum.filter(&(&1.name in candidates))
-    |> Enum.reject(&(&1.name in covered_fields))
+    |> Enum.reject(&(&1.name in covered_fields or sole_primary_key?(&1, primary_key)))
     |> Enum.map(&missing_identity_issue(&1, resource, issue_line, issue_meta))
   end
+
+  # A sole primary-key attribute is already unique - an identity would be
+  # redundant. Members of a composite key stay flagged: only the tuple is
+  # unique there, so the attribute itself may still want an identity.
+  defp sole_primary_key?(%{name: name}, primary_key), do: primary_key == [name]
 
   defp collect_identity_fields(identities) do
     identities

--- a/lib/ash_credo/check/design/missing_identity.ex
+++ b/lib/ash_credo/check/design/missing_identity.ex
@@ -16,8 +16,10 @@ defmodule AshCredo.Check.Design.MissingIdentity do
           end
 
       An attribute that is the sole primary key is already unique and is
-      not flagged. Members of a composite primary key still are: only the
-      key tuple is unique there, not the attribute itself.
+      not flagged - for uniqueness enforcement an identity adds nothing
+      there. Define one anyway if you want to reference it by name, e.g.
+      via `upsert_identity:`. Members of a composite primary key are still
+      flagged: only the key tuple is unique, not the attribute itself.
 
       This check uses Ash's runtime introspection (`Ash.Resource.Info`) to
       see the fully-resolved attribute and identity lists - including
@@ -76,9 +78,10 @@ defmodule AshCredo.Check.Design.MissingIdentity do
     |> Enum.map(&missing_identity_issue(&1, resource, issue_line, issue_meta))
   end
 
-  # A sole primary-key attribute is already unique - an identity would be
-  # redundant. Members of a composite key stay flagged: only the tuple is
-  # unique there, so the attribute itself may still want an identity.
+  # A sole primary-key attribute is already unique, so no identity is
+  # needed for uniqueness enforcement (named identities for e.g.
+  # `upsert_identity:` are a deliberate choice, not a lint gap). Members
+  # of a composite key stay flagged: only the tuple is unique there.
   defp sole_primary_key?(%{name: name}, primary_key), do: primary_key == [name]
 
   defp collect_identity_fields(identities) do

--- a/test/ash_credo/check/design/missing_identity_test.exs
+++ b/test/ash_credo/check/design/missing_identity_test.exs
@@ -82,4 +82,30 @@ defmodule AshCredo.Check.Design.MissingIdentityTest do
     assert issue.message =~ "Could not load"
     assert issue.message =~ "Totally.Fake.Resource"
   end
+
+  test "no issue when the candidate attribute is the sole primary key" do
+    # EmailKey's :email IS the primary key - already unique, identity
+    # would be redundant.
+    source = """
+    defmodule AshCredoFixtures.Accounts.EmailKey do
+      use Ash.Resource, domain: AshCredoFixtures.Accounts
+    end
+    """
+
+    assert [] = run_check(MissingIdentity, source)
+  end
+
+  test "still flags a candidate that is only part of a composite primary key" do
+    # TenantEmailKey's key is {tenant_id, email} - the tuple is unique,
+    # :email alone is not.
+    source = """
+    defmodule AshCredoFixtures.Accounts.TenantEmailKey do
+      use Ash.Resource, domain: AshCredoFixtures.Accounts
+    end
+    """
+
+    assert [issue] = run_check(MissingIdentity, source)
+    assert issue.trigger == "email"
+    assert issue.message =~ "unique_email"
+  end
 end

--- a/test/support/fixtures/ash_fixtures.ex
+++ b/test/support/fixtures/ash_fixtures.ex
@@ -150,6 +150,48 @@ defmodule AshCredoFixtures.Accounts.Profile do
   end
 end
 
+defmodule AshCredoFixtures.Accounts.EmailKey do
+  @moduledoc """
+  `MissingIdentity` sole-primary-key fixture: `:email` IS the primary key,
+  so it is already unique and an identity would be redundant.
+  """
+
+  use Ash.Resource,
+    domain: AshCredoFixtures.Accounts,
+    validate_domain_inclusion?: false
+
+  actions do
+    defaults [:read]
+    default_accept []
+  end
+
+  attributes do
+    attribute :email, :string, primary_key?: true, allow_nil?: false, public?: true
+  end
+end
+
+defmodule AshCredoFixtures.Accounts.TenantEmailKey do
+  @moduledoc """
+  `MissingIdentity` composite-primary-key fixture: `:email` is one member
+  of a composite key - only the tuple is unique, so the identity
+  suggestion still applies to the attribute.
+  """
+
+  use Ash.Resource,
+    domain: AshCredoFixtures.Accounts,
+    validate_domain_inclusion?: false
+
+  actions do
+    defaults [:read]
+    default_accept []
+  end
+
+  attributes do
+    attribute :tenant_id, :uuid, primary_key?: true, allow_nil?: false, public?: true
+    attribute :email, :string, primary_key?: true, allow_nil?: false, public?: true
+  end
+end
+
 defmodule AshCredoFixtures.Accounts.EmbeddedContact do
   @moduledoc """
   `MissingIdentity` embedded-resource fixture: declares `data_layer: :embedded`
@@ -236,6 +278,8 @@ defmodule AshCredoFixtures.Accounts do
     resource AshCredoFixtures.Accounts.Member
     resource AshCredoFixtures.Accounts.Profile
     resource AshCredoFixtures.Accounts.Account
+    resource AshCredoFixtures.Accounts.EmailKey
+    resource AshCredoFixtures.Accounts.TenantEmailKey
   end
 end
 


### PR DESCRIPTION
## Motivation

`MissingIdentity` suggested a uniqueness identity for candidate attributes like `:email` even when the attribute IS the resource's sole primary key - which is already unique, making the identity redundant and the warning a false positive.

## Changes

- Skip candidates that are the sole primary-key attribute; members of a composite key stay flagged, since only the key tuple is unique there
- Add sole-key and composite-key fixtures pinning both sides
