### PR TITLE
fix: tag ActorOnCallOptions as a security check

### DIFF
--- a/lib/ash_credo/check/warning/actor_on_call_options.ex
+++ b/lib/ash_credo/check/warning/actor_on_call_options.ex
@@ -2,7 +2,7 @@ defmodule AshCredo.Check.Warning.ActorOnCallOptions do
   use Credo.Check,
     base_priority: :high,
     category: :warning,
-    tags: [:ash],
+    tags: [:ash, :security],
     explanations: [
       check: """
       `actor:` and `tenant:` belong on the query/changeset/input, set when it


### PR DESCRIPTION
## Summary

- `ActorOnCallOptions` enforces an Ash authorization usage rule but only carried `tags: [:ash]`, so `mix credo --only security` skipped it while surfacing the other authorization and data-exposure checks. Add the `:security` tag.