### PR TITLE
fix: resolve single-record Ash calls

### DIFF
--- a/lib/ash_credo/check/refactor/use_code_interface.ex
+++ b/lib/ash_credo/check/refactor/use_code_interface.ex
@@ -43,6 +43,11 @@ defmodule AshCredo.Check.Refactor.UseCodeInterface do
       `query_to_*` / `changeset_to_*` / `input_to_*` helper that Ash
       generates for code interfaces.
 
+      `Ash.read_one` calls only match no-key interfaces configured with
+      `get?: true`. `Ash.read_first` calls are intentionally not flagged:
+      generated get interfaces use `Ash.read_one` and therefore do not
+      preserve `read_first`'s behavior when several records match.
+
       Detection of references to actions that do not exist on the resource
       lives in `AshCredo.Check.Warning.UnknownAction` - enable that check
       separately if you want typo detection.
@@ -145,10 +150,19 @@ defmodule AshCredo.Check.Refactor.UseCodeInterface do
     }
   end
 
+  # A generated read code interface either lists records or uses `Ash.read_one`
+  # when configured with `get?: true`. It cannot preserve `Ash.read_first`'s
+  # "take the first record even when several match" semantics.
+  defp check_site(
+         %AshCallSite{call_kind: :read_first, resolution: {:ok, _resource, _info}},
+         _issue_meta,
+         _config
+       ), do: []
+
   defp check_site(%AshCallSite{resolution: {:ok, resource, info}} = site, issue_meta, config) do
     case CompiledIntrospection.action(resource, site.action_name) do
       {:ok, action} ->
-        classification = classify(resource, site.action_name, action.type, info, site, config)
+        classification = classify(resource, site.action_name, action, info, site, config)
 
         if enforced?(classification, config) do
           classification
@@ -186,7 +200,7 @@ defmodule AshCredo.Check.Refactor.UseCodeInterface do
   defp enforced?(%{same_domain?: true}, %{in_domain: in_domain}), do: in_domain
   defp enforced?(%{same_domain?: false}, %{outside_domain: outside}), do: outside
 
-  defp classify(resource, action_name, action_type, info, site, config) do
+  defp classify(resource, action_name, action, info, site, config) do
     caller = caller_atom(site.call_info)
     caller_domain = caller_domain(caller)
     resource_domain = info.domain
@@ -198,10 +212,10 @@ defmodule AshCredo.Check.Refactor.UseCodeInterface do
     %{
       resource: resource,
       action: action_name,
-      action_type: action_type,
+      action_type: action.type,
       resource_domain: resource_domain,
-      resource_iface: matching_interface(info.interfaces, action_name, site, info),
-      domain_iface: domain_interface(resource_domain, resource, action_name, site, info),
+      resource_iface: matching_interface(info.interfaces, action_name, action, site, info),
+      domain_iface: domain_interface(resource_domain, resource, action_name, action, site, info),
       same_domain?: same_domain?,
       scope: config.scope,
       bang?: AshCallResolver.bang?(site),
@@ -209,21 +223,23 @@ defmodule AshCredo.Check.Refactor.UseCodeInterface do
       call_kind: site.call_kind,
       fun_name: site.fun_name,
       lookup_keys: site.lookup_keys,
-      identities: info.identities
+      identities: info.identities,
+      not_found_error?: read_one_not_found_error(site)
     }
   end
 
-  defp domain_interface(nil, _resource, _action_name, _site, _info), do: nil
+  defp domain_interface(nil, _resource, _action_name, _action, _site, _info), do: nil
 
-  defp domain_interface(domain, resource, action_name, site, info) do
+  defp domain_interface(domain, resource, action_name, action, site, info) do
     domain
     |> CompiledIntrospection.domain_interfaces(resource)
-    |> matching_interface(action_name, site, info)
+    |> matching_interface(action_name, action, site, info)
   end
 
-  defp matching_interface(interfaces, action_name, site, info) do
+  defp matching_interface(interfaces, action_name, action, site, info) do
     Enum.find(interfaces, fn iface ->
-      interface_action?(iface, action_name) and interface_matches_site?(iface, site, info)
+      interface_action?(iface, action_name) and
+        interface_matches_site?(iface, action, site, info)
     end)
   end
 
@@ -231,20 +247,30 @@ defmodule AshCredo.Check.Refactor.UseCodeInterface do
     (iface.action || iface.name) == action_name
   end
 
-  defp interface_matches_site?(iface, %{call_kind: :get_one, lookup_keys: keys}, info) do
+  defp interface_matches_site?(iface, _action, %{call_kind: :get_one, lookup_keys: keys}, info) do
     get_interface_for_keys?(iface, keys, info)
   end
 
-  defp interface_matches_site?(iface, %{call_kind: kind}, _info)
+  defp interface_matches_site?(iface, action, %{call_kind: :read_one}, info) do
+    effective_get_interface?(iface, action) and is_nil(interface_lookup_keys(iface, info)) and
+      no_required_interface_args?(iface)
+  end
+
+  defp interface_matches_site?(iface, _action, %{call_kind: kind}, _info)
        when kind in [:read_many, :stream_many] do
     not get_interface?(iface)
   end
 
-  defp interface_matches_site?(iface, %{builder_prefix: prefix}, _info) when not is_nil(prefix) do
+  defp interface_matches_site?(iface, _action, %{builder_prefix: prefix}, _info)
+       when not is_nil(prefix) do
     not get_interface?(iface)
   end
 
-  defp interface_matches_site?(_iface, _site, _info), do: true
+  defp interface_matches_site?(_iface, _action, _site, _info), do: true
+
+  defp effective_get_interface?(iface, action) do
+    get_interface?(iface) or Map.get(action, :get?) == true
+  end
 
   defp get_interface_for_keys?(_iface, keys, _info) when keys in [nil, []], do: false
 
@@ -277,6 +303,28 @@ defmodule AshCredo.Check.Refactor.UseCodeInterface do
 
   defp get_interface?(iface) do
     iface.get? == true or not is_nil(iface.get_by) or not is_nil(iface.get_by_identity)
+  end
+
+  defp no_required_interface_args?(iface) do
+    Enum.all?(iface.args || [], &match?({:optional, _}, &1))
+  end
+
+  defp read_one_not_found_error(%{call_kind: :read_one, call_info: %{args: args}}) do
+    case Enum.fetch(args, 1) do
+      {:ok, opts} when is_list(opts) -> literal_not_found_error(opts)
+      {:ok, _dynamic_opts} -> :dynamic
+      :error -> false
+    end
+  end
+
+  defp read_one_not_found_error(_site), do: nil
+
+  defp literal_not_found_error(opts) do
+    case Keyword.fetch(opts, :not_found_error?) do
+      {:ok, value} when is_boolean(value) -> value
+      {:ok, _dynamic_value} -> :dynamic
+      :error -> false
+    end
   end
 
   defp caller_atom(%{enclosing_module_segments: segs}) when is_list(segs) and segs != [] do
@@ -324,6 +372,8 @@ defmodule AshCredo.Check.Refactor.UseCodeInterface do
   end
 
   defp pick_suggestion(%{call_kind: :get_one, lookup_keys: keys}) when keys in [nil, []], do: nil
+
+  defp pick_suggestion(%{call_kind: :read_one, not_found_error?: :dynamic}), do: nil
 
   # `:resource` preference: always direct at the resource, even across domains.
   defp pick_suggestion(%{scope: :resource, resource_iface: iface}) when not is_nil(iface),
@@ -381,6 +431,26 @@ defmodule AshCredo.Check.Refactor.UseCodeInterface do
     fun = interface_call(iface, classification)
 
     "Prefer `#{inspect(domain)}.#{fun}` over `#{qualified}/#{arity}`."
+  end
+
+  defp format_message(
+         {:define, :resource},
+         %{resource: resource, action: action, call_kind: :read_one},
+         qualified,
+         arity
+       ) do
+    "Prefer a get code interface on `#{inspect(resource)}` over `#{qualified}/#{arity}`. " <>
+      "Define one with `define :#{action}, get?: true` inside the resource's `code_interface` block."
+  end
+
+  defp format_message(
+         {:define, :domain},
+         %{resource: resource, resource_domain: domain, action: action, call_kind: :read_one},
+         qualified,
+         arity
+       ) do
+    "Prefer a get code interface on `#{inspect(domain)}` over `#{qualified}/#{arity}`. " <>
+      "Define one with `define :some_name, action: :#{action}, get?: true` inside the `resource #{inspect(resource)} do ... end` block of the domain."
   end
 
   defp format_message(
@@ -443,6 +513,13 @@ defmodule AshCredo.Check.Refactor.UseCodeInterface do
     "#{fun}(#{Enum.join(args, ", ")})"
   end
 
+  defp interface_call(iface, %{call_kind: :read_one} = classification) do
+    fun = interface_function_name(iface.name, classification.builder_prefix, classification.bang?)
+    args = read_one_call_args(iface, classification.not_found_error?)
+
+    "#{fun}(#{Enum.join(args, ", ")})"
+  end
+
   defp interface_call(iface, %{call_kind: :stream_many} = classification) do
     fun = interface_function_name(iface.name, classification.builder_prefix, true)
 
@@ -462,6 +539,16 @@ defmodule AshCredo.Check.Refactor.UseCodeInterface do
       args ++ ["not_found_error?: false"]
     end
   end
+
+  defp read_one_call_args(iface, not_found_error?) when is_boolean(not_found_error?) do
+    if interface_not_found_error?(iface) == not_found_error? do
+      []
+    else
+      ["not_found_error?: #{not_found_error?}"]
+    end
+  end
+
+  defp interface_not_found_error?(iface), do: Map.get(iface, :not_found_error?) != false
 
   defp get_define_name(:read, keys), do: "get_by_#{keys_suffix(keys)}"
   defp get_define_name(action, keys), do: "get_#{action}_by_#{keys_suffix(keys)}"

--- a/lib/ash_credo/check/warning/unknown_action.ex
+++ b/lib/ash_credo/check/warning/unknown_action.ex
@@ -21,9 +21,10 @@ defmodule AshCredo.Check.Warning.UnknownAction do
       action either exists on the resource or it doesn't. There's nothing
       to configure.
 
-      It runs against the same call sites that `UseCodeInterface` does -
-      `Ash.read!`/`Ash.get!`/`Ash.bulk_*`/`Ash.Changeset.for_*`/
-      `Ash.Query.for_read`/`Ash.ActionInput.for_action` - whenever both
+      It runs against the same resolved Ash call-site pipeline as
+      `UseCodeInterface`, including
+      `Ash.read!`/`Ash.get!`/`Ash.read_one!`/`Ash.read_first!`/`Ash.bulk_*`/
+      `Ash.Changeset.for_*`/`Ash.Query.for_read`/`Ash.ActionInput.for_action` - whenever both
       the resource and the action argument are literal values that can be
       resolved at lint time.
 

--- a/lib/ash_credo/introspection/ash_call_resolver.ex
+++ b/lib/ash_credo/introspection/ash_call_resolver.ex
@@ -9,7 +9,7 @@ defmodule AshCredo.Introspection.AshCallResolver do
   Four dispatch patterns are recognised:
 
     * Pattern A - resource at arg 0, `:action` in keyword opts (`Ash.read!`,
-      `Ash.get`, `Ash.stream!`, ...). When no `:action` is present, read-like
+      `Ash.get`, `Ash.read_one`, `Ash.stream!`, ...). When no `:action` is present, read-like
       calls resolve to the resource's primary `:read` action, but still carry
       their original call shape so checks can preserve list/get/stream
       semantics in suggestions.
@@ -46,7 +46,8 @@ defmodule AshCredo.Introspection.AshCallResolver do
   @sites_key_tag {__MODULE__, :sites}
 
   # Pattern A: resource at arg 0, action in keyword opts (:action key).
-  @action_in_opts ~w(read read! get get! stream!)a
+  @action_in_opts ~w(read read! get get! read_one read_one! read_first read_first! stream!)a
+  @get_funs ~w(get get!)a
 
   # Pattern B: bulk_create - resource at arg 1, action at arg 2.
   @bulk_create_funs ~w(bulk_create bulk_create!)a
@@ -167,7 +168,7 @@ defmodule AshCredo.Introspection.AshCallResolver do
   defp extract_action_in_opts(args, ctx) do
     with {:ok, resource_ast} <- arg_at(args, 0),
          {:ok, segs} <- literal_segments(resource_ast, ast_context(ctx.call_info)) do
-      case action_in_opts(args) do
+      case action_in_opts(args, ctx.fun_name) do
         {:literal, action} -> [build_site(segs, action, ctx)]
         :absent -> implicit_read_sites(segs, ctx)
         # `:action` is present but not a literal atom (e.g. a bound variable).
@@ -230,6 +231,8 @@ defmodule AshCredo.Introspection.AshCallResolver do
 
   defp call_kind([:Ash], fun_name) when fun_name in [:read, :read!], do: :read_many
   defp call_kind([:Ash], fun_name) when fun_name in [:get, :get!], do: :get_one
+  defp call_kind([:Ash], fun_name) when fun_name in [:read_one, :read_one!], do: :read_one
+  defp call_kind([:Ash], fun_name) when fun_name in [:read_first, :read_first!], do: :read_first
   defp call_kind([:Ash], :stream!), do: :stream_many
   defp call_kind([:Ash], fun_name) when fun_name in @bulk_create_funs, do: :bulk
   defp call_kind([:Ash], fun_name) when fun_name in @bulk_query_funs, do: :bulk
@@ -257,7 +260,6 @@ defmodule AshCredo.Introspection.AshCallResolver do
     if Keyword.keyword?(keys) do
       keys
       |> Keyword.keys()
-      |> Enum.reject(&(&1 == :action))
       |> case do
         [] -> nil
         literal_keys -> literal_keys
@@ -445,12 +447,24 @@ defmodule AshCredo.Introspection.AshCallResolver do
 
   defp arg_at(args, idx), do: Enum.fetch(args, idx)
 
-  defp action_in_opts(args) do
-    with [kwl | _] when is_list(kwl) <- Enum.reverse(args),
-         {:ok, value} <- Keyword.fetch(kwl, :action) do
-      if is_atom(value) and not is_nil(value), do: {:literal, value}, else: :non_literal
-    else
-      _ -> :absent
+  # `Ash.get/2`'s second argument is always the identifier, even when it is a
+  # keyword list containing an `:action` attribute. Only `Ash.get/3` has call
+  # options. The other Pattern A functions take options at index 1.
+  defp action_in_opts(args, fun_name) do
+    opts_idx = if fun_name in @get_funs, do: 2, else: 1
+
+    case arg_at(args, opts_idx) do
+      {:ok, opts} when is_list(opts) -> action_from_literal_opts(opts)
+      {:ok, _dynamic_or_invalid_opts} -> :non_literal
+      :error -> :absent
+    end
+  end
+
+  defp action_from_literal_opts(opts) do
+    case Keyword.fetch(opts, :action) do
+      {:ok, value} when is_atom(value) and not is_nil(value) -> {:literal, value}
+      {:ok, _value} -> :non_literal
+      :error -> :absent
     end
   end
 end

--- a/lib/ash_credo/introspection/ash_call_site.ex
+++ b/lib/ash_credo/introspection/ash_call_site.ex
@@ -13,7 +13,7 @@ defmodule AshCredo.Introspection.AshCallSite do
       unreachable, `:not_a_resource` for non-Ash modules, or `:ash_missing`
       when Ash itself is not loaded.
     * `:action_name` - atom of the action this call targets (literal `:action`
-      keyword for `Ash.read/get/stream!`, positional arg for `bulk_*`/builders,
+      keyword for `Ash.read/get/read_one/read_first/stream!`, positional arg for `bulk_*`/builders,
       or the resource's primary `:read` for the bare-form Ash.read! shape).
     * `:fun_name` - the function called (e.g. `:read!`, `:bulk_create`).
     * `:module` - alias-expanded segments of the called module.
@@ -25,8 +25,8 @@ defmodule AshCredo.Introspection.AshCallSite do
     * `:builder_prefix` - `:changeset_to | :query_to | :input_to | nil` for
       the corresponding `for_*` builder shape, otherwise `nil`.
     * `:call_kind` - high-level call shape used to pick the right interface
-      suggestion (`:read_many`, `:get_one`, `:stream_many`, `:builder`,
-      `:bulk`, or `nil`).
+      suggestion (`:read_many`, `:read_one`, `:read_first`, `:get_one`,
+      `:stream_many`, `:builder`, `:bulk`, or `nil`).
     * `:lookup_keys` - the list of attribute names a `get_one` call looks up
       by (from a literal map / kw arg, or the resource's single-key primary
       key); `nil` for non-`:get_one` calls.
@@ -72,7 +72,15 @@ defmodule AshCredo.Introspection.AshCallSite do
           call_meta: keyword(),
           call_info: map(),
           builder_prefix: :changeset_to | :query_to | :input_to | nil,
-          call_kind: :read_many | :get_one | :stream_many | :builder | :bulk | nil,
+          call_kind:
+            :read_many
+            | :read_one
+            | :read_first
+            | :get_one
+            | :stream_many
+            | :builder
+            | :bulk
+            | nil,
           lookup_keys: [atom()] | nil
         }
 end

--- a/test/ash_credo/check/refactor/use_code_interface_test.exs
+++ b/test/ash_credo/check/refactor/use_code_interface_test.exs
@@ -136,6 +136,113 @@ defmodule AshCredo.Check.Refactor.UseCodeInterfaceTest do
       assert issue.message =~ "AshCredoFixtures.Blog.Post.all_posts!(stream?: true)"
     end
 
+    test "Ash.read_one uses only a no-key get interface" do
+      source = """
+      defmodule AshCredoFixtures.Accounts do
+        def one_account do
+          Ash.read_one!(AshCredoFixtures.Accounts.Account, action: :read)
+        end
+      end
+      """
+
+      assert [issue] = run_check(UseCodeInterface, source)
+      assert issue.trigger == "Ash.read_one!"
+      assert issue.message =~ "AshCredoFixtures.Accounts.Account.single_account!()"
+      refute issue.message =~ "get_account_by_email"
+    end
+
+    test "Ash.read_one treats action-level get? as an effective get interface" do
+      source = """
+      defmodule AshCredoFixtures.Accounts do
+        def one_account do
+          Ash.read_one!(AshCredoFixtures.Accounts.Account, action: :singleton)
+        end
+      end
+      """
+
+      assert [issue] = run_check(UseCodeInterface, source)
+      assert issue.trigger == "Ash.read_one!"
+
+      assert issue.message =~
+               "AshCredoFixtures.Accounts.Account.action_single_account!(not_found_error?: false)"
+    end
+
+    test "Ash.read_one preserves an explicit not_found_error? override" do
+      source = """
+      defmodule AshCredoFixtures.Accounts do
+        def one_account do
+          Ash.read_one!(
+            AshCredoFixtures.Accounts.Account,
+            action: :read,
+            not_found_error?: true
+          )
+        end
+      end
+      """
+
+      assert [issue] = run_check(UseCodeInterface, source)
+      assert issue.message =~ "single_account!(not_found_error?: true)"
+    end
+
+    test "Ash.read_one is ignored when not_found_error? is dynamic" do
+      source = """
+      defmodule AshCredoFixtures.Accounts do
+        def one_account(not_found_error?) do
+          Ash.read_one!(
+            AshCredoFixtures.Accounts.Account,
+            action: :read,
+            not_found_error?: not_found_error?
+          )
+        end
+      end
+      """
+
+      assert [] = run_check(UseCodeInterface, source)
+    end
+
+    test "Ash.read_one does not suggest a list or keyed interface" do
+      source = """
+      defmodule AshCredoFixtures.Blog do
+        def one_post do
+          Ash.read_one!(AshCredoFixtures.Blog.Post, action: :read)
+        end
+      end
+      """
+
+      assert [issue] = run_check(UseCodeInterface, source)
+      assert issue.message =~ "define :read, get?: true"
+      refute issue.message =~ "all_posts"
+      refute issue.message =~ "get_post_by_id"
+    end
+
+    test "Ash.read_first is ignored because code interfaces cannot preserve its semantics" do
+      source = """
+      defmodule AshCredoFixtures.Accounts do
+        def first_account do
+          Ash.read_first!(AshCredoFixtures.Accounts.Account, action: :read)
+        end
+      end
+      """
+
+      assert [] = run_check(UseCodeInterface, source)
+    end
+
+    test "Ash.get/2 can match an identity whose key is :action" do
+      source = """
+      defmodule AshCredoFixtures.Accounts do
+        def find(action) do
+          Ash.get!(AshCredoFixtures.Accounts.Account, action: action)
+        end
+      end
+      """
+
+      assert [issue] = run_check(UseCodeInterface, source)
+      assert issue.trigger == "Ash.get!"
+
+      assert issue.message =~
+               "AshCredoFixtures.Accounts.Account.get_account_by_action!(action, not_found_error?: false)"
+    end
+
     test "bare Ash.read!(Unloadable) still emits the :not_loadable diagnostic" do
       source = """
       defmodule SomeController do

--- a/test/ash_credo/check/warning/unknown_action_test.exs
+++ b/test/ash_credo/check/warning/unknown_action_test.exs
@@ -54,6 +54,43 @@ defmodule AshCredo.Check.Warning.UnknownActionTest do
       assert [] = run_check(UnknownAction, source)
     end
 
+    test "fires for Ash.read_one and Ash.read_first variants" do
+      source = """
+      defmodule AshCredoFixtures.Blog do
+        def a, do: Ash.read_one(AshCredoFixtures.Blog.Post, action: :publishd)
+        def b, do: Ash.read_one!(AshCredoFixtures.Blog.Post, action: :publishd)
+        def c, do: Ash.read_first(AshCredoFixtures.Blog.Post, action: :publishd)
+        def d, do: Ash.read_first!(AshCredoFixtures.Blog.Post, action: :publishd)
+      end
+      """
+
+      assert Enum.map(run_check(UnknownAction, source), & &1.trigger) == [
+               "Ash.read_one",
+               "Ash.read_one!",
+               "Ash.read_first",
+               "Ash.read_first!"
+             ]
+    end
+
+    test "Ash.get/3 still reads the action from options after a keyword identifier" do
+      source = """
+      defmodule AshCredoFixtures.Accounts do
+        def find do
+          Ash.get!(
+            AshCredoFixtures.Accounts.Account,
+            [action: "activate"],
+            action: :readd
+          )
+        end
+      end
+      """
+
+      assert [issue] = run_check(UnknownAction, source)
+      assert issue.trigger == "Ash.get!"
+      assert issue.message =~ ":readd"
+      assert issue.message =~ ":read"
+    end
+
     test "fires for an Ash.Query.for_read builder (pattern D)" do
       source = """
       defmodule AshCredoFixtures.Blog do

--- a/test/ash_credo/introspection/ash_call_resolver_test.exs
+++ b/test/ash_credo/introspection/ash_call_resolver_test.exs
@@ -26,15 +26,34 @@ defmodule AshCredo.Introspection.AshCallResolverTest do
       assert site.lookup_keys == [:id]
     end
 
-    test "extracts keys from a keyword id, ignoring :action" do
+    test "treats :action in an Ash.get/2 keyword identifier as a lookup key" do
       source = """
       defmodule M do
-        def f, do: Ash.get!(AshCredoFixtures.Blog.Post, action: :read, id: 1)
+        def f, do: Ash.get!(AshCredoFixtures.Accounts.Account, action: "activate")
       end
       """
 
       assert [site] = sites(source)
-      assert site.lookup_keys == [:id]
+      assert site.action_name == :read
+      assert site.lookup_keys == [:action]
+    end
+
+    test "reads :action from Ash.get/3 options, not from its keyword identifier" do
+      source = """
+      defmodule M do
+        def f do
+          Ash.get!(
+            AshCredoFixtures.Accounts.Account,
+            [action: "activate"],
+            action: :missing
+          )
+        end
+      end
+      """
+
+      assert [site] = sites(source)
+      assert site.action_name == :missing
+      assert site.lookup_keys == [:action]
     end
 
     test "falls back to the resource's single primary key when the id is opaque" do
@@ -46,6 +65,26 @@ defmodule AshCredo.Introspection.AshCallResolverTest do
 
       assert [site] = sites(source)
       assert site.lookup_keys == [:id]
+    end
+  end
+
+  describe "single-record reads" do
+    test "resolves read_one and read_first variants with distinct call kinds" do
+      source = """
+      defmodule M do
+        def a, do: Ash.read_one(AshCredoFixtures.Blog.Post, action: :published)
+        def b, do: Ash.read_one!(AshCredoFixtures.Blog.Post, action: :published)
+        def c, do: Ash.read_first(AshCredoFixtures.Blog.Post, action: :published)
+        def d, do: Ash.read_first!(AshCredoFixtures.Blog.Post, action: :published)
+      end
+      """
+
+      assert Enum.map(sites(source), &{&1.fun_name, &1.call_kind, &1.action_name}) == [
+               {:read_one, :read_one, :published},
+               {:read_one!, :read_one, :published},
+               {:read_first, :read_first, :published},
+               {:read_first!, :read_first, :published}
+             ]
     end
   end
 

--- a/test/support/fixtures/ash_fixtures.ex
+++ b/test/support/fixtures/ash_fixtures.ex
@@ -214,8 +214,14 @@ defmodule AshCredoFixtures.Accounts.Account do
     * `get_account_by_email` uses `get_by_identity: :unique_email` - the
       suggestion must resolve the identity to its keys to match a
       `Ash.get!(Account, %{email: ...})` lookup.
+    * `get_account_by_action` covers an identity whose key is literally
+      `:action`, which must not be confused with `Ash.get/3` call options.
     * `fetch_account_by_id` sets `not_found_error?: false` - the suggested
       call must NOT carry the trailing `not_found_error?: false` argument.
+    * `single_account` is a no-key `get?: true` interface suitable for
+      replacing `Ash.read_one`, but not `Ash.read_first`.
+    * `action_single_account` targets a read action whose own `get?: true`
+      makes the otherwise plain interface return one record.
     * `:activate` is a generic action with an interface - builder calls via
       `Ash.ActionInput.for_action/3` must suggest the `input_to_*` helper.
   """
@@ -226,13 +232,18 @@ defmodule AshCredoFixtures.Accounts.Account do
 
   code_interface do
     define :get_account_by_email, action: :read, get_by_identity: :unique_email
+    define :get_account_by_action, action: :read, get_by_identity: :unique_action
     define :fetch_account_by_id, action: :read, get_by: [:id], not_found_error?: false
+    define :single_account, action: :read, get?: true, not_found_error?: false
+    define :action_single_account, action: :singleton
     define :activate
   end
 
   actions do
     defaults [:read]
     default_accept []
+
+    read :singleton, get?: true
 
     action :activate do
       run fn _input, _ -> :ok end
@@ -242,10 +253,12 @@ defmodule AshCredoFixtures.Accounts.Account do
   attributes do
     uuid_primary_key :id
     attribute :email, :string, public?: true
+    attribute :action, :string, public?: true
   end
 
   identities do
     identity :unique_email, [:email]
+    identity :unique_action, [:action]
   end
 end
 


### PR DESCRIPTION
## Summary

- Read `Ash.get/3` action options from the correct argument while preserving `:action` as an `Ash.get/2` keyword identity key.
- Resolve `read_one`, `read_one!`, `read_first`, and `read_first!` for unknown-action checks.
- Suggest code interfaces only when they preserve single-record, first-record, and `not_found_error?` semantics.
- Add resolver, warning-check, and refactor-check regressions.

## Validation

- Focused resolver and check suites passed with 105 tests.
- Full suite passed with 776 tests.
- `mix lint` passed.
- Independent review found no remaining blocker.