### PR TITLE
fix: silence default_accept warnings without an inheriting action

### DIFF
--- a/lib/ash_credo/check/warning/sensitive_field_in_accept.ex
+++ b/lib/ash_credo/check/warning/sensitive_field_in_accept.ex
@@ -137,7 +137,17 @@ defmodule AshCredo.Check.Warning.SensitiveFieldInAccept do
     end)
   end
 
+  # Mirrors WildcardAcceptOnAction: `default_accept` is only an input
+  # surface when some action can inherit it.
   defp find_dangerous_default_accept(actions_ast, dangerous, issue_meta) do
+    if Introspection.default_accept_inheritors?(actions_ast) do
+      dangerous_default_accept_issues(actions_ast, dangerous, issue_meta)
+    else
+      []
+    end
+  end
+
+  defp dangerous_default_accept_issues(actions_ast, dangerous, issue_meta) do
     actions_ast
     |> Introspection.option_occurrences(:default_accept)
     |> Enum.flat_map(fn

--- a/lib/ash_credo/check/warning/wildcard_accept_on_action.ex
+++ b/lib/ash_credo/check/warning/wildcard_accept_on_action.ex
@@ -94,7 +94,18 @@ defmodule AshCredo.Check.Warning.WildcardAcceptOnAction do
     end)
   end
 
+  # `default_accept` only reaches actions that can inherit it; on a
+  # resource with none (e.g. only reads and hard destroys) the option is
+  # dead configuration, not a mass-assignment surface.
   defp default_accept_issues(actions_ast, issue_meta) do
+    if Introspection.default_accept_inheritors?(actions_ast) do
+      wildcard_default_accept_issues(actions_ast, issue_meta)
+    else
+      []
+    end
+  end
+
+  defp wildcard_default_accept_issues(actions_ast, issue_meta) do
     actions_ast
     |> Introspection.option_occurrences(:default_accept)
     |> Enum.filter(fn {value, _line_no} -> wildcard_accept_value?(value) end)

--- a/lib/ash_credo/introspection.ex
+++ b/lib/ash_credo/introspection.ex
@@ -255,6 +255,28 @@ defmodule AshCredo.Introspection do
       soft_destroy_entities(actions_ast)
   end
 
+  @doc """
+  Returns true when some action in the section can inherit
+  `default_accept`: an accepting action (create, update, soft destroy)
+  without its own `accept` option, or a bare `:create`/`:update` atom in
+  `defaults`. Ash's DefaultAccept transformer applies the default only to
+  those - explicit accept lists override it, and hard destroys and reads
+  never take one.
+  """
+  def default_accept_inheritors?(actions_ast) do
+    inheriting_entity? =
+      actions_ast
+      |> accepting_action_entities()
+      |> Enum.any?(&(not entity_has_opt_key?(&1, :accept)))
+
+    inheriting_entity? or
+      Enum.any?(entities(actions_ast, :defaults), fn defaults_ast ->
+        defaults_ast
+        |> default_action_entries()
+        |> Enum.any?(&(&1 in [:create, :update]))
+      end)
+  end
+
   defp soft_destroy_entities(actions_ast) do
     actions_ast
     |> action_entities([:destroy])

--- a/lib/ash_credo/introspection.ex
+++ b/lib/ash_credo/introspection.ex
@@ -262,19 +262,45 @@ defmodule AshCredo.Introspection do
   `defaults`. Ash's DefaultAccept transformer applies the default only to
   those - explicit accept lists override it, and hard destroys and reads
   never take one.
+
+  Non-literal shapes count as inheritors: `defaults @actions` may expand
+  to inheriting entries and `soft? @soft` may compile a destroy soft, so
+  silencing a warning based on an unreadable value would hide a real
+  mass-assignment surface.
   """
   def default_accept_inheritors?(actions_ast) do
-    inheriting_entity? =
-      actions_ast
-      |> accepting_action_entities()
-      |> Enum.any?(&(not entity_has_opt_key?(&1, :accept)))
+    inheriting_accepting_entity?(actions_ast) or
+      inheriting_defaults_entry?(actions_ast) or
+      potentially_soft_destroy_inheritor?(actions_ast)
+  end
 
-    inheriting_entity? or
-      Enum.any?(entities(actions_ast, :defaults), fn defaults_ast ->
-        defaults_ast
-        |> default_action_entries()
-        |> Enum.any?(&(&1 in [:create, :update]))
-      end)
+  defp inheriting_accepting_entity?(actions_ast) do
+    actions_ast
+    |> accepting_action_entities()
+    |> Enum.any?(&(not entity_has_opt_key?(&1, :accept)))
+  end
+
+  defp inheriting_defaults_entry?(actions_ast) do
+    Enum.any?(entities(actions_ast, :defaults), fn
+      {:defaults, _, [entries]} when is_list(entries) ->
+        Enum.any?(entries, &(&1 in [:create, :update]))
+
+      _non_literal ->
+        true
+    end)
+  end
+
+  # A destroy whose `soft?` value is anything but the literal `false` may
+  # compile soft and then inherits like an update, unless it carries its
+  # own accept list.
+  defp potentially_soft_destroy_inheritor?(actions_ast) do
+    actions_ast
+    |> action_entities([:destroy])
+    |> Enum.any?(fn entity ->
+      entity_has_opt_key?(entity, :soft?) and
+        not entity_has_opt?(entity, :soft?, false) and
+        not entity_has_opt_key?(entity, :accept)
+    end)
   end
 
   defp soft_destroy_entities(actions_ast) do

--- a/test/ash_credo/check/warning/sensitive_field_in_accept_test.exs
+++ b/test/ash_credo/check/warning/sensitive_field_in_accept_test.exs
@@ -137,6 +137,25 @@ defmodule AshCredo.Check.Warning.SensitiveFieldInAcceptTest do
     assert issue.message =~ "is_admin"
   end
 
+  test "reports dangerous default_accept inherited by a soft destroy" do
+    source = """
+    defmodule MyApp.User do
+      use Ash.Resource, domain: MyApp.Accounts
+
+      actions do
+        default_accept [:name, :is_admin]
+
+        destroy :archive do
+          soft? true
+        end
+      end
+    end
+    """
+
+    assert [issue] = run_check(SensitiveFieldInAccept, source)
+    assert issue.message =~ "is_admin"
+  end
+
   test "no issue for dangerous default_accept when no action can inherit it" do
     source = """
     defmodule MyApp.User do

--- a/test/ash_credo/check/warning/sensitive_field_in_accept_test.exs
+++ b/test/ash_credo/check/warning/sensitive_field_in_accept_test.exs
@@ -137,6 +137,22 @@ defmodule AshCredo.Check.Warning.SensitiveFieldInAcceptTest do
     assert issue.message =~ "is_admin"
   end
 
+  test "no issue for dangerous default_accept when no action can inherit it" do
+    source = """
+    defmodule MyApp.User do
+      use Ash.Resource, domain: MyApp.Accounts
+
+      actions do
+        default_accept [:name, :is_admin]
+        read :read
+        destroy :purge
+      end
+    end
+    """
+
+    assert [] = run_check(SensitiveFieldInAccept, source)
+  end
+
   test "matches dangerous fields by regex when configured" do
     source = """
     defmodule MyApp.User do

--- a/test/ash_credo/check/warning/wildcard_accept_on_action_test.exs
+++ b/test/ash_credo/check/warning/wildcard_accept_on_action_test.exs
@@ -160,13 +160,51 @@ defmodule AshCredo.Check.Warning.WildcardAcceptOnActionTest do
     assert issue.line_no == 5
   end
 
-  test "reports issue for default_accept :*" do
+  test "reports issue for default_accept :* inherited by an action" do
     source = """
     defmodule MyApp.Post do
       use Ash.Resource, domain: MyApp.Blog
 
       actions do
         default_accept :*
+        create :create
+      end
+    end
+    """
+
+    assert [issue] = run_check(WildcardAcceptOnAction, source)
+    assert issue.message =~ "default_accept"
+  end
+
+  test "reports issue for default_accept :* inherited by a bare defaults entry" do
+    source = """
+    defmodule MyApp.Post do
+      use Ash.Resource, domain: MyApp.Blog
+
+      actions do
+        default_accept :*
+        defaults [:create, :read]
+      end
+    end
+    """
+
+    assert [issue] = run_check(WildcardAcceptOnAction, source)
+    assert issue.message =~ "default_accept"
+  end
+
+  test "no issue for default_accept :* when no action can inherit it" do
+    # Reads and hard destroys never take an accept list, and the create's
+    # explicit accept overrides the default - the option is dead config,
+    # not a mass-assignment surface.
+    source = """
+    defmodule MyApp.Post do
+      use Ash.Resource, domain: MyApp.Blog
+
+      actions do
+        default_accept :*
+        read :read
+        destroy :destroy
+
         create :create do
           accept [:title]
         end
@@ -174,8 +212,22 @@ defmodule AshCredo.Check.Warning.WildcardAcceptOnActionTest do
     end
     """
 
-    assert [issue] = run_check(WildcardAcceptOnAction, source)
-    assert issue.message =~ "default_accept"
+    assert [] = run_check(WildcardAcceptOnAction, source)
+  end
+
+  test "no issue for default_accept :* on a hard-destroy-only resource" do
+    source = """
+    defmodule MyApp.Post do
+      use Ash.Resource, domain: MyApp.Blog
+
+      actions do
+        default_accept :*
+        destroy :purge
+      end
+    end
+    """
+
+    assert [] = run_check(WildcardAcceptOnAction, source)
   end
 
   test "ignores read and destroy actions" do

--- a/test/ash_credo/check/warning/wildcard_accept_on_action_test.exs
+++ b/test/ash_credo/check/warning/wildcard_accept_on_action_test.exs
@@ -192,6 +192,68 @@ defmodule AshCredo.Check.Warning.WildcardAcceptOnActionTest do
     assert issue.message =~ "default_accept"
   end
 
+  test "reports default_accept :* when defaults is a module attribute (conservative)" do
+    # `defaults @default_actions` may expand to inheriting entries - the
+    # gate must not silence the warning based on an unreadable list.
+    source = """
+    defmodule MyApp.Post do
+      use Ash.Resource, domain: MyApp.Blog
+
+      @default_actions [:create]
+
+      actions do
+        default_accept :*
+        defaults @default_actions
+      end
+    end
+    """
+
+    assert [issue] = run_check(WildcardAcceptOnAction, source)
+    assert issue.message =~ "default_accept"
+  end
+
+  test "reports default_accept :* inherited by a soft destroy" do
+    source = """
+    defmodule MyApp.Post do
+      use Ash.Resource, domain: MyApp.Blog
+
+      actions do
+        default_accept :*
+
+        destroy :archive do
+          soft? true
+        end
+      end
+    end
+    """
+
+    assert [issue] = run_check(WildcardAcceptOnAction, source)
+    assert issue.message =~ "default_accept"
+  end
+
+  test "reports default_accept :* when soft? is a module attribute (conservative)" do
+    # `soft? @soft` may compile the destroy soft, making it inherit -
+    # anything but a literal `soft? false` counts.
+    source = """
+    defmodule MyApp.Post do
+      use Ash.Resource, domain: MyApp.Blog
+
+      @soft true
+
+      actions do
+        default_accept :*
+
+        destroy :archive do
+          soft? @soft
+        end
+      end
+    end
+    """
+
+    assert [issue] = run_check(WildcardAcceptOnAction, source)
+    assert issue.message =~ "default_accept"
+  end
+
   test "no issue for default_accept :* when no action can inherit it" do
     # Reads and hard destroys never take an accept list, and the create's
     # explicit accept overrides the default - the option is dead config,


### PR DESCRIPTION
## Motivation

Ash's `DefaultAccept` transformer applies `default_accept` only to create/update/soft-destroy actions without their own accept list, and to bare `:create`/`:update` defaults entries - reads and hard destroys never take one, and explicit accept lists override it. Both accept checks flagged `default_accept :*` unconditionally, so a resource with only reads and hard destroys (or explicit accepts everywhere) was warned about a mass-assignment surface that does not exist.

## Changes

- Add `Introspection.default_accept_inheritors?/1` encoding the inheritance rule
- Gate the `default_accept` paths of `WildcardAcceptOnAction` and `SensitiveFieldInAccept` on it, with tests for the inheriting, defaults-entry, dead-config, and hard-destroy-only shapes
