### PR TITLE
fix: handle options on permissive policy checks

### DIFF
--- a/lib/ash_credo/check/warning/overly_permissive_policy.ex
+++ b/lib/ash_credo/check/warning/overly_permissive_policy.ex
@@ -89,7 +89,7 @@ defmodule AshCredo.Check.Warning.OverlyPermissivePolicy do
       {forbid, _, _}, _acc when forbid in [:forbid_if, :forbid_unless] ->
         {:halt, false}
 
-      {:authorize_if, _, [{:always, _, _}]}, _acc ->
+      {:authorize_if, _, [{:always, _, _} | _opts]}, _acc ->
         {:halt, true}
 
       _other, acc ->

--- a/test/ash_credo/check/warning/overly_permissive_policy_test.exs
+++ b/test/ash_credo/check/warning/overly_permissive_policy_test.exs
@@ -22,6 +22,40 @@ defmodule AshCredo.Check.Warning.OverlyPermissivePolicyTest do
     assert issue.line_no == 5
   end
 
+  test "reports issue when authorize_if always() carries trailing options" do
+    source = """
+    defmodule MyApp.Post do
+      use Ash.Resource, domain: MyApp.Blog, authorizers: [Ash.Policy.Authorizer]
+
+      policies do
+        policy always() do
+          authorize_if always(), name: "everyone"
+        end
+      end
+    end
+    """
+
+    assert [issue] = run_check(OverlyPermissivePolicy, source)
+    assert issue.message =~ "Unscoped policy"
+    assert issue.trigger == "authorize_if always()"
+  end
+
+  test "no issue when another authorize_if check carries trailing options" do
+    source = """
+    defmodule MyApp.Post do
+      use Ash.Resource, domain: MyApp.Blog, authorizers: [Ash.Policy.Authorizer]
+
+      policies do
+        policy always() do
+          authorize_if actor_attribute_equals(:admin, true), name: "admins"
+        end
+      end
+    end
+    """
+
+    assert [] = run_check(OverlyPermissivePolicy, source)
+  end
+
   test "reports issue when policy uses expr(true) as guard" do
     source = """
     defmodule MyApp.Post do


### PR DESCRIPTION
## Summary

- Match `authorize_if always()` when valid trailing DSL options such as `name:` are present.
- Add regressions for named permissive and non-permissive checks.

## Validation

- Focused policy-check tests: 33 passed.
- Full test and lint suites passed.