### PR TITLE
fix: flag pinned Time.utc_now in expressions

### DIFF
--- a/lib/ash_credo/check/warning/pinned_time_in_expression.ex
+++ b/lib/ash_credo/check/warning/pinned_time_in_expression.ex
@@ -34,10 +34,14 @@ defmodule AshCredo.Check.Warning.PinnedTimeInExpression do
   alias AshCredo.Introspection.Block
   alias Credo.Code.Name
 
+  # `Time.utc_now` maps to `nil`: Ash has no expression builtin returning
+  # the current time of day, so the message advises passing the value in
+  # instead of naming a replacement.
   @time_calls %{
     {[:Date], :utc_today} => "today()",
     {[:DateTime], :utc_now} => "now()",
-    {[:NaiveDateTime], :utc_now} => "now()"
+    {[:NaiveDateTime], :utc_now} => "now()",
+    {[:Time], :utc_now} => nil
   }
 
   @impl true
@@ -54,18 +58,16 @@ defmodule AshCredo.Check.Warning.PinnedTimeInExpression do
       ast,
       fn
         {:^, meta, [{{:., _, [{:__aliases__, _, module}, func]}, _, _}]} = node, acc ->
-          case Map.get(@time_calls, {module, func}) do
-            nil ->
+          case Map.fetch(@time_calls, {module, func}) do
+            :error ->
               {node, acc}
 
-            replacement ->
+            {:ok, replacement} ->
               pinned = "^#{Name.full(module)}.#{func}()"
 
               issue =
                 format_issue(issue_meta,
-                  message:
-                    "Use `#{replacement}` instead of `#{pinned}` in Ash expressions. " <>
-                      "The pinned call is evaluated at compile time and never updates.",
+                  message: pinned_message(replacement, pinned),
                   trigger: pinned,
                   line_no: meta[:line]
                 )
@@ -78,6 +80,17 @@ defmodule AshCredo.Check.Warning.PinnedTimeInExpression do
       end,
       []
     )
+  end
+
+  defp pinned_message(nil, pinned) do
+    "`#{pinned}` is evaluated at compile time and never updates, and no " <>
+      "expression builtin returns the current time of day. Pass the value " <>
+      "as an action argument, or compare datetimes with `now()`."
+  end
+
+  defp pinned_message(replacement, pinned) do
+    "Use `#{replacement}` instead of `#{pinned}` in Ash expressions. " <>
+      "The pinned call is evaluated at compile time and never updates."
   end
 
   defp module_expr_issues(module_ast, issue_meta) do

--- a/test/ash_credo/check/warning/pinned_time_in_expression_test.exs
+++ b/test/ash_credo/check/warning/pinned_time_in_expression_test.exs
@@ -287,4 +287,27 @@ defmodule AshCredo.Check.Warning.PinnedTimeInExpressionTest do
 
     assert [] = run_check(PinnedTimeInExpression, source)
   end
+
+  test "flags pinned Time.utc_now with pass-the-value advice" do
+    # No expression builtin returns the current time of day, so the
+    # message advises an argument instead of naming a replacement.
+    source = """
+    defmodule MyApp.Venue do
+      use Ash.Resource, domain: MyApp.Places
+
+      actions do
+        read :open_now do
+          filter expr(opens_at <= ^Time.utc_now())
+        end
+      end
+    end
+    """
+
+    assert [issue] = run_check(PinnedTimeInExpression, source)
+    assert issue.trigger == "^Time.utc_now()"
+    assert issue.line_no == 6
+    assert issue.message =~ "never updates"
+    assert issue.message =~ "action argument"
+    refute issue.message =~ "Use `"
+  end
 end


### PR DESCRIPTION
## Motivation

The sibling `CompileTimeDefault` check covers `Time.utc_now` but `PinnedTimeInExpression` did not, so `filter expr(opens_at <= ^Time.utc_now())` went unflagged despite freezing at compile time exactly like the `Date` and `DateTime` forms.

## Changes

- Flag pinned `Time.utc_now()` in expressions; since Ash has no expression builtin returning the current time of day, the message advises passing the value as an action argument (or comparing datetimes with `now()`) instead of naming a replacement
