### PR TITLE
fix: enumerate all same-named DSL section blocks

### DIFF
--- a/lib/ash_credo/check/readability/action_missing_description.ex
+++ b/lib/ash_credo/check/readability/action_missing_description.ex
@@ -30,8 +30,6 @@ defmodule AshCredo.Check.Readability.ActionMissingDescription do
         &check_descriptions/2
       )
 
-  defp check_descriptions(nil, _issue_meta), do: []
-
   defp check_descriptions(actions_ast, issue_meta) do
     actions_ast
     |> Introspection.action_entities(@action_types)

--- a/lib/ash_credo/check/readability/belongs_to_missing_allow_nil.ex
+++ b/lib/ash_credo/check/readability/belongs_to_missing_allow_nil.ex
@@ -26,8 +26,6 @@ defmodule AshCredo.Check.Readability.BelongsToMissingAllowNil do
         &check_belongs_to/2
       )
 
-  defp check_belongs_to(nil, _issue_meta), do: []
-
   defp check_belongs_to(rels_ast, issue_meta) do
     rels_ast
     |> Introspection.entities(:belongs_to)

--- a/lib/ash_credo/check/refactor/anonymous_function_in_dsl.ex
+++ b/lib/ash_credo/check/refactor/anonymous_function_in_dsl.ex
@@ -85,32 +85,22 @@ defmodule AshCredo.Check.Refactor.AnonymousFunctionInDsl do
   end
 
   defp entity_body_issues(context, section_name, entity_names, issue_meta) do
-    case Introspection.resource_section(context, section_name) do
-      nil ->
-        []
-
-      section_ast ->
-        section_ast
-        |> Introspection.action_entities(entity_names)
-        |> Enum.flat_map(fn entity_ast ->
-          entity_ast
-          |> Introspection.entity_body()
-          |> Enum.flat_map(&anonymous_wrapper_issues(&1, issue_meta))
-        end)
-    end
+    context
+    |> Introspection.resource_sections(section_name)
+    |> Introspection.action_entities(entity_names)
+    |> Enum.flat_map(fn entity_ast ->
+      entity_ast
+      |> Introspection.entity_body()
+      |> Enum.flat_map(&anonymous_wrapper_issues(&1, issue_meta))
+    end)
   end
 
   defp entity_section_issues(context, issue_meta) do
     Enum.flat_map(@entity_sections, fn section_name ->
-      case Introspection.resource_section(context, section_name) do
-        nil ->
-          []
-
-        section_ast ->
-          section_ast
-          |> Introspection.action_entities(@wrappers)
-          |> Enum.flat_map(&anonymous_wrapper_issues(&1, issue_meta))
-      end
+      context
+      |> Introspection.resource_sections(section_name)
+      |> Introspection.action_entities(@wrappers)
+      |> Enum.flat_map(&anonymous_wrapper_issues(&1, issue_meta))
     end)
   end
 
@@ -118,15 +108,10 @@ defmodule AshCredo.Check.Refactor.AnonymousFunctionInDsl do
   # (`calculate :name, :type, fn ... end`), unlike the wrappers, where it
   # is the first.
   defp calculation_issues(context, issue_meta) do
-    case Introspection.resource_section(context, :calculations) do
-      nil ->
-        []
-
-      section_ast ->
-        section_ast
-        |> Introspection.action_entities([:calculate])
-        |> Enum.flat_map(&calculate_entity_issues(&1, issue_meta))
-    end
+    context
+    |> Introspection.resource_sections(:calculations)
+    |> Introspection.action_entities([:calculate])
+    |> Enum.flat_map(&calculate_entity_issues(&1, issue_meta))
   end
 
   defp calculate_entity_issues(

--- a/lib/ash_credo/check/warning/authorize_false.ex
+++ b/lib/ash_credo/check/warning/authorize_false.ex
@@ -92,14 +92,12 @@ defmodule AshCredo.Check.Warning.AuthorizeFalse do
       |> Introspection.resource_contexts()
       |> Enum.flat_map(fn %ResourceContext{} = context ->
         context
-        |> Introspection.resource_section(:actions)
+        |> Introspection.resource_sections(:actions)
         |> action_authorize_false_lines()
       end)
 
     Enum.sort(Enum.uniq(call_lines ++ action_lines))
   end
-
-  defp action_authorize_false_lines(nil), do: []
 
   defp action_authorize_false_lines(actions_ast) do
     for action <- Introspection.action_entities(actions_ast),

--- a/lib/ash_credo/check/warning/compile_time_default.ex
+++ b/lib/ash_credo/check/warning/compile_time_default.ex
@@ -66,10 +66,9 @@ defmodule AshCredo.Check.Warning.CompileTimeDefault do
   end
 
   defp section_issues(context, section_name, issue_meta) do
-    case Introspection.resource_section(context, section_name) do
-      nil -> []
-      section_ast -> default_option_issues(section_ast, issue_meta)
-    end
+    context
+    |> Introspection.resource_sections(section_name)
+    |> Enum.flat_map(&default_option_issues(&1, issue_meta))
   end
 
   # Collects default/update_default occurrences in both forms: inline

--- a/lib/ash_credo/check/warning/empty_domain.ex
+++ b/lib/ash_credo/check/warning/empty_domain.ex
@@ -34,28 +34,28 @@ defmodule AshCredo.Check.Warning.EmptyDomain do
   end
 
   defp empty_domain_issues(module_ast, issue_meta) do
-    resources_ast = Introspection.find_dsl_section(module_ast, :resources)
+    resources_asts = Introspection.find_dsl_sections(module_ast, :resources)
     use_line = Introspection.find_use_line(module_ast, [:Ash, :Domain])
 
-    case resources_ast do
-      nil ->
+    case resources_asts do
+      [] ->
         [
           format_issue(issue_meta,
             message: "Domain has no `resources` block.",
             trigger: "use Ash.Domain",
-            line_no: Introspection.section_issue_line(resources_ast, use_line)
+            line_no: Introspection.section_issue_line(nil, use_line)
           )
         ]
 
-      resources_ast ->
-        if Introspection.section_has_entries?(resources_ast) do
+      [first_resources_ast | _] ->
+        if Introspection.section_has_entries?(resources_asts) do
           []
         else
           [
             format_issue(issue_meta,
               message: "Domain has an empty `resources` block.",
               trigger: "resources",
-              line_no: Introspection.section_issue_line(resources_ast, use_line)
+              line_no: Introspection.section_issue_line(first_resources_ast, use_line)
             )
           ]
         end

--- a/lib/ash_credo/check/warning/missing_builtin_wrapper.ex
+++ b/lib/ash_credo/check/warning/missing_builtin_wrapper.ex
@@ -209,10 +209,9 @@ defmodule AshCredo.Check.Warning.MissingBuiltinWrapper do
   end
 
   defp naked_global_section_issues(context, section_name, builtins, advice, issue_meta) do
-    case Introspection.resource_section(context, section_name) do
-      nil -> []
-      section_ast -> naked_builtin_calls(section_ast, builtins, advice, issue_meta)
-    end
+    context
+    |> Introspection.resource_sections(section_name)
+    |> Enum.flat_map(&naked_builtin_calls(&1, builtins, advice, issue_meta))
   end
 
   defp naked_builtin_section_issues(
@@ -221,14 +220,13 @@ defmodule AshCredo.Check.Warning.MissingBuiltinWrapper do
          advice,
          issue_meta
        ) do
-    with true <- MapSet.size(builtins) > 0,
-         section_ast when not is_nil(section_ast) <-
-           Introspection.resource_section(context, section_name) do
-      section_ast
+    if MapSet.size(builtins) > 0 do
+      context
+      |> Introspection.resource_sections(section_name)
       |> Introspection.action_entities(entity_names)
       |> Enum.flat_map(&naked_builtin_calls(&1, builtins, advice, issue_meta))
     else
-      _ -> []
+      []
     end
   end
 

--- a/lib/ash_credo/check/warning/overly_permissive_policy.ex
+++ b/lib/ash_credo/check/warning/overly_permissive_policy.ex
@@ -50,8 +50,6 @@ defmodule AshCredo.Check.Warning.OverlyPermissivePolicy do
   def run(%SourceFile{} = source_file, params),
     do: Orchestration.flat_map_resource_section(source_file, params, :policies, &check_policies/2)
 
-  defp check_policies(nil, _issue_meta), do: []
-
   defp check_policies(policies_ast, issue_meta) do
     policies_ast
     |> Introspection.policy_entities_with_conditions()

--- a/lib/ash_credo/check/warning/redundant_validation.ex
+++ b/lib/ash_credo/check/warning/redundant_validation.ex
@@ -76,33 +76,23 @@ defmodule AshCredo.Check.Warning.RedundantValidation do
   end
 
   defp action_candidates(context) do
-    case Introspection.resource_section(context, :actions) do
-      nil ->
-        []
+    context
+    |> Introspection.resource_sections(:actions)
+    |> Introspection.action_entities(@changeset_action_types)
+    |> Enum.flat_map(fn action_ast ->
+      scope = {:action, Introspection.entity_name(action_ast)}
 
-      actions_ast ->
-        actions_ast
-        |> Introspection.action_entities(@changeset_action_types)
-        |> Enum.flat_map(fn action_ast ->
-          scope = {:action, Introspection.entity_name(action_ast)}
-
-          action_ast
-          |> Introspection.entity_body()
-          |> Enum.flat_map(&parse_validate(&1, scope))
-        end)
-    end
+      action_ast
+      |> Introspection.entity_body()
+      |> Enum.flat_map(&parse_validate(&1, scope))
+    end)
   end
 
   defp global_candidates(context) do
-    case Introspection.resource_section(context, :validations) do
-      nil ->
-        []
-
-      validations_ast ->
-        validations_ast
-        |> Introspection.action_entities([:validate])
-        |> Enum.flat_map(&parse_validate(&1, :global))
-    end
+    context
+    |> Introspection.resource_sections(:validations)
+    |> Introspection.action_entities([:validate])
+    |> Enum.flat_map(&parse_validate(&1, :global))
   end
 
   defp parse_validate({:validate, meta, [present_call | rest]}, scope) do

--- a/lib/ash_credo/check/warning/sensitive_attribute_exposed.ex
+++ b/lib/ash_credo/check/warning/sensitive_attribute_exposed.ex
@@ -46,12 +46,10 @@ defmodule AshCredo.Check.Warning.SensitiveAttributeExposed do
     |> Introspection.resource_modules()
     |> Enum.flat_map(fn module_ast ->
       module_ast
-      |> Introspection.find_dsl_section(:attributes)
+      |> Introspection.find_dsl_sections(:attributes)
       |> check_sensitive_attrs(sensitive_names, issue_meta)
     end)
   end
-
-  defp check_sensitive_attrs(nil, _sensitive_names, _issue_meta), do: []
 
   defp check_sensitive_attrs(attrs_ast, sensitive_names, issue_meta) do
     attrs_ast

--- a/lib/ash_credo/check/warning/sensitive_field_in_accept.ex
+++ b/lib/ash_credo/check/warning/sensitive_field_in_accept.ex
@@ -65,12 +65,10 @@ defmodule AshCredo.Check.Warning.SensitiveFieldInAccept do
     |> Introspection.resource_contexts()
     |> Enum.flat_map(fn %ResourceContext{} = context ->
       context
-      |> Introspection.resource_section(:actions)
+      |> Introspection.resource_sections(:actions)
       |> check_actions(dangerous, issue_meta)
     end)
   end
-
-  defp check_actions(nil, _dangerous, _issue_meta), do: []
 
   defp check_actions(actions_ast, dangerous, issue_meta) do
     action_issues =

--- a/lib/ash_credo/check/warning/wildcard_accept_on_action.ex
+++ b/lib/ash_credo/check/warning/wildcard_accept_on_action.ex
@@ -51,8 +51,6 @@ defmodule AshCredo.Check.Warning.WildcardAcceptOnAction do
     end
   end
 
-  defp check_actions(nil, _issue_meta), do: []
-
   defp check_actions(actions_ast, issue_meta) do
     explicit_action_issues(actions_ast, issue_meta) ++
       default_action_issues(actions_ast, issue_meta) ++

--- a/lib/ash_credo/introspection.ex
+++ b/lib/ash_credo/introspection.ex
@@ -201,16 +201,22 @@ defmodule AshCredo.Introspection do
     |> normalized_use_opts()
   end
 
-  @doc "Finds the AST node for a top-level DSL section (e.g. :attributes) in a module AST or resource/domain context."
+  @doc """
+  Finds the AST node of the first top-level DSL section (e.g. :attributes)
+  in a module AST or resource/domain context.
+
+  Suitable only for line anchoring: Spark merges multiple same-named
+  top-level blocks into one section, so entries may live in later blocks.
+  Use `find_dsl_sections/2` to enumerate entries.
+  """
   def find_dsl_section(%ResourceContext{module_ast: module_ast}, section_name) do
     find_dsl_section(module_ast, section_name)
   end
 
   def find_dsl_section({:defmodule, _, _} = module_ast, section_name) do
-    Enum.find(Block.module_body(module_ast), fn
-      {^section_name, _meta, [[do: _body]]} -> true
-      _ -> false
-    end)
+    module_ast
+    |> find_dsl_sections(section_name)
+    |> List.first()
   end
 
   def find_dsl_section(%SourceFile{}, _section_name) do
@@ -218,8 +224,35 @@ defmodule AshCredo.Introspection do
           "find_dsl_section/2 no longer accepts a SourceFile; pass a module AST or resource/domain context"
   end
 
-  @doc "Checks if an entity call exists inside a section AST node."
+  @doc """
+  Finds the AST nodes of all same-named top-level DSL sections (e.g.
+  :attributes) in a module AST or resource/domain context, in source order.
+
+  Spark merges multiple same-named top-level blocks into one section, so
+  entry enumeration must consider every block, not just the first.
+  """
+  def find_dsl_sections(%ResourceContext{module_ast: module_ast}, section_name) do
+    find_dsl_sections(module_ast, section_name)
+  end
+
+  def find_dsl_sections({:defmodule, _, _} = module_ast, section_name) do
+    Enum.filter(Block.module_body(module_ast), fn
+      {^section_name, _meta, [[do: _body]]} -> true
+      _ -> false
+    end)
+  end
+
+  def find_dsl_sections(%SourceFile{}, _section_name) do
+    raise ArgumentError,
+          "find_dsl_sections/2 does not accept a SourceFile; pass a module AST or resource/domain context"
+  end
+
+  @doc "Checks if an entity call exists inside a section AST node or list of section blocks."
   def has_entity?(nil, _), do: false
+
+  def has_entity?(section_asts, entity_name) when is_list(section_asts) do
+    Enum.any?(section_asts, &has_entity?(&1, entity_name))
+  end
 
   def has_entity?({_section, _, [[do: _body]]} = section_ast, entity_name) do
     section_ast
@@ -230,14 +263,18 @@ defmodule AshCredo.Introspection do
     end)
   end
 
-  @doc "Returns all entity AST nodes of a given name within a section."
+  @doc "Returns all entity AST nodes of a given name within a section or list of section blocks."
   def entities(nil, _), do: []
+
+  def entities(section_asts, entity_name) when is_list(section_asts) do
+    Enum.flat_map(section_asts, &entities(&1, entity_name))
+  end
 
   def entities({_section, _, [[do: _body]]} = section_ast, entity_name) do
     filter_entities(section_entries(section_ast), entity_name)
   end
 
-  @doc "Returns all explicit action entity AST nodes within an `actions` section."
+  @doc "Returns all explicit action entity AST nodes within an `actions` section or list of section blocks."
   def action_entities(actions_ast, action_types \\ @action_entities) do
     entries = section_entries(actions_ast)
 
@@ -326,12 +363,19 @@ defmodule AshCredo.Introspection do
 
   def module_line_count(_), do: nil
 
-  @doc "Finds a top-level DSL section from a resource context."
+  @doc "Finds the first top-level DSL section from a resource context. Suitable only for line anchoring; use `resource_sections/2` to enumerate entries."
   def resource_section(%ResourceContext{} = resource_context, section_name) do
     find_dsl_section(resource_context, section_name)
   end
 
   def resource_section(_, _section_name), do: nil
+
+  @doc "Finds all same-named top-level DSL section blocks from a resource context, in source order."
+  def resource_sections(%ResourceContext{} = resource_context, section_name) do
+    find_dsl_sections(resource_context, section_name)
+  end
+
+  def resource_sections(_, _section_name), do: []
 
   @doc "Returns the best issue anchor line for a section, falling back to `line` and then `fallback`."
   def section_issue_line(section_ast, line \\ nil, fallback \\ 1) do
@@ -372,6 +416,10 @@ defmodule AshCredo.Introspection do
   defp use_metadata_opt(%UseMetadata{opts: opts}, key), do: Keyword.get(opts, key)
   defp use_metadata_opt(_, _key), do: nil
 
+  defp section_entries(section_asts) when is_list(section_asts) do
+    Enum.flat_map(section_asts, &section_entries/1)
+  end
+
   defp section_entries(section_ast), do: Block.do_block_entries(section_ast)
 
   @doc "Extracts keyword options from an entity AST call."
@@ -396,9 +444,13 @@ defmodule AshCredo.Introspection do
     end
   end
 
-  @doc "Returns normalized option values with line numbers from inline opts and `do` blocks."
+  @doc "Returns normalized option values with line numbers from inline opts and `do` blocks. Accepts a single AST node or a list of nodes (e.g. duplicate section blocks)."
   def option_occurrences({_name, meta, _args} = ast, key) do
     normalized_option_occurrences(ast, key, meta[:line])
+  end
+
+  def option_occurrences(asts, key) when is_list(asts) do
+    Enum.flat_map(asts, &option_occurrences(&1, key))
   end
 
   def option_occurrences(_, _), do: []
@@ -442,8 +494,9 @@ defmodule AshCredo.Introspection do
     option_occurrences(entity_ast, key) != []
   end
 
-  @doc "Returns the flattened list of statements inside a section body."
+  @doc "Returns the flattened list of statements inside a section body or across a list of section blocks."
   def section_body({_section, _, [[do: _body]]} = section_ast), do: section_entries(section_ast)
+  def section_body(section_asts) when is_list(section_asts), do: section_entries(section_asts)
   def section_body(nil), do: []
 
   @doc "Returns true if a section contains at least one DSL entry."

--- a/lib/ash_credo/orchestration.ex
+++ b/lib/ash_credo/orchestration.ex
@@ -24,12 +24,17 @@ defmodule AshCredo.Orchestration do
     |> Enum.flat_map(&fun.(&1, issue_meta))
   end
 
-  @doc "Looks up a DSL section in each resource context, flat-mapping each through `fun.(section_ast, issue_meta)`."
+  @doc """
+  Looks up all same-named DSL section blocks in each resource context,
+  flat-mapping each context through `fun.(section_asts, issue_meta)`.
+  Spark merges duplicate top-level blocks into one section, so `fun`
+  receives the full list (empty when the section is absent).
+  """
   def flat_map_resource_section(%SourceFile{} = source_file, params, section_name, fun)
       when is_function(fun, 2) do
     flat_map_resource_context(source_file, params, fn context, issue_meta ->
       context
-      |> Introspection.resource_section(section_name)
+      |> Introspection.resource_sections(section_name)
       |> fun.(issue_meta)
     end)
   end

--- a/test/ash_credo/check/warning/sensitive_attribute_exposed_test.exs
+++ b/test/ash_credo/check/warning/sensitive_attribute_exposed_test.exs
@@ -21,6 +21,27 @@ defmodule AshCredo.Check.Warning.SensitiveAttributeExposedTest do
     assert issue.message =~ "sensitive?"
   end
 
+  test "reports issue for sensitive attribute in a second attributes block" do
+    source = """
+    defmodule MyApp.User do
+      use Ash.Resource, domain: MyApp.Accounts
+
+      attributes do
+        uuid_primary_key :id
+        attribute :email, :string
+      end
+
+      attributes do
+        attribute :hashed_password, :string
+      end
+    end
+    """
+
+    assert [issue] = run_check(SensitiveAttributeExposed, source)
+    assert issue.message =~ "hashed_password"
+    assert issue.line_no == 10
+  end
+
   test "no issue when sensitive attribute marked sensitive" do
     source = """
     defmodule MyApp.User do

--- a/test/ash_credo/check/warning/wildcard_accept_on_action_test.exs
+++ b/test/ash_credo/check/warning/wildcard_accept_on_action_test.exs
@@ -91,6 +91,28 @@ defmodule AshCredo.Check.Warning.WildcardAcceptOnActionTest do
     assert [] = run_check(WildcardAcceptOnAction, source)
   end
 
+  test "reports issue for accept :* declared in a second actions block" do
+    source = """
+    defmodule MyApp.Post do
+      use Ash.Resource, domain: MyApp.Blog
+
+      actions do
+        defaults [:read]
+      end
+
+      actions do
+        create :create do
+          accept :*
+        end
+      end
+    end
+    """
+
+    assert [issue] = run_check(WildcardAcceptOnAction, source)
+    assert issue.message =~ "accept :*"
+    assert issue.line_no == 10
+  end
+
   test "no issue for explicit accept list" do
     source = """
     defmodule MyApp.Post do

--- a/test/ash_credo/introspection_test.exs
+++ b/test/ash_credo/introspection_test.exs
@@ -36,6 +36,24 @@ defmodule AshCredo.IntrospectionTest do
   end
   """
 
+  # Spark merges same-named top-level blocks, so the create in the second
+  # `actions` block belongs to the same section as the defaults in the first.
+  @duplicate_actions_resource """
+  defmodule MyApp.Post do
+    use Ash.Resource, domain: MyApp.Blog
+
+    actions do
+      defaults [:read]
+    end
+
+    actions do
+      create :create do
+        accept [:title]
+      end
+    end
+  end
+  """
+
   @plain_module """
   defmodule MyApp.Utils do
     def hello, do: :world
@@ -599,6 +617,55 @@ defmodule AshCredo.IntrospectionTest do
       assert nil == Introspection.find_dsl_section(outer, :actions)
       assert {:actions, _, _} = Introspection.find_dsl_section(inner, :actions)
     end
+
+    test "returns the first block when the section is declared twice" do
+      first = first_resource_section(@duplicate_actions_resource, :actions)
+
+      assert {:actions, meta, _} = first
+      assert meta[:line] == 4
+    end
+  end
+
+  describe "find_dsl_sections/2" do
+    test "returns all same-named top-level blocks in source order" do
+      sections =
+        @duplicate_actions_resource
+        |> first_resource_module()
+        |> Introspection.find_dsl_sections(:actions)
+
+      assert [{:actions, first_meta, _}, {:actions, second_meta, _}] = sections
+      assert first_meta[:line] < second_meta[:line]
+    end
+
+    test "returns an empty list for a missing section" do
+      sections =
+        @ash_resource
+        |> first_resource_module()
+        |> Introspection.find_dsl_sections(:policies)
+
+      assert [] == sections
+    end
+
+    test "finds entities declared in a later duplicate block" do
+      sections =
+        @duplicate_actions_resource
+        |> first_resource_module()
+        |> Introspection.find_dsl_sections(:actions)
+
+      assert Introspection.has_entity?(sections, :create)
+      assert [{:create, _, [:create | _]}] = Introspection.entities(sections, :create)
+      assert [{:create, _, _}] = Introspection.action_entities(sections)
+    end
+
+    test "raises on source files to avoid ambiguous lookups" do
+      sf = source_file(@ash_resource)
+
+      assert_raise ArgumentError,
+                   ~r/find_dsl_sections\/2 does not accept a SourceFile/,
+                   fn ->
+                     Introspection.find_dsl_sections(sf, :attributes)
+                   end
+    end
   end
 
   describe "has_entity?/2" do
@@ -750,6 +817,19 @@ defmodule AshCredo.IntrospectionTest do
 
       assert nil == Introspection.resource_section(outer, :actions)
       assert {:actions, _, _} = Introspection.resource_section(inner, :actions)
+    end
+  end
+
+  describe "resource_sections/2" do
+    test "returns all same-named section blocks from a resource context" do
+      [context] = Introspection.resource_contexts(source_file(@duplicate_actions_resource))
+
+      assert [{:actions, _, _}, {:actions, _, _}] =
+               Introspection.resource_sections(context, :actions)
+    end
+
+    test "returns an empty list for a non-context input" do
+      assert [] == Introspection.resource_sections(:not_a_context, :actions)
     end
   end
 


### PR DESCRIPTION
## Summary

- `Introspection.find_dsl_section/2` returned only the first matching top-level section block, but Spark merges duplicate same-named blocks (e.g. two `actions do` blocks in one resource), so entries declared in later blocks were invisible to every check built on it.
- Add plural `find_dsl_sections/2` / `resource_sections/2` returning all matching blocks in source order; the entry helpers (`has_entity?/2`, `entities/2`, `section_body/1`, `option_occurrences/2`) now also accept a list of blocks, and `Orchestration.flat_map_resource_section/4` passes the full list.
- Move the twelve entry-enumerating checks to the plural path. `EmptyDomain` now distinguishes a missing `resources` block from blocks that are all empty.
- Keep the singular `find_dsl_section/2` / `resource_section/2` for line anchoring only (`MissingPrimaryAction`, `MissingCodeInterface`, `MissingTimestamps`), documented as such.
- Add regressions: a second-block `create` found through the entity helpers, `accept :*` in a second `actions` block, and an unmarked sensitive attribute in a second `attributes` block.