### PR TITLE
perf: replace global lock with name-registration claim for hint dedup

### DIFF
--- a/lib/ash_credo/cache.ex
+++ b/lib/ash_credo/cache.ex
@@ -189,22 +189,47 @@ defmodule AshCredo.Cache do
   # would otherwise repeat the message once per accessor call per file.
   # The flag check and set are not atomic on their own, and Credo dispatches
   # its first wave of check tasks simultaneously - many processes can pass
-  # the flag check before any of them sets it. Serialize the first emission
-  # through a :global lock and re-check the flag inside the critical section;
-  # after the flag is set, callers take the lock-free fast path.
+  # the flag check before any of them sets it. Resolve the race through
+  # atomic name registration: each racer spawns a fresh helper that tries
+  # to register a claim name, and only the winner re-checks the flag, sets
+  # it, and prints. Losers exit immediately - no lock, no backoff sleeps
+  # (:global.trans here would put every racer through randomized retry
+  # sleeps). After the flag is set, callers take the claim-free fast path.
   defp warn_missing_table do
     if not hint_emitted?() do
-      :global.trans({@hint_emitted_key, self()}, &emit_hint_if_first/0)
+      claim_and_emit_hint()
     end
 
     :ok
   end
 
-  defp emit_hint_if_first do
-    if not hint_emitted?() do
-      :persistent_term.put(@hint_emitted_key, true)
-      IO.puts(:stderr, @missing_table_hint)
+  # The helper is a spawned process rather than the caller itself because a
+  # process can hold only one registered name and the caller may already
+  # have one. The caller awaits the helper so the hint is on stderr before
+  # the triggering accessor returns. The flag is set before the winner
+  # exits (freeing the name), so a later claimant always finds it set.
+  # This orders emission at-most-once: a winner that crashes between
+  # setting the flag and printing suppresses the hint rather than letting
+  # another process print it twice.
+  defp claim_and_emit_hint do
+    {pid, ref} =
+      spawn_monitor(fn ->
+        if claim_registered?() and not hint_emitted?() do
+          :persistent_term.put(@hint_emitted_key, true)
+          IO.puts(:stderr, @missing_table_hint)
+        end
+      end)
+
+    receive do
+      {:DOWN, ^ref, :process, ^pid, _reason} -> :ok
     end
+  end
+
+  defp claim_registered? do
+    Process.register(self(), __MODULE__.MissingTableHintClaim)
+    true
+  rescue
+    ArgumentError -> false
   end
 
   defp hint_emitted?, do: :persistent_term.get(@hint_emitted_key, false)


### PR DESCRIPTION
## Motivation

The one-time "plugin not registered" hint deduplicates racing first accesses through `:global.trans`, whose contention path retries with randomized backoff sleeps. Credo dispatches its first wave of check tasks simultaneously, so a `mix credo` run without the plugin registered pays roughly half a second of sleeps at startup, and the 50-way concurrency test spent ~600ms in the lock (over half the suite's runtime). The lock is also cluster-wide, which is mismatched scope for a guard around a per-VM `:persistent_term` flag.

## Changes

- Replace the `:global.trans` critical section with atomic name registration: each racer spawns a fresh helper that tries to register a claim name; only the registration winner re-checks the flag, sets it, and emits the hint, while losers exit immediately without sleeping
- Use a spawned helper (not the caller) as the registration target since a process can hold only one registered name, and await it so the hint reaches stderr before the triggering accessor returns
- Set the flag before the winner exits and frees the name, keeping emission at-most-once per VM
