### PR TITLE
chore: fail lint on ExDoc warnings

### DIFF
--- a/lib/ash_credo/check/warning/redundant_validation.ex
+++ b/lib/ash_credo/check/warning/redundant_validation.ex
@@ -34,7 +34,7 @@ defmodule AshCredo.Check.Warning.RedundantValidation do
       add a real constraint. Fields shadowed by a same-named `argument` on
       an update or destroy action are skipped too. In the atomic execution
       path - the default for those action types (`require_atomic?`
-      defaults to `true`) - `Ash.Resource.Validation.Present` validates
+      defaults to `true`) - the built-in `present` validation validates
       the argument instead of the attribute, so the validation enforces
       "the caller supplied the argument" regardless of the attribute
       constraint. (The non-atomic path falls back to the attribute when

--- a/mix.exs
+++ b/mix.exs
@@ -37,7 +37,8 @@ defmodule AshCredo.MixProject do
         "lint.no_emdash",
         "lint.credence",
         "lint.reach",
-        "xref graph --format cycles --fail-above 0"
+        "xref graph --format cycles --fail-above 0",
+        "docs --warnings-as-errors"
       ]
     ]
   end


### PR DESCRIPTION
## Motivation

Publishing 0.16.0 surfaced an ExDoc warning: the RedundantValidation check's explanation referenced `Ash.Resource.Validation.Present` in backticks, which ExDoc auto-links, but that module is hidden (`@moduledoc false`) in Ash, so the link would be dead. Nothing in the lint suite guarded against this class of doc problem, so it only showed up mid-publish.

## Changes

- Rephrase the RedundantValidation explanation to say "the built-in `present` validation" instead of naming the hidden module, removing the dead link
- Add `docs --warnings-as-errors` to the `lint` alias so ExDoc warnings (hidden-module references, broken links) fail `mix lint` before they surface during `hex.publish`
