### PR TITLE
docs: cover embedded resources in MissingPrimaryAction on purpose

### DIFF
--- a/lib/ash_credo/check/design/missing_primary_action.ex
+++ b/lib/ash_credo/check/design/missing_primary_action.ex
@@ -25,6 +25,13 @@ defmodule AshCredo.Check.Design.MissingPrimaryAction do
       Spark transformers and extensions - so it catches cases where a
       transformer adds an action that breaks the primary-action invariant.
 
+      Embedded resources are deliberately covered: when casting embedded
+      values, Ash resolves the primary action of each CRUD type via
+      `Ash.Resource.Info.primary_action!/2`, so a missing primary raises at
+      runtime there as well. Ash injects primary defaults into embedded
+      resources, but defining an action that shadows a default's name (e.g.
+      `update :update`) without `primary?: true` removes that safety net.
+
       ## Requirements
 
       Your project must be compiled before running `mix credo` so that the

--- a/test/ash_credo/check/design/missing_primary_action_test.exs
+++ b/test/ash_credo/check/design/missing_primary_action_test.exs
@@ -37,6 +37,23 @@ defmodule AshCredo.Check.Design.MissingPrimaryActionTest do
     assert [] = run_check(MissingPrimaryAction, source)
   end
 
+  test "reports embedded resources too - Ash casts embeds via primary actions" do
+    # EmbeddedAddress shadows the injected `:update` default without marking
+    # it primary, leaving two non-primary updates. `Ash.EmbeddableType`
+    # resolves updates via `primary_action!/2`, so this raises at runtime -
+    # embedded resources are deliberately not exempt from this check, unlike
+    # in the sibling Design checks (identities and code interfaces have no
+    # effect on embedded resources; primary actions do).
+    source = """
+    defmodule AshCredoFixtures.Accounts.EmbeddedAddress do
+      use Ash.Resource, data_layer: :embedded
+    end
+    """
+
+    assert [issue] = run_check(MissingPrimaryAction, source)
+    assert issue.trigger == "update"
+  end
+
   test "reports an issue when multiple creates exist without primary" do
     # Blog.Tag has :create_basic and :create_with_slug, neither primary.
     source = """

--- a/test/support/fixtures/ash_fixtures.ex
+++ b/test/support/fixtures/ash_fixtures.ex
@@ -207,6 +207,31 @@ defmodule AshCredoFixtures.Accounts.EmbeddedContact do
   end
 end
 
+defmodule AshCredoFixtures.Accounts.EmbeddedAddress do
+  @moduledoc """
+  `MissingPrimaryAction` embedded-resource fixture: two `:update` actions,
+  neither primary. Naming one `:update` shadows the primary default Ash
+  injects into embedded resources (`SetPrimaryActions.add_defaults/1` skips
+  a default whose name is taken), so the resource ends up with no primary
+  update. Embedded resources are deliberately covered by the check -
+  `Ash.EmbeddableType` resolves the primary `create`/`read`/`update`/
+  `destroy` via `Ash.Resource.Info.primary_action!/2` when casting embeds,
+  which raises in exactly this state.
+  """
+
+  use Ash.Resource, data_layer: :embedded
+
+  actions do
+    update :update
+    update :update_city
+  end
+
+  attributes do
+    attribute :street, :string, public?: true
+    attribute :city, :string, public?: true
+  end
+end
+
 defmodule AshCredoFixtures.Accounts.Account do
   @moduledoc """
   `UseCodeInterface` fixture for the long-tail suggestion families:


### PR DESCRIPTION
## Summary

- `MissingPrimaryAction` is the only Design check without an embedded-resource filter, which looked like an oversight. It is not: when casting embedded values, Ash resolves the primary action of each CRUD type via `Ash.Resource.Info.primary_action!/2`, so a missing primary raises at runtime on embedded resources too.
- Ash injects primary defaults into embedded resources, but `SetPrimaryActions.add_defaults/1` skips a default whose name is taken - defining `update :update` without `primary?: true` leaves the resource with no primary update.
- Document the deliberate coverage in the check's explanation and pin it with an `EmbeddedAddress` fixture that shadows the injected `:update` default, so the missing filter is not "fixed" into a false negative later.