### PR TITLE
refactor: hoist the actions section line helper into Introspection

### DIFF
--- a/lib/ash_credo/check/design/missing_code_interface.ex
+++ b/lib/ash_credo/check/design/missing_code_interface.ex
@@ -101,7 +101,7 @@ defmodule AshCredo.Check.Design.MissingCodeInterface do
          issue_meta,
          excluded_actions
        ) do
-    actions_line = actions_section_line(module_ast, context)
+    actions_line = Introspection.actions_section_line(module_ast, context)
 
     actions
     |> Enum.reject(fn action ->
@@ -129,11 +129,5 @@ defmodule AshCredo.Check.Design.MissingCodeInterface do
       trigger: "#{action.name}",
       line_no: line
     )
-  end
-
-  defp actions_section_line(module_ast, context) do
-    actions_ast = Introspection.find_dsl_section(module_ast, :actions)
-
-    Introspection.section_issue_line(actions_ast, context.use_line, 1)
   end
 end

--- a/lib/ash_credo/check/design/missing_primary_action.ex
+++ b/lib/ash_credo/check/design/missing_primary_action.ex
@@ -56,7 +56,7 @@ defmodule AshCredo.Check.Design.MissingPrimaryAction do
   end
 
   defp flag_missing_primaries(actions, module_ast, context, issue_meta) do
-    actions_line = actions_section_line(module_ast, context)
+    actions_line = Introspection.actions_section_line(module_ast, context)
     {counts, primaries} = summarise_actions(actions)
 
     for type <- @action_types,
@@ -83,11 +83,5 @@ defmodule AshCredo.Check.Design.MissingPrimaryAction do
 
       {next_counts, next_primaries}
     end)
-  end
-
-  defp actions_section_line(module_ast, context) do
-    actions_ast = Introspection.find_dsl_section(module_ast, :actions)
-
-    Introspection.section_issue_line(actions_ast, context.use_line, 1)
   end
 end

--- a/lib/ash_credo/introspection.ex
+++ b/lib/ash_credo/introspection.ex
@@ -338,6 +338,13 @@ defmodule AshCredo.Introspection do
     section_line(section_ast) || line || fallback
   end
 
+  @doc "Returns the best issue anchor line for a module's `actions` section, falling back to the `use` line and then line 1."
+  def actions_section_line(module_ast, %ResourceContext{use_line: use_line}) do
+    module_ast
+    |> find_dsl_section(:actions)
+    |> section_issue_line(use_line, 1)
+  end
+
   @doc "Returns the best issue anchor line for a resource section, falling back to the `use` line and then `fallback`."
   def resource_issue_line(resource_context, section_ast \\ nil, fallback \\ 1)
 


### PR DESCRIPTION
## Motivation

`MissingPrimaryAction` and `MissingCodeInterface` carried an identical private helper resolving the `actions` section to an issue anchor line.

## Changes

- Hoist it as `Introspection.actions_section_line/2` next to the other line helpers and use it from both checks
