### PR TITLE
test: cover the minimum Elixir version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,33 @@ jobs:
       - run: mix deps.get
       - run: mix hex.audit
 
+  compatibility:
+    name: Compile (Elixir 1.17 / OTP 27)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      MIX_ENV: prod
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: erlef/setup-beam@54075bcc5e249e4758d363f27d099f55d843f124 # v1.24.1
+        id: beam
+        with:
+          otp-version: "27"
+          elixir-version: "1.17"
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            deps
+            _build
+          key: mix-prod-${{ steps.beam.outputs.otp-version }}-${{ steps.beam.outputs.elixir-version }}-${{ hashFiles('mix.lock') }}
+          restore-keys: |
+            mix-prod-${{ steps.beam.outputs.otp-version }}-${{ steps.beam.outputs.elixir-version }}-
+      - run: mix deps.get
+      - run: mix compile --warnings-as-errors
+
   test:
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary

- Compile the shipped production dependency surface on Elixir 1.17/OTP 27, matching the compatibility floor declared in `mix.exs`.
- Retain the full test suite on Elixir 1.20/OTP 29 because development-only lint dependencies require newer Elixir releases.
- Keep lint and dependency auditing on the current toolchain.

## Validation

- Parsed the updated workflow as YAML.
- Production-mode compilation passed locally on the current toolchain.
- The Elixir 1.17 compatibility compile is exercised by this PR CI.