### PR TITLE
fix: resolve aliases in frozen-time checks

### DIFF
--- a/lib/ash_credo/check/warning/compile_time_default.ex
+++ b/lib/ash_credo/check/warning/compile_time_default.ex
@@ -36,20 +36,23 @@ defmodule AshCredo.Check.Warning.CompileTimeDefault do
     ]
 
   alias AshCredo.Introspection
+  alias AshCredo.Introspection.Aliases
+  alias AshCredo.Introspection.LexicalScopeWalker
   alias AshCredo.Orchestration
   alias Credo.Code.Name
 
   # Functions whose value is only meaningful when produced per record.
-  # Matched on literal alias segments, like the sibling
-  # PinnedTimeInExpression.
+  # Matched on the module resolved through the lexical environment, like
+  # the sibling PinnedTimeInExpression, so aliased forms
+  # (`alias DateTime, as: DT`) are caught too.
   @frozen_calls [
-    {[:Date], :utc_today},
-    {[:DateTime], :utc_now},
-    {[:NaiveDateTime], :utc_now},
-    {[:Time], :utc_now},
-    {[:Ash, :UUID], :generate},
-    {[:Ash, :UUIDv7], :generate},
-    {[:Ecto, :UUID], :generate}
+    {Date, :utc_today},
+    {DateTime, :utc_now},
+    {NaiveDateTime, :utc_now},
+    {Time, :utc_now},
+    {Ash.UUID, :generate},
+    {Ash.UUIDv7, :generate},
+    {Ecto.UUID, :generate}
   ]
 
   @default_options ~w(default update_default)a
@@ -61,40 +64,67 @@ defmodule AshCredo.Check.Warning.CompileTimeDefault do
   @impl true
   def run(%SourceFile{} = source_file, params) do
     Orchestration.flat_map_resource_context(source_file, params, fn context, issue_meta ->
-      Enum.flat_map(@sections, &section_issues(context, &1, issue_meta))
+      case Enum.flat_map(@sections, &Introspection.resource_sections(context, &1)) do
+        [] -> []
+        sections -> default_option_issues(context.module_ast, sections, issue_meta)
+      end
     end)
-  end
-
-  defp section_issues(context, section_name, issue_meta) do
-    context
-    |> Introspection.resource_sections(section_name)
-    |> Enum.flat_map(&default_option_issues(&1, issue_meta))
   end
 
   # Collects default/update_default occurrences in both forms: inline
   # keyword options (`default: value` - a 2-tuple in the AST) and do-block
-  # option calls (`default value`).
-  defp default_option_issues(section_ast, issue_meta) do
-    Credo.Code.prewalk(
-      section_ast,
-      fn
-        {option, _meta, [value]} = node, acc when option in @default_options ->
-          {node, frozen_call_issues(value, option, issue_meta) ++ acc}
+  # option calls (`default value`). The whole module is walked (rather
+  # than each section on its own) so directives at module top are already
+  # applied to the env by the time the sections are reached;
+  # `section_depth` gates collection to the sections.
+  defp default_option_issues(module_ast, sections, issue_meta) do
+    {state, _scope} =
+      LexicalScopeWalker.traverse(
+        module_ast,
+        %{issues: [], section_depth: 0, sections: sections},
+        &enter(&1, &2, &3, issue_meta),
+        &leave/3
+      )
 
-        {option, value} = node, acc when option in @default_options ->
-          {node, frozen_call_issues(value, option, issue_meta) ++ acc}
-
-        node, acc ->
-          {node, acc}
-      end,
-      []
-    )
+    Enum.reverse(state.issues)
   end
+
+  defp enter(node, scope, state, issue_meta) do
+    cond do
+      node in state.sections ->
+        %{state | section_depth: state.section_depth + 1}
+
+      state.section_depth == 0 ->
+        state
+
+      true ->
+        collect_option(node, LexicalScopeWalker.env(scope), state, issue_meta)
+    end
+  end
+
+  defp leave(node, _scope, state) do
+    if node in state.sections do
+      %{state | section_depth: state.section_depth - 1}
+    else
+      state
+    end
+  end
+
+  defp collect_option({option, _meta, [value]}, env, state, issue_meta)
+       when option in @default_options do
+    %{state | issues: frozen_call_issues(value, option, env, issue_meta) ++ state.issues}
+  end
+
+  defp collect_option({option, value}, env, state, issue_meta) when option in @default_options do
+    %{state | issues: frozen_call_issues(value, option, env, issue_meta) ++ state.issues}
+  end
+
+  defp collect_option(_node, _env, state, _issue_meta), do: state
 
   # Walks the option value for frozen calls, including inside containers
   # (`default: %{at: DateTime.utc_now()}` is just as frozen). Subtrees under
   # `fn` or `&` are pruned: there the call is deferred, which is the fix.
-  defp frozen_call_issues(value, option, issue_meta) do
+  defp frozen_call_issues(value, option, env, issue_meta) do
     {_ast, issues} =
       Macro.prewalk(value, [], fn
         {deferred, _, _}, acc when deferred in [:fn, :&] ->
@@ -102,7 +132,7 @@ defmodule AshCredo.Check.Warning.CompileTimeDefault do
 
         {{:., _, [{:__aliases__, _, segments}, fun]}, meta, args} = node, acc
         when is_list(args) ->
-          if {segments, fun} in @frozen_calls do
+          if frozen_call?(segments, fun, env) do
             {node, [frozen_issue(segments, fun, option, meta, issue_meta) | acc]}
           else
             {node, acc}
@@ -113,6 +143,13 @@ defmodule AshCredo.Check.Warning.CompileTimeDefault do
       end)
 
     issues
+  end
+
+  defp frozen_call?(segments, fun, env) do
+    case Aliases.expand_to_module(segments, env) do
+      {:ok, module} -> {module, fun} in @frozen_calls
+      :error -> false
+    end
   end
 
   defp frozen_issue(segments, fun, option, meta, issue_meta) do

--- a/lib/ash_credo/check/warning/pinned_time_in_expression.ex
+++ b/lib/ash_credo/check/warning/pinned_time_in_expression.ex
@@ -31,17 +31,21 @@ defmodule AshCredo.Check.Warning.PinnedTimeInExpression do
     ]
 
   alias AshCredo.Introspection
+  alias AshCredo.Introspection.Aliases
   alias AshCredo.Introspection.Block
+  alias AshCredo.Introspection.LexicalScopeWalker
   alias Credo.Code.Name
 
-  # `Time.utc_now` maps to `nil`: Ash has no expression builtin returning
-  # the current time of day, so the message advises passing the value in
-  # instead of naming a replacement.
+  # Keyed on the module resolved through the lexical environment, so
+  # aliased forms (`alias DateTime, as: DT`) match too. `Time.utc_now`
+  # maps to `nil`: Ash has no expression builtin returning the current
+  # time of day, so the message advises passing the value in instead of
+  # naming a replacement.
   @time_calls %{
-    {[:Date], :utc_today} => "today()",
-    {[:DateTime], :utc_now} => "now()",
-    {[:NaiveDateTime], :utc_now} => "now()",
-    {[:Time], :utc_now} => nil
+    {Date, :utc_today} => "today()",
+    {DateTime, :utc_now} => "now()",
+    {NaiveDateTime, :utc_now} => "now()",
+    {Time, :utc_now} => nil
   }
 
   @impl true
@@ -53,17 +57,17 @@ defmodule AshCredo.Check.Warning.PinnedTimeInExpression do
     |> Enum.flat_map(&module_expr_issues(&1, issue_meta))
   end
 
-  defp find_pinned_time_calls(ast, issue_meta) do
+  defp find_pinned_time_calls(ast, env, issue_meta) do
     Credo.Code.prewalk(
       ast,
       fn
-        {:^, meta, [{{:., _, [{:__aliases__, _, module}, func]}, _, _}]} = node, acc ->
-          case Map.fetch(@time_calls, {module, func}) do
+        {:^, meta, [{{:., _, [{:__aliases__, _, segments}, func]}, _, _}]} = node, acc ->
+          case time_call(segments, func, env) do
             :error ->
               {node, acc}
 
             {:ok, replacement} ->
-              pinned = "^#{Name.full(module)}.#{func}()"
+              pinned = "^#{Name.full(segments)}.#{func}()"
 
               issue =
                 format_issue(issue_meta,
@@ -82,6 +86,15 @@ defmodule AshCredo.Check.Warning.PinnedTimeInExpression do
     )
   end
 
+  # Resolves the pinned call's target module through the env visible at
+  # the enclosing `expr`, so an aliased `^DT.utc_now()` matches and an
+  # unrelated module's `utc_now` does not.
+  defp time_call(segments, func, env) do
+    with {:ok, module} <- Aliases.expand_to_module(segments, env) do
+      Map.fetch(@time_calls, {module, func})
+    end
+  end
+
   defp pinned_message(nil, pinned) do
     "`#{pinned}` is evaluated at compile time and never updates, and no " <>
       "expression builtin returns the current time of day. Pass the value " <>
@@ -94,17 +107,41 @@ defmodule AshCredo.Check.Warning.PinnedTimeInExpression do
   end
 
   defp module_expr_issues(module_ast, issue_meta) do
+    envs = expr_envs(module_ast)
+
     module_ast
     |> Block.module_body()
     |> Enum.reject(&match?({:defmodule, _, _}, &1))
-    |> Enum.flat_map(&expr_issues(&1, issue_meta))
+    |> Enum.flat_map(&expr_issues(&1, envs, issue_meta))
+  end
+
+  # Maps each `expr(...)` node in the module to the `Macro.Env` visible at
+  # it, so pinned calls resolve through the directives lexically in scope.
+  # Keyed on the node itself: its meta carries line/column, so structural
+  # equality identifies the call site.
+  defp expr_envs(module_ast) do
+    {envs, _scope} =
+      LexicalScopeWalker.traverse(
+        module_ast,
+        %{},
+        fn
+          {:expr, _, [_body]} = node, scope, acc ->
+            Map.put_new(acc, node, LexicalScopeWalker.env(scope))
+
+          _node, _scope, acc ->
+            acc
+        end,
+        fn _node, _scope, acc -> acc end
+      )
+
+    envs
   end
 
   # Heads whose bodies run after compilation: the pinned call inside them
   # is re-evaluated per invocation, so the freeze bug does not exist there.
   @deferred_heads ~w(def defp defmacro defmacrop fn &)a
 
-  defp expr_issues(ast, issue_meta) do
+  defp expr_issues(ast, envs, issue_meta) do
     Credo.Code.prewalk(
       ast,
       fn
@@ -122,7 +159,8 @@ defmodule AshCredo.Check.Warning.PinnedTimeInExpression do
           {:pruned, acc}
 
         {:expr, _meta, [body]} = node, acc ->
-          {node, find_pinned_time_calls(body, issue_meta) ++ acc}
+          env = Map.get(envs, node, Aliases.base_env())
+          {node, find_pinned_time_calls(body, env, issue_meta) ++ acc}
 
         node, acc ->
           {node, acc}

--- a/test/ash_credo/check/warning/compile_time_default_test.exs
+++ b/test/ash_credo/check/warning/compile_time_default_test.exs
@@ -40,6 +40,26 @@ defmodule AshCredo.Check.Warning.CompileTimeDefaultTest do
     assert issue.line_no == 6
   end
 
+  test "reports a frozen default in a second attributes block" do
+    source = """
+    defmodule MyApp.Post do
+      use Ash.Resource, domain: MyApp.Blog
+
+      attributes do
+        uuid_primary_key :id
+      end
+
+      attributes do
+        attribute :scheduled_at, :utc_datetime, default: DateTime.utc_now()
+      end
+    end
+    """
+
+    assert [issue] = run_check(CompileTimeDefault, source)
+    assert issue.trigger == "DateTime.utc_now()"
+    assert issue.line_no == 9
+  end
+
   test "reports frozen update_default" do
     source = """
     defmodule MyApp.Post do
@@ -150,6 +170,81 @@ defmodule AshCredo.Check.Warning.CompileTimeDefaultTest do
 
     assert [issue] = run_check(CompileTimeDefault, source)
     assert issue.trigger == "DateTime.utc_now()"
+  end
+
+  test "reports frozen default called through an alias rename" do
+    source = """
+    defmodule MyApp.Post do
+      use Ash.Resource, domain: MyApp.Blog
+
+      alias DateTime, as: DT
+
+      attributes do
+        attribute :scheduled_at, :utc_datetime, default: DT.utc_now()
+      end
+    end
+    """
+
+    assert [issue] = run_check(CompileTimeDefault, source)
+    assert issue.trigger == "DT.utc_now()"
+    assert issue.line_no == 7
+    assert issue.message =~ "&DT.utc_now/0"
+  end
+
+  test "reports frozen default called through a plain alias" do
+    source = """
+    defmodule MyApp.Post do
+      use Ash.Resource, domain: MyApp.Blog
+
+      alias Ash.UUID
+
+      attributes do
+        attribute :token, :uuid, default: UUID.generate()
+      end
+    end
+    """
+
+    assert [issue] = run_check(CompileTimeDefault, source)
+    assert issue.trigger == "UUID.generate()"
+    assert issue.line_no == 7
+  end
+
+  test "reports Elixir-prefixed forms, aliased and fully qualified" do
+    source = """
+    defmodule MyApp.Post do
+      use Ash.Resource, domain: MyApp.Blog
+
+      alias Elixir.DateTime
+
+      attributes do
+        attribute :scheduled_at, :utc_datetime, default: DateTime.utc_now()
+        attribute :expires_at, :utc_datetime, default: Elixir.DateTime.utc_now()
+      end
+    end
+    """
+
+    assert [first, second] = run_check(CompileTimeDefault, source)
+    assert first.trigger == "DateTime.utc_now()"
+    assert first.line_no == 7
+    assert second.trigger == "Elixir.DateTime.utc_now()"
+    assert second.line_no == 8
+  end
+
+  test "no issue for a differently-named module's utc_now" do
+    source = """
+    defmodule MyApp.Post do
+      use Ash.Resource, domain: MyApp.Blog
+
+      alias MyApp.Clock
+
+      attributes do
+        attribute :scheduled_at, :utc_datetime, default: Clock.utc_now()
+        attribute :expires_at, :utc_datetime, default: MyApp.Clock.utc_now()
+      end
+    end
+    """
+
+    assert [] = run_check(CompileTimeDefault, source)
   end
 
   test "no issue for zero-arity captures" do

--- a/test/ash_credo/check/warning/pinned_time_in_expression_test.exs
+++ b/test/ash_credo/check/warning/pinned_time_in_expression_test.exs
@@ -66,6 +66,72 @@ defmodule AshCredo.Check.Warning.PinnedTimeInExpressionTest do
     assert issue.trigger =~ "^NaiveDateTime.utc_now()"
   end
 
+  test "reports pinned time called through an alias rename" do
+    source = """
+    defmodule MyApp.Session do
+      use Ash.Resource, domain: MyApp.Auth
+
+      alias DateTime, as: DT
+
+      actions do
+        read :active do
+          filter expr(expires_at >= ^DT.utc_now())
+        end
+      end
+    end
+    """
+
+    assert [issue] = run_check(PinnedTimeInExpression, source)
+    assert issue.message =~ "now()"
+    assert issue.trigger == "^DT.utc_now()"
+    assert issue.line_no == 8
+  end
+
+  test "reports Elixir-prefixed pinned forms, aliased and fully qualified" do
+    source = """
+    defmodule MyApp.Session do
+      use Ash.Resource, domain: MyApp.Auth
+
+      alias Elixir.DateTime
+
+      actions do
+        read :active do
+          filter expr(expires_at >= ^DateTime.utc_now())
+        end
+
+        read :expired do
+          filter expr(expires_at < ^Elixir.DateTime.utc_now())
+        end
+      end
+    end
+    """
+
+    issues = run_check(PinnedTimeInExpression, source)
+    assert sorted_lines(issues) == [8, 12]
+
+    assert Enum.map(issues, & &1.trigger) |> Enum.sort() ==
+             ["^DateTime.utc_now()", "^Elixir.DateTime.utc_now()"]
+  end
+
+  test "no issue for a differently-named module's utc_now" do
+    source = """
+    defmodule MyApp.Venue do
+      use Ash.Resource, domain: MyApp.Places
+
+      alias MyApp.Clock
+
+      actions do
+        read :open_now do
+          filter expr(opens_at <= ^Clock.utc_now())
+          filter expr(closes_at >= ^MyApp.Clock.utc_now())
+        end
+      end
+    end
+    """
+
+    assert [] = run_check(PinnedTimeInExpression, source)
+  end
+
   test "no issue when using today() in expr" do
     source = """
     defmodule MyApp.Subscription do


### PR DESCRIPTION
## Summary

- `CompileTimeDefault` and `PinnedTimeInExpression` matched frozen-time calls by literal alias segments (`[:DateTime]`, `[:Ash, :UUID]`, ...), so `alias DateTime, as: DT` + `default: DT.utc_now()` slipped through, as did fully-qualified `Elixir.DateTime.utc_now()`.
- Key both call tables on resolved module atoms and resolve each call's target through the lexical environment (`Introspection.LexicalScopeWalker` + `Aliases.expand_to_module/2`), the same mechanism `ActorOnCallOptions` and `MissingMacroDirective` already use.
- `CompileTimeDefault` walks the module AST with the walker so top-of-module directives are in scope when the `attributes`/`actions`/`calculations` sections are reached; `PinnedTimeInExpression` maps each `expr(...)` node to its visible env before scanning for pinned calls.
- Issue messages keep the as-written call name so column anchoring is unchanged.
- Add regressions for the `as:` rename, plain aliases, and `Elixir.`-prefixed forms as issues, and a differently-named module's `utc_now/0` as a non-issue.