### PR TITLE
fix: rescue mid-introspection raises in compiled inspection

### DIFF
--- a/lib/ash_credo/introspection/compiled.ex
+++ b/lib/ash_credo/introspection/compiled.ex
@@ -666,6 +666,13 @@ defmodule AshCredo.Introspection.Compiled do
       {:error, _reason} ->
         {:error, :not_loadable}
     end
+  rescue
+    # The `Ash.Resource.Info` accessors bottom out in `Spark.Dsl.Extension`,
+    # which raises `ArgumentError` when `module` is not (or no longer) a Spark
+    # DSL module and `UndefinedFunctionError` when it was purged. Both can
+    # occur after `resource?/1` succeeded if the module is recompiled or
+    # purged mid-run; the memoized error also stops per-call re-raising.
+    _ in [ArgumentError, UndefinedFunctionError] -> {:error, :not_loadable}
   end
 
   # Policies live in `Ash.Policy.Info` (a separate module from `Ash.Resource.Info`).

--- a/test/ash_credo/introspection/compiled_test.exs
+++ b/test/ash_credo/introspection/compiled_test.exs
@@ -89,5 +89,12 @@ defmodule AshCredo.Introspection.CompiledTest do
       assert Compiled.authorizers(@plain) == {:error, :not_a_resource}
       assert Compiled.action(@plain, :read) == {:error, :not_a_resource}
     end
+
+    test "a module raising mid-introspection yields :not_loadable instead of crashing" do
+      half_purged = AshCredoFixtures.HalfPurgedResource
+
+      assert Compiled.inspect_module(half_purged) == {:error, :not_loadable}
+      assert Compiled.attributes(half_purged) == {:error, :not_loadable}
+    end
   end
 end

--- a/test/support/fixtures/ash_fixtures.ex
+++ b/test/support/fixtures/ash_fixtures.ex
@@ -302,6 +302,18 @@ defmodule AshCredoFixtures.Plain do
   def hello, do: :world
 end
 
+defmodule AshCredoFixtures.HalfPurgedResource do
+  @moduledoc """
+  Passes the `Ash.Resource.Info.resource?/1` guard (via `spark_is/0`) but
+  defines none of the Spark DSL introspection functions, so every subsequent
+  `Ash.Resource.Info` accessor raises `ArgumentError`. Models a resource
+  purged or recompiled between the `resource?/1` guard and the accessor
+  calls, for the `Compiled.do_inspect/1` rescue tests.
+  """
+
+  def spark_is, do: Ash.Resource
+end
+
 defmodule AshCredoFixtures.Blog.Changes.Archive do
   @moduledoc """
   Fixture `Ash.Resource.Change` module used to exercise the "callback module


### PR DESCRIPTION
## Summary

- `Compiled.do_inspect/1` called the `Ash.Resource.Info` accessors unguarded, unlike its siblings `read_policies/1`, `do_macros/1`, and `module_behaviours/1`. The accessors bottom out in `Spark.Dsl.Extension`, which raises `ArgumentError` / `UndefinedFunctionError` when the module is purged or recompiled between the `resource?/1` guard and the accessor calls - the same window the sibling rescues already handle.
- Because the raise happened inside `Cache.memoize`, nothing was cached and every later call re-raised; under Credo's default `crash_on_error: true`, the first raise aborts the whole run.
- Rescue to `{:error, :not_loadable}`, which the orchestration already surfaces as the deduped per-module diagnostic and which the memo cache now stores, so one broken module degrades to a diagnostic instead of crashing the run.
- Add a `HalfPurgedResource` fixture that passes the `resource?/1` guard but raises on every subsequent accessor, plus regressions for `inspect_module/1` and the accessors built on it.