### PR TITLE
fix: name the missing timestamp side and the domain opt-out

### DIFF
--- a/lib/ash_credo/check/design/missing_timestamps.ex
+++ b/lib/ash_credo/check/design/missing_timestamps.ex
@@ -44,10 +44,12 @@ defmodule AshCredo.Check.Design.MissingTimestamps do
       issue_meta,
       __MODULE__,
       fn attributes ->
-        if has_timestamps?(attributes) do
-          []
-        else
-          [missing_timestamps_issue(context.module_ast, context, issue_meta)]
+        case timestamp_sides(attributes) do
+          {true, true} ->
+            []
+
+          sides ->
+            [missing_timestamps_issue(sides, context.module_ast, context, issue_meta)]
         end
       end
     )
@@ -65,14 +67,11 @@ defmodule AshCredo.Check.Design.MissingTimestamps do
   # `create_timestamp`/`update_timestamp` DSL entries without hard-coding
   # specific attribute names, while still catching partial setups where
   # only one side is present.
-  defp has_timestamps?(attributes) do
-    {has_create?, has_update?} =
-      Enum.reduce(attributes, {false, false}, fn attr, {has_create?, has_update?} ->
-        {has_create? or create_timestamp_attribute?(attr),
-         has_update? or update_timestamp_attribute?(attr)}
-      end)
-
-    has_create? and has_update?
+  defp timestamp_sides(attributes) do
+    Enum.reduce(attributes, {false, false}, fn attr, {has_create?, has_update?} ->
+      {has_create? or create_timestamp_attribute?(attr),
+       has_update? or update_timestamp_attribute?(attr)}
+    end)
   end
 
   defp create_timestamp_attribute?(%{
@@ -102,13 +101,27 @@ defmodule AshCredo.Check.Design.MissingTimestamps do
   # create-timestamp predicate and mask a missing `create_timestamp`.
   defp datetime_attribute_type?(type), do: CompiledIntrospection.datetime_type?(type)
 
-  defp missing_timestamps_issue(module_ast, context, issue_meta) do
+  defp missing_timestamps_issue(sides, module_ast, context, issue_meta) do
     attrs_ast = Introspection.find_dsl_section(module_ast, :attributes)
 
     format_issue(issue_meta,
-      message: "Resource is missing timestamps.",
+      message: missing_timestamps_message(sides),
       trigger: "attributes",
       line_no: Introspection.resource_issue_line(context, attrs_ast)
     )
+  end
+
+  defp missing_timestamps_message({false, false}) do
+    "Resource has no timestamps. Add `timestamps()` to the `attributes` block."
+  end
+
+  defp missing_timestamps_message({false, true}) do
+    "Resource has an update timestamp but no create timestamp. " <>
+      "Add `create_timestamp :inserted_at` to the `attributes` block."
+  end
+
+  defp missing_timestamps_message({true, false}) do
+    "Resource has a create timestamp but no update timestamp. " <>
+      "Add `update_timestamp :updated_at` to the `attributes` block."
   end
 end

--- a/lib/ash_credo/check/warning/missing_domain.ex
+++ b/lib/ash_credo/check/warning/missing_domain.ex
@@ -5,10 +5,14 @@ defmodule AshCredo.Check.Warning.MissingDomain do
     tags: [:ash],
     explanations: [
       check: """
-      In Ash 3.x, resources without a `domain:` option cannot be queried
-      through the standard API.
+      In Ash 3.x, a resource normally declares its domain:
 
           use Ash.Resource, domain: MyApp.Blog
+
+      Without it, code interfaces and domain configuration do not apply,
+      and callers must supply the domain themselves. A resource shared
+      across domains can opt out explicitly with `domain: nil` - the
+      check accepts that and only flags a missing option.
       """
     ]
 
@@ -27,7 +31,9 @@ defmodule AshCredo.Check.Warning.MissingDomain do
     else
       [
         format_issue(issue_meta,
-          message: "Resource is missing a `domain:` option in `use Ash.Resource`.",
+          message:
+            "Resource declares no `domain:` in `use Ash.Resource`. " <>
+              "Name its domain, or pass `domain: nil` explicitly if it is deliberately shared across domains.",
           trigger: "use Ash.Resource",
           line_no: Introspection.resource_issue_line(context)
         )

--- a/test/ash_credo/check/design/missing_timestamps_test.exs
+++ b/test/ash_credo/check/design/missing_timestamps_test.exs
@@ -23,7 +23,8 @@ defmodule AshCredo.Check.Design.MissingTimestampsTest do
     """
 
     assert [issue] = run_check(MissingTimestamps, source)
-    assert issue.message =~ "missing timestamps"
+    assert issue.message =~ "no timestamps"
+    assert issue.message =~ "timestamps()"
   end
 
   test "reports an issue when only `update_timestamp` is present" do
@@ -40,7 +41,23 @@ defmodule AshCredo.Check.Design.MissingTimestampsTest do
     """
 
     assert [issue] = run_check(MissingTimestamps, source)
-    assert issue.message =~ "missing timestamps"
+    assert issue.message =~ "no create timestamp"
+    assert issue.message =~ "create_timestamp :inserted_at"
+    refute issue.message =~ "timestamps()"
+  end
+
+  test "reports the update side when only `create_timestamp` is present" do
+    source = """
+    defmodule AshCredoFixtures.Blog.CreateOnlyTimestamp do
+      use Ash.Resource,
+        domain: AshCredoFixtures.Blog,
+        data_layer: AshPostgres.DataLayer
+    end
+    """
+
+    assert [issue] = run_check(MissingTimestamps, source)
+    assert issue.message =~ "no update timestamp"
+    assert issue.message =~ "update_timestamp :updated_at"
   end
 
   test "no issue when the resource uses `timestamps()`" do

--- a/test/support/fixtures/ash_fixtures.ex
+++ b/test/support/fixtures/ash_fixtures.ex
@@ -74,6 +74,7 @@ defmodule AshCredoFixtures.Blog do
 
     resource AshCredoFixtures.Blog.Article
     resource AshCredoFixtures.Blog.PartialTimestamps
+    resource AshCredoFixtures.Blog.CreateOnlyTimestamp
     resource AshCredoFixtures.Blog.CustomTimestamps
     resource AshCredoFixtures.Blog.Tag
     resource AshCredoFixtures.Blog.Contact
@@ -302,6 +303,28 @@ defmodule AshCredoFixtures.Blog.PartialTimestamps do
     uuid_primary_key :id
     attribute :title, :string, public?: true
     update_timestamp :updated_at
+  end
+end
+
+defmodule AshCredoFixtures.Blog.CreateOnlyTimestamp do
+  @moduledoc """
+  `MissingTimestamps` fixture with only a `create_timestamp`: the check
+  must name the missing update side.
+  """
+
+  use Ash.Resource,
+    domain: AshCredoFixtures.Blog,
+    validate_domain_inclusion?: false
+
+  actions do
+    defaults [:read]
+    default_accept []
+  end
+
+  attributes do
+    uuid_primary_key :id
+    attribute :title, :string, public?: true
+    create_timestamp :inserted_at
   end
 end
 


### PR DESCRIPTION
## Motivation

`MissingTimestamps` computed which timestamp side was absent and then discarded it, reporting the same generic message whether a resource had no timestamps at all or was missing only one side. `MissingDomain` claimed domainless resources "cannot be queried through the standard API", which overstates it - callers can supply the domain, and `domain: nil` is the sanctioned opt-out for resources shared across domains.

## Changes

- `MissingTimestamps` names the missing side with the matching DSL entry (`timestamps()`, `create_timestamp :inserted_at`, or `update_timestamp :updated_at`), with a new create-only fixture covering the third variant
- `MissingDomain` docs and message now describe the actual consequences and point at `domain: nil` as the explicit opt-out the check already accepts
