### PR TITLE
fix: constrain pre-1.0 installation versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,8 +40,8 @@ jobs:
         if: steps.release.outputs.pr
         run: |
           VERSION=$(jq -r '.["."]' .release-please-manifest.json)
-          MAJOR_MINOR="${VERSION%.*}"
-          sed -Ei "s/\{:ash_credo, \"~> [0-9]+\.[0-9]+\"/\{:ash_credo, \"~> ${MAJOR_MINOR}\"/" README.md
+          sed -Ei "s/(mix igniter\.install ash_credo)@[0-9]+\.[0-9]+\.[0-9]+/\1@${VERSION}/" README.md
+          sed -Ei "s/\{:ash_credo, \"~> [0-9]+\.[0-9]+\.[0-9]+\"/\{:ash_credo, \"~> ${VERSION}\"/" README.md
 
       - name: Commit and push
         if: steps.release.outputs.pr

--- a/README.md
+++ b/README.md
@@ -27,10 +27,10 @@ AshCredo requires [Credo](https://credo.hexdocs.pm) to already be installed in y
 If your project uses [Igniter](https://igniter.hexdocs.pm), a single command will add the dependency and register the plugin in your `.credo.exs`:
 
 ```bash
-mix igniter.install ash_credo
+mix igniter.install ash_credo@0.16.1
 ```
 
-The installer scopes `ash_credo` to `:dev`/`:test` and sets `runtime: false` automatically, matching how `credo` itself is typically declared. Pass `--only dev,test` if you'd like an early error when running from another `MIX_ENV`.
+The explicit version prevents Igniter from generating a broad pre-1.0 requirement. Igniter pins a three-part version exactly; use the manual requirement below if you prefer compatible patch updates. The installer scopes `ash_credo` to `:dev`/`:test` and sets `runtime: false` automatically, matching how `credo` itself is typically declared. Pass `--only dev,test` if you'd like an early error when running from another `MIX_ENV`.
 
 ### Manual
 
@@ -39,7 +39,7 @@ Add `ash_credo` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:ash_credo, "~> 0.16", only: [:dev, :test], runtime: false}
+    {:ash_credo, "~> 0.16.0", only: [:dev, :test], runtime: false}
   ]
 end
 ```


### PR DESCRIPTION
## Summary

- Pin the documented Igniter command to the current exact release instead of allowing Igniter to generate `~> 0.16`.
- Use `~> 0.16.0` for manual installations so compatible patch updates remain available without admitting breaking minor releases.
- Keep both README examples synchronized from the release manifest.

## Validation

- Confirmed Igniter resolves `ash_credo@0.16.1` to `== 0.16.1`.
- Parsed the release workflow as YAML and dry-ran both version replacements.
- `mix lint` passed.