### PR TITLE
docs: rewrite README, module docs, and comments for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@
 [![HexDocs](https://img.shields.io/badge/hex-docs-blue.svg)](https://ash-credo.hexdocs.pm)
 [![License: MIT](https://img.shields.io/badge/license-MIT-brightgreen.svg)](https://opensource.org/licenses/MIT)
 
-Unofficial static code analysis checks for the [Ash Framework](https://ash-hq.org), built as a [Credo](https://github.com/rrrene/credo) plugin.
+AshCredo is an unofficial set of static analysis checks for the [Ash Framework](https://ash-hq.org), built as a [Credo](https://github.com/rrrene/credo) plugin.
 
-AshCredo detects common anti-patterns, security pitfalls, and missing best practices in your Ash resources, domains, and the code that calls into them. Some checks analyse unexpanded source AST; others introspect the compiled modules to see the fully-resolved DSL state, including anything Spark transformers and extensions contribute.
+AshCredo finds common anti-patterns, security pitfalls, and missing best practices in your Ash resources, domains, and the code that calls into them. Some checks analyse the unexpanded source AST. Others introspect the compiled modules and see the fully resolved DSL state, including anything Spark transformers and extensions contribute.
 
 > [!WARNING]
 > This project is experimental and might break frequently.
 
-**Note: only the following checks are enabled by default.** All other checks are opt-in - enable them individually in your `.credo.exs` (see [Configuration](#configuration)).
+**Only the following checks are enabled by default.** All other checks are opt-in: enable them individually in your `.credo.exs` (see [Configuration](#configuration)).
 
 - `Warning.CompileTimeDefault`
 - `Warning.MissingBuiltinWrapper`
@@ -24,13 +24,13 @@ AshCredo requires [Credo](https://credo.hexdocs.pm) to already be installed in y
 
 ### With Igniter (recommended)
 
-If your project uses [Igniter](https://igniter.hexdocs.pm), a single command will add the dependency and register the plugin in your `.credo.exs`:
+If your project uses [Igniter](https://igniter.hexdocs.pm), a single command adds the dependency and registers the plugin in your `.credo.exs`:
 
 ```bash
 mix igniter.install ash_credo@0.17.0
 ```
 
-The explicit version prevents Igniter from generating a broad pre-1.0 requirement. Igniter pins a three-part version exactly; use the manual requirement below if you prefer compatible patch updates. The installer scopes `ash_credo` to `:dev`/`:test` and sets `runtime: false` automatically, matching how `credo` itself is typically declared. Pass `--only dev,test` if you'd like an early error when running from another `MIX_ENV`.
+The explicit version prevents Igniter from generating a broad pre-1.0 requirement. Igniter pins a three-part version exactly, so if you prefer compatible patch updates, use the manual requirement below. The installer scopes `ash_credo` to `:dev`/`:test` and sets `runtime: false` automatically, matching how `credo` itself is typically declared. Pass `--only dev,test` if you'd like an early error when running from another `MIX_ENV`.
 
 ### Manual
 
@@ -68,43 +68,43 @@ mix deps.get
 mix credo
 ```
 
-If you have any compiled-introspection checks enabled, run `mix compile` before `mix credo` - typically via a Mix alias like `lint: ["compile", "credo --strict"]`. See [Checks that require a compiled project](#checks-that-require-a-compiled-project) for the full list and the rationale.
+If you have any compiled-introspection checks enabled, run `mix compile` before `mix credo`, typically via a Mix alias like `lint: ["compile", "credo --strict"]`. See [Checks that require a compiled project](#checks-that-require-a-compiled-project) for the full list and the rationale.
 
 ## Checks
 
 | Check | Category | Priority | Default | Description |
 |---|---|---|---|---|
-| `ActorOnCallOptions` | Warning | High | No | Flags `actor:`/`tenant:` passed in the options of `Ash.read!`/`Ash.create!`/... when the subject visibly went through a `for_*` builder - per Ash's authorization usage rules they belong on the query/changeset/input |
+| `ActorOnCallOptions` | Warning | High | No | Flags `actor:`/`tenant:` passed in the options of `Ash.read!`/`Ash.create!`/... when the subject visibly went through a `for_*` builder. Per Ash's authorization usage rules, these options belong on the query, changeset, or input |
 | `AuthorizeFalse` | Warning | High | No | Flags literal `authorize?: false` in Ash calls, action DSL, and (by default) any other call site |
-| `AuthorizerWithoutPolicies` | Warning | High | No | Detects resources with `Ash.Policy.Authorizer` but no policies defined. **Requires compiled project.** |
-| `CompileTimeDefault` | Warning | High | Yes | Flags `default: DateTime.utc_now()` / `Ash.UUID.generate()` (missing `&.../0` capture) on attributes and arguments - the call runs once at compile time, so every record gets the same frozen value |
+| `AuthorizerWithoutPolicies` | Warning | High | No | Detects resources with `Ash.Policy.Authorizer` but no policies defined. **Requires a compiled project.** |
+| `CompileTimeDefault` | Warning | High | Yes | Flags `default: DateTime.utc_now()` / `Ash.UUID.generate()` (missing the `&.../0` capture) on attributes and arguments. The call runs once at compile time, so every record gets the same frozen value |
 | `EmptyDomain` | Warning | Normal | No | Flags domains with no resources registered |
-| `MissingBuiltinWrapper` | Warning | High | Yes | Flags builtin change/validation/preparation/calculation functions (`set_attribute`, `present`, `build`, `concat`, ...) used without their `change`/`validate`/`prepare`/`calculate` wrapper in action bodies, pipelines, and global sections - the bare call compiles but is silently discarded |
-| `MissingDomain` | Warning | Normal | No | Ensures non-embedded resources set the `domain:` option |
-| `MissingMacroDirective` | Warning | High | Yes | Flags qualified calls to `Ash.Query`/`Ash.Expr` macros (`filter`, `expr`, ...) when the enclosing module does not have a matching module-level `require`/`import`. Catches the runtime `UndefinedFunctionError` that slips past the compiler when the macro argument is a bare runtime value. **Requires compiled project** and **configurable**. |
+| `MissingBuiltinWrapper` | Warning | High | Yes | Flags builtin change/validation/preparation/calculation functions (`set_attribute`, `present`, `build`, `concat`, ...) used without their `change`/`validate`/`prepare`/`calculate` wrapper in action bodies, pipelines, and global sections. The bare call compiles but is silently discarded |
+| `MissingDomain` | Warning | Normal | No | Flags non-embedded resources that don't set the `domain:` option |
+| `MissingMacroDirective` | Warning | High | Yes | Flags qualified calls to `Ash.Query`/`Ash.Expr` macros (`filter`, `expr`, ...) when the enclosing module has no matching module-level `require`/`import`. Catches the runtime `UndefinedFunctionError` that slips past the compiler when the macro argument is a bare runtime value. **Requires a compiled project** and **configurable**. |
 | `OverlyPermissivePolicy` | Warning | High | No | Flags unscoped `authorize_if always()` policies |
 | `PinnedTimeInExpression` | Warning | High | Yes | Flags `^Date.utc_today()` / `^DateTime.utc_now()` in Ash expressions (frozen at compile time) |
-| `RedundantValidation` | Warning | Normal | No | Flags `validate present(...)` on attributes that already have `allow_nil? false` - the constraint guarantees presence, making the validation redundant (skips `allow_nil_input` escape hatches). **Requires compiled project.** |
+| `RedundantValidation` | Warning | Normal | No | Flags `validate present(...)` on attributes that already have `allow_nil? false`. The constraint guarantees presence, so the validation is redundant (skips `allow_nil_input` escape hatches). **Requires a compiled project.** |
 | `SensitiveAttributeExposed` | Warning | High | No | Flags sensitive attributes (password, token, secret, ...) not marked `sensitive?: true` |
 | `SensitiveFieldInAccept` | Warning | High | No | Flags privilege-escalation fields (`is_admin`, `permissions`, ...) in `accept` lists |
-| `UnknownAction` | Warning | High | No | Flags `Ash.*` calls referencing actions that do not exist on the resolved resource, with a fuzzy `Did you mean` hint. **Requires compiled project.** |
+| `UnknownAction` | Warning | High | No | Flags `Ash.*` calls referencing actions that don't exist on the resolved resource, with a fuzzy `Did you mean` hint. **Requires a compiled project.** |
 | `WildcardAcceptOnAction` | Warning | High | No | Detects `accept :*` on `create`/`update`/soft `destroy` actions (mass-assignment risk) |
-| `AnonymousFunctionInDsl` | Refactor | Normal | No | Flags `fn`/`&` captures passed to `change`/`validate`/`prepare`/`calculate` - anonymous functions can never be atomic (changes/validations) or supply an expression (calculations); extract them into callback modules |
+| `AnonymousFunctionInDsl` | Refactor | Normal | No | Flags `fn`/`&` captures passed to `change`/`validate`/`prepare`/`calculate`. Anonymous functions can never be atomic (changes/validations) or supply an expression (calculations), so extract them into callback modules |
 | `DirectiveInFunctionBody` | Refactor | Normal | No | Flags `require`/`import`/`alias` of configured modules (default `Ash.Query`, `Ash.Expr`) declared inside function bodies instead of at module level |
 | `LargeResource` | Refactor | Low | No | Flags resource files exceeding 400 lines |
-| `RaisingCall` | Refactor | Low | No | Flags Ash bang calls - top-level `Ash.read!`/`Ash.create!`/`Ash.Filter.parse!` plus code-interface bangs like `MyApp.Blog.create_post!`. Orphan bangs (those without a non-bang counterpart, e.g. `Ash.stream!`, `Ash.Seed.seed!`) are detected dynamically and skipped. Test directories excluded by default. **Requires compiled project.** |
-| `UseCodeInterface` | Refactor | Normal | No | Flags `Ash.*` calls where both resource and action are literals - names the exact code interface function to call instead. **Requires compiled project** and **configurable** (see below). Pair with `Warning.UnknownAction` for typo detection. |
-| `MissingCodeInterface` | Design | Low | No | Flags each action on non-embedded resources that has no code interface (resource- or domain-level). **Requires compiled project.** |
-| `MissingIdentity` | Design | Normal | No | Suggests identities for attributes like `email`, `username`, `slug` on non-embedded resources. **Requires compiled project.** |
-| `MissingPrimaryAction` | Design | Normal | No | Flags missing `primary?: true` when multiple actions of the same CRUD type exist (generic `:action` types are excluded). **Requires compiled project.** |
-| `MissingTimestamps` | Design | Normal | No | Suggests adding `timestamps()` to persisted resources. **Requires compiled project.** |
+| `RaisingCall` | Refactor | Low | No | Flags Ash bang calls: top-level `Ash.read!`/`Ash.create!`/`Ash.Filter.parse!` plus code-interface bangs like `MyApp.Blog.create_post!`. Orphan bangs (those without a non-bang counterpart, e.g. `Ash.stream!`, `Ash.Seed.seed!`) are detected dynamically and skipped. Test directories are excluded by default. **Requires a compiled project.** |
+| `UseCodeInterface` | Refactor | Normal | No | Flags `Ash.*` calls where both resource and action are literals, and names the exact code interface function to call instead. **Requires a compiled project** and **configurable** (see below). Pair it with `Warning.UnknownAction` for typo detection |
+| `MissingCodeInterface` | Design | Low | No | Flags each action on non-embedded resources that has no code interface (resource- or domain-level). **Requires a compiled project.** |
+| `MissingIdentity` | Design | Normal | No | Suggests identities for attributes like `email`, `username`, `slug` on non-embedded resources. **Requires a compiled project.** |
+| `MissingPrimaryAction` | Design | Normal | No | Flags missing `primary?: true` when multiple actions of the same CRUD type exist (generic `:action` types are excluded). **Requires a compiled project.** |
+| `MissingTimestamps` | Design | Normal | No | Suggests adding `timestamps()` to persisted resources. **Requires a compiled project.** |
 | `ActionMissingDescription` | Readability | Low | No | Flags actions without a `description` |
-| `BelongsToMissingAllowNil` | Readability | Normal | No | Flags `belongs_to` without explicit `allow_nil?` |
+| `BelongsToMissingAllowNil` | Readability | Normal | No | Flags `belongs_to` without an explicit `allow_nil?` |
 
 ## Checks that require a compiled project
 
-Several checks read Ash's runtime introspection (`Ash.Resource.Info`, `Ash.Domain.Info`, and `Ash.Policy.Info`) rather than source AST.
-They see the fully-resolved resource state - including anything Spark transformers or extensions contribute - and catch bugs that pure AST scanning would miss (e.g. identities on AshAuthentication-injected `:email` attributes, fragment-spliced actions, extension-added authorizers).
+Several checks read Ash's runtime introspection (`Ash.Resource.Info`, `Ash.Domain.Info`, and `Ash.Policy.Info`) rather than the source AST.
+They see the fully resolved resource state, including anything Spark transformers or extensions contribute, and catch bugs that pure AST scanning would miss: identities on AshAuthentication-injected `:email` attributes, fragment-spliced actions, extension-added authorizers, and so on.
 
 - `Warning.AuthorizerWithoutPolicies`
 - `Warning.MissingMacroDirective`
@@ -117,8 +117,8 @@ They see the fully-resolved resource state - including anything Spark transforme
 - `Design.MissingPrimaryAction`
 - `Design.MissingTimestamps`
 
-**Your project must be compiled before running `mix credo`**, otherwise these checks emit a configuration diagnostic and become a no-op.
-Typically chain the two commands in a Mix alias:
+**Compile your project before running `mix credo`.** Otherwise these checks emit a configuration diagnostic and become a no-op.
+Typically you chain the two commands in a Mix alias:
 
 ```elixir
 # mix.exs
@@ -129,7 +129,7 @@ defp aliases do
 end
 ```
 
-If a referenced resource cannot be loaded, the check emits a per-call-site "could not load" issue pointing at the resource. If Ash itself is not available in the VM running Credo (why are you using `ash_credo` without depending on Ash?), these checks emit a single shared diagnostic and become no-ops. You can disable any of them in `.credo.exs` if your workflow can't run `mix compile` beforehand.
+If a referenced resource can't be loaded, the check emits a per-call-site "could not load" issue pointing at the resource. If Ash itself isn't available in the VM running Credo, these checks emit a single shared diagnostic and become no-ops. You can disable any of them in `.credo.exs` if your workflow can't run `mix compile` beforehand.
 
 ## Configuration
 
@@ -163,7 +163,7 @@ Enable additional checks by adding them to the `extra` section of your `.credo.e
 }
 ```
 
-To enable **all** checks at once (the default-on checks listed above do not need an entry):
+To enable **all** checks at once (the default-on checks listed above don't need an entry):
 
 ```elixir
 checks: %{
@@ -201,18 +201,18 @@ The following checks accept custom parameters:
 | Check | Parameter | Default | Description |
 |---|---|---|---|
 | `Warning.AuthorizeFalse` | `include_non_ash_calls` | `true` | When `false`, only checks Ash API calls and action DSL definitions |
-| `Warning.AuthorizeFalse` | `excluded_paths` | `[~r"/test/", "test"]` | Paths or regexes to skip. Binary entries match as path segments or full file paths. Defaults to test directories where `authorize?: false` is typically intentional |
+| `Warning.AuthorizeFalse` | `excluded_paths` | `[~r"/test/", "test"]` | Paths or regexes to skip. Binary entries match as path segments or full file paths. Defaults to test directories, where `authorize?: false` is typically intentional |
 | `Warning.MissingMacroDirective` | `macro_modules` | `[Ash.Query, Ash.Expr]` | Modules whose qualified macro calls the check validates. Macros are read from `module.__info__(:macros)`, so only real macros are flagged |
 | `Warning.SensitiveAttributeExposed` | `sensitive_names` | `~w(password hashed_password password_hash password_digest token access_token secret client_secret totp_secret api_key private_key ssn)a` | Attribute names to flag when not marked `sensitive?: true`. Atom entries match exactly; `Regex` entries (e.g. `~r/_token$/`) match against the attribute name |
 | `Warning.SensitiveAttributeExposed` | `excluded_paths` | `[~r"/test/", "test"]` | Paths or regexes to skip. Binary entries match as path segments or full file paths. Defaults to test directories, where fake sensitive attributes are common in test resources |
 | `Warning.SensitiveFieldInAccept` | `dangerous_fields` | `~w(is_admin admin permissions api_key secret_key)a` | Field names to flag when found in `accept` lists |
 | `Warning.SensitiveFieldInAccept` | `excluded_paths` | `[~r"/test/", "test"]` | Paths or regexes to skip. Binary entries match as path segments or full file paths. Defaults to test directories, where accepting these fields is often intentional |
 | `Warning.WildcardAcceptOnAction` | `excluded_paths` | `[~r"/test/", "test"]` | Paths or regexes to skip. Binary entries match as path segments or full file paths. Defaults to test directories, where `accept :*` is often intentional |
-| `Refactor.DirectiveInFunctionBody` | `directive_modules` | `[Ash.Query, Ash.Expr]` | List of modules whose `require`/`import`/`alias` must live at module level. Add any other macro module your team treats the same way |
-| `Refactor.LargeResource` | `max_lines` | `400` | Maximum line count before triggering |
-| `Refactor.RaisingCall` | `excluded_functions` | `[]` | `{module, :fun!}` tuples to allow without flagging. Bang-only APIs (those with no non-bang counterpart) are detected dynamically by probing `module.__info__(:functions)`, so no curated allowlist is needed - this option only exists for cases where you want to silence a real bang/non-bang pair |
+| `Refactor.DirectiveInFunctionBody` | `directive_modules` | `[Ash.Query, Ash.Expr]` | Modules whose `require`/`import`/`alias` must live at module level. Add any other macro module your team treats the same way |
+| `Refactor.LargeResource` | `max_lines` | `400` | Maximum line count before the check triggers |
+| `Refactor.RaisingCall` | `excluded_functions` | `[]` | `{module, :fun!}` tuples to allow without flagging. Bang-only APIs (those with no non-bang counterpart) are detected dynamically by probing `module.__info__(:functions)`, so no curated allowlist is needed. This option only exists for cases where you want to silence a real bang/non-bang pair |
 | `Refactor.RaisingCall` | `excluded_paths` | `[~r"/test/", "test"]` | Paths or regexes to skip. Binary entries match as path segments (`"test"` excludes any file under a `test/` directory) or as full file paths (`"priv/seeds.exs"` excludes that file). Defaults to test directories, where bang versions are idiomatic |
-| `Refactor.RaisingCall` | `flag_bang_only_apis` | `false` | When `true`, also flag bangs whose non-bang counterpart doesn't exist (e.g. `Ash.stream!`, `Ash.Seed.seed!`) with a generic "ensure failures are properly handled" message. Default is `false` since the suggested non-bang twin wouldn't exist for these calls; opt in only if your team policy is "no bare bang calls anywhere" |
+| `Refactor.RaisingCall` | `flag_bang_only_apis` | `false` | When `true`, also flags bangs whose non-bang counterpart doesn't exist (e.g. `Ash.stream!`, `Ash.Seed.seed!`) with a generic "ensure failures are properly handled" message. Defaults to `false` since the suggested non-bang twin wouldn't exist for these calls; opt in only if your team policy is "no bare bang calls anywhere" |
 | `Refactor.UseCodeInterface` | `enforce_code_interface_in_domain` | `true` | See [Adapting UseCodeInterface](#adapting-usecodeinterface-to-your-teams-conventions) below |
 | `Refactor.UseCodeInterface` | `enforce_code_interface_outside_domain` | `true` | See [Adapting UseCodeInterface](#adapting-usecodeinterface-to-your-teams-conventions) below |
 | `Refactor.UseCodeInterface` | `excluded_paths` | `[~r"/test/", "test"]` | Paths or regexes to skip. Binary entries match as path segments or full file paths. Defaults to test directories, where raw `Ash.*` calls are idiomatic setup code |
@@ -223,56 +223,57 @@ The following checks accept custom parameters:
 ### Adapting `UseCodeInterface` to your team's conventions
 
 `UseCodeInterface` accepts params that map to common code-interface
-philosophies. The two `enforce_*` flags decide *which call sites* the check
-fires on; `prefer_interface_scope` decides *which interface* the suggestion
+philosophies. The two `enforce_*` flags decide which call sites the check
+fires on; `prefer_interface_scope` decides which interface the suggestion
 points at. They compose freely.
 
 ```elixir
-# Default - "in-domain caller → resource interface,
-#            outside-domain caller → domain interface" hierarchy.
+# Default: an in-domain caller gets the resource interface.
+# An outside-domain caller gets the domain interface.
 {AshCredo.Check.Refactor.UseCodeInterface, []},
 
-# Opinion A - raw Ash.* calls are OK when the caller is in the resource's
+# Opinion A: raw Ash.* calls are OK when the caller is in the resource's
 # domain (e.g. inside a Change / Preparation / Validation module). Only
 # flag callers from outside the domain.
 {AshCredo.Check.Refactor.UseCodeInterface,
  [enforce_code_interface_in_domain: false]},
 
-# Opinion B - code interfaces are only defined on resources; never suggest
+# Opinion B: code interfaces are only defined on resources. Never suggest
 # reaching for a domain-level interface, regardless of the call site.
 {AshCredo.Check.Refactor.UseCodeInterface,
  [prefer_interface_scope: :resource]},
 
-# Opinion C - the inverse of Opinion A. Strict inside the domain (changes,
+# Opinion C: the inverse of Opinion A. Strict inside the domain (changes,
 # preparations, validations, sibling resources must use code interfaces),
 # but permissive outside (controllers, LiveViews, workers can call Ash.*
-# directly without a nag). Useful for incremental adoption - enforce the
+# directly without a nag). Useful for incremental adoption: enforce the
 # pattern in the resource layer first, clean up the web layer later.
 {AshCredo.Check.Refactor.UseCodeInterface,
  [enforce_code_interface_outside_domain: false]},
 
-# Opinion A + B - allow same-domain raw calls AND always direct the rest
+# Opinion A + B: allow same-domain raw calls AND always direct the rest
 # at the resource-level interface.
 {AshCredo.Check.Refactor.UseCodeInterface,
  [enforce_code_interface_in_domain: false, prefer_interface_scope: :resource]},
 ```
 
-- **`enforce_code_interface_in_domain`** (`true` default) - when `false`, leaves
-  callers that share a domain with the resource alone (Opinion A).
-- **`enforce_code_interface_outside_domain`** (`true` default) - when `false`,
-  silences every case where the caller is not confirmed to be in the resource's
-  domain (different domain, plain controller/LiveView, domainless resource,
-  `:not_loadable` resource) (Opinion C).
-- **`prefer_interface_scope`** (`:auto | :resource | :domain`, default `:auto`)
-  - overrides which interface the check points at. `:auto` follows the
-  in-domain/outside-domain heuristic; `:resource` always suggests a
+- **`enforce_code_interface_in_domain`** (default `true`). When `false`, the
+  check leaves callers that share a domain with the resource alone
+  (Opinion A).
+- **`enforce_code_interface_outside_domain`** (default `true`). When `false`,
+  the check silences every case where the caller isn't confirmed to be in the
+  resource's domain: a different domain, a plain controller or LiveView, a
+  domainless resource, or a `:not_loadable` resource (Opinion C).
+- **`prefer_interface_scope`** (`:auto | :resource | :domain`, default
+  `:auto`). Overrides which interface the check points at. `:auto` follows
+  the in-domain/outside-domain heuristic; `:resource` always suggests a
   resource-level function (Opinion B); `:domain` always suggests a
   domain-level function.
 
 Setting both `enforce_*` flags to `false` effectively disables the check
 for loadable resources. In this configuration `prefer_interface_scope`
-becomes inert - no suggestion path fires, so combining Opinions A + B + C
-is observationally identical to A + C alone.
+becomes inert, since no suggestion path fires, so combining Opinions
+A + B + C is observationally identical to A + C alone.
 
 ## Contributing
 
@@ -280,8 +281,8 @@ is observationally identical to A + C alone.
 2. Create your feature branch (`git switch -c my-new-check`)
 3. Apply formatting and make sure tests and lints pass (`mix format`, `mix test`, `mix lint`)
 4. Commit your changes
-5. Open a pull request - PR titles must follow the [Conventional Commits](https://www.conventionalcommits.org) format (e.g. `feat: add check for XY`, `fix: handle XY edge case`)
+5. Open a pull request. PR titles must follow the [Conventional Commits](https://www.conventionalcommits.org) format (e.g. `feat: add check for XY`, `fix: handle XY edge case`)
 
 ## License
 
-MIT - see [LICENSE](LICENSE) for details.
+MIT, see [LICENSE](LICENSE) for details.

--- a/lib/ash_credo.ex
+++ b/lib/ash_credo.ex
@@ -1,20 +1,21 @@
 defmodule AshCredo do
   @moduledoc """
-  Credo checks for Ash Framework.
+  Credo checks for the Ash Framework.
 
-  Provides pre-built checks that detect common Ash anti-patterns.
-  Some checks analyse unexpanded source AST; others introspect the
-  compiled modules to see the fully-resolved DSL state, including
-  anything Spark transformers and extensions contribute.
+  The plugin provides pre-built checks that detect common Ash
+  anti-patterns. Some checks analyse the unexpanded source AST, while
+  others introspect the compiled modules to see the fully resolved DSL
+  state, including everything Spark transformers and extensions
+  contribute.
 
-  Checks that introspect compiled modules require the project to be
-  compiled before running `mix credo` (for example via a Mix alias
-  like `lint: ["compile", "credo --strict"]`); otherwise they emit a
+  Checks that introspect compiled modules need the project to be
+  compiled before running `mix credo`, for example via a Mix alias like
+  `lint: ["compile", "credo --strict"]`. Otherwise they emit a
   configuration diagnostic and become a no-op.
 
   ## Plugin Usage
 
-  Add to your `.credo.exs`:
+  Add this to your `.credo.exs`:
 
       %{configs: [%{
         name: "default",

--- a/lib/ash_credo/cache.ex
+++ b/lib/ash_credo/cache.ex
@@ -1,28 +1,30 @@
 defmodule AshCredo.Cache do
   @moduledoc """
-  Process-independent key-value cache backed by a single named ETS table
-  owned by a supervised GenServer.
+  A process-independent key-value cache backed by a single named ETS
+  table owned by a supervised GenServer.
 
   Reads and writes go straight to ETS from the calling process; the
   GenServer exists only to keep the table alive across Credo's transient
   task churn.
 
-  Cleared at the start and end of every Credo run, so each `mix credo`
-  invocation sees a fresh table regardless of how long the host VM has
-  been alive.
+  AshCredo clears the cache at the start and end of every Credo run, so
+  each `mix credo` invocation sees a fresh table regardless of how long
+  the host VM has been alive.
 
-  The OTP application callback starts the cache under supervision when the
-  `:ash_credo` application boots. `AshCredo.init/1` additionally calls
-  `ensure_started!/0` before any check runs, so the table is also available
-  when `mix credo` runs without booting the `:ash_credo` application.
+  The OTP application callback starts the cache under supervision when
+  the `:ash_credo` application boots. `AshCredo.init/1` additionally
+  calls `ensure_started!/0` before any check runs, so the table is also
+  available when `mix credo` doesn't boot the `:ash_credo` application.
 
-  If the table does not exist - for example when checks are enabled directly
+  The table may be absent, for example when checks are enabled directly
   in `.credo.exs` without registering the `{AshCredo, []}` plugin, so
-  `AshCredo.init/1` never runs - every function degrades gracefully instead
-  of raising: reads behave as if nothing were cached and writes are no-ops.
-  Checks then work correctly, just without cross-call caching. The first
-  such access emits a one-time hint to stderr suggesting the plugin
-  registration.
+  `AshCredo.init/1` never runs. In that case every function degrades
+  gracefully instead of raising: reads behave as if nothing were cached,
+  and writes are no-ops.
+
+  Checks then still work correctly, just without cross-call caching.
+  The first such access emits a one-time hint to stderr suggesting the
+  plugin registration.
   """
 
   use GenServer
@@ -39,7 +41,7 @@ defmodule AshCredo.Cache do
   @memoize_miss {__MODULE__, :memoize_miss}
 
   @doc """
-  Starts the cache GenServer. Idempotent - returns the existing pid if
+  Starts the cache GenServer. Idempotent: returns the existing pid if
   already started.
   """
   @spec start_link(keyword()) :: GenServer.on_start()
@@ -48,15 +50,16 @@ defmodule AshCredo.Cache do
   end
 
   @doc """
-  Ensures the cache GenServer is running and its ETS table is ready for use.
-  Safe to call from any process at any time; idempotent.
+  Ensures the cache GenServer is running and its ETS table is ready for
+  use. Safe to call from any process at any time; idempotent.
 
-  Starts the GenServer directly rather than via `Application.ensure_all_started/1`.
-  The latter would cascade through `:ash_credo`'s runtime application deps -
-  notably `:credo` - and during `mix credo` the live `Credo.Supervisor` collides
-  with that re-start, causing the whole cascade to roll back and the cache to
-  fail to start. The OTP application callback skips its cache child when this
-  function has already started it.
+  Starts the GenServer directly rather than via
+  `Application.ensure_all_started/1`. The latter would cascade through
+  `:ash_credo`'s runtime application deps, notably `:credo`, and during
+  `mix credo` the live `Credo.Supervisor` collides with that re-start,
+  causing the whole cascade to roll back and the cache to fail to start.
+  The OTP application callback skips its cache child when this function
+  has already started it.
   """
   @spec ensure_started!() :: :ok
   def ensure_started! do
@@ -68,8 +71,8 @@ defmodule AshCredo.Cache do
   end
 
   @doc """
-  Returns the cached value at `key`, or `default` if absent. Reads bypass
-  the GenServer for zero-overhead lookups.
+  Returns the cached value at `key`, or `default` if absent. Reads
+  bypass the GenServer for zero-overhead lookups.
   """
   @spec get(term(), term()) :: term()
   def get(key, default \\ nil) do
@@ -85,8 +88,8 @@ defmodule AshCredo.Cache do
   end
 
   @doc """
-  Stores `value` under `key`, overwriting any existing entry. Writes bypass
-  the GenServer.
+  Stores `value` under `key`, overwriting any existing entry. Writes
+  bypass the GenServer.
   """
   @spec put(term(), term()) :: :ok
   def put(key, value) do
@@ -100,11 +103,13 @@ defmodule AshCredo.Cache do
   end
 
   @doc """
-  Returns the cached value at `key`, computing it with `fun` and storing the
-  result on a miss. `fun` must be a pure function of `key`: concurrent first
-  callers may each compute, and the last write wins.
+  Returns the cached value at `key`, computing it with `fun` and storing
+  the result on a miss. `fun` must be a pure function of `key`:
+  concurrent first callers may each compute the value, and the last
+  write wins.
 
-  When the table is missing, computes on every call (nothing is ever cached).
+  When the table is missing, computes on every call; nothing is ever
+  cached.
   """
   @spec memoize(term(), (-> term())) :: term()
   def memoize(key, fun) when is_function(fun, 0) do
@@ -121,12 +126,13 @@ defmodule AshCredo.Cache do
 
   @doc """
   Atomically inserts `key` (with a placeholder value) only if absent.
-  Returns `true` if this call inserted (the caller is the first to see
-  this key), `false` if `key` was already present. Use this when you
-  need to act exactly once per key across concurrent callers.
+  Returns `true` if this call inserted the key, meaning the caller is
+  the first to see it, and `false` if `key` was already present. Use
+  this when you need to act exactly once per key across concurrent
+  callers.
 
-  When the table is missing, returns `true` on every call (nothing is
-  ever cached, so every caller looks like the first one).
+  When the table is missing, returns `true` on every call: nothing is
+  ever cached, so every caller looks like the first one.
   """
   @spec insert_new(term()) :: boolean()
   def insert_new(key) do
@@ -151,7 +157,7 @@ defmodule AshCredo.Cache do
 
   @doc """
   Deletes every entry in the cache. Idempotent and safe to call before
-  the cache GenServer has started (no-op in that case).
+  the cache GenServer has started (a no-op in that case).
   """
   @spec clear() :: :ok
   def clear do
@@ -163,9 +169,9 @@ defmodule AshCredo.Cache do
   end
 
   @doc """
-  Forgets that the missing-table hint was emitted, so the next missing-table
-  access emits it again. Test helper that keeps the flag key private to this
-  module.
+  Forgets that the missing-table hint was emitted, so the next
+  missing-table access emits it again. Test helper that keeps the flag
+  key private to this module.
   """
   @spec reset_missing_table_hint() :: :ok
   def reset_missing_table_hint do
@@ -174,9 +180,9 @@ defmodule AshCredo.Cache do
   end
 
   @doc """
-  Marks the missing-table hint as already emitted, silencing it for the rest
-  of the VM's lifetime. Test helper that keeps the flag key private to this
-  module.
+  Marks the missing-table hint as already emitted, silencing it for the
+  rest of the VM's lifetime. Test helper that keeps the flag key private
+  to this module.
   """
   @spec mark_missing_table_hint_emitted() :: :ok
   def mark_missing_table_hint_emitted do
@@ -187,14 +193,15 @@ defmodule AshCredo.Cache do
 
   # One hint per VM, tracked outside the (missing) table: a no-plugin run
   # would otherwise repeat the message once per accessor call per file.
-  # The flag check and set are not atomic on their own, and Credo dispatches
-  # its first wave of check tasks simultaneously - many processes can pass
-  # the flag check before any of them sets it. Resolve the race through
-  # atomic name registration: each racer spawns a fresh helper that tries
-  # to register a claim name, and only the winner re-checks the flag, sets
-  # it, and prints. Losers exit immediately - no lock, no backoff sleeps
-  # (:global.trans here would put every racer through randomized retry
-  # sleeps). After the flag is set, callers take the claim-free fast path.
+  # The flag check and set are not atomic on their own, and Credo
+  # dispatches its first wave of check tasks simultaneously, so many
+  # processes can pass the flag check before any of them sets it. Atomic
+  # name registration resolves the race: each racer spawns a fresh helper
+  # that tries to register a claim name, and only the winner re-checks the
+  # flag, sets it, and prints. Losers exit immediately, with no lock and
+  # no backoff sleeps (:global.trans here would put every racer through
+  # randomized retry sleeps). After the flag is set, callers take the
+  # claim-free fast path.
   defp warn_missing_table do
     if not hint_emitted?() do
       claim_and_emit_hint()
@@ -203,14 +210,14 @@ defmodule AshCredo.Cache do
     :ok
   end
 
-  # The helper is a spawned process rather than the caller itself because a
-  # process can hold only one registered name and the caller may already
-  # have one. The caller awaits the helper so the hint is on stderr before
-  # the triggering accessor returns. The flag is set before the winner
-  # exits (freeing the name), so a later claimant always finds it set.
-  # This orders emission at-most-once: a winner that crashes between
-  # setting the flag and printing suppresses the hint rather than letting
-  # another process print it twice.
+  # The helper is a spawned process rather than the caller itself because
+  # a process can hold only one registered name and the caller may already
+  # have one. The caller awaits the helper, so the hint is on stderr
+  # before the triggering accessor returns. The winner sets the flag
+  # before it exits and frees the name, so a later claimant always finds
+  # the flag set. This makes emission at-most-once: a winner that crashes
+  # between setting the flag and printing suppresses the hint rather than
+  # letting another process print it twice.
   defp claim_and_emit_hint do
     {pid, ref} =
       spawn_monitor(fn ->

--- a/lib/ash_credo/check/design/missing_identity.ex
+++ b/lib/ash_credo/check/design/missing_identity.ex
@@ -25,9 +25,9 @@ defmodule AshCredo.Check.Design.MissingIdentity do
       see the fully-resolved attribute and identity lists - including
       contributions from extensions like `AshAuthentication`, which adds an
       `:email` attribute via a transformer that the AST scanner cannot see.
-      Migrating to compiled introspection turns this check from "scans the
-      source for known attribute names" into "catches concrete missing
-      identities on extension-contributed attributes too".
+      So rather than merely scanning the source for known attribute names,
+      the check also catches missing identities on extension-contributed
+      attributes.
 
       ## Requirements
 

--- a/lib/ash_credo/check/refactor/directive_in_function_body.ex
+++ b/lib/ash_credo/check/refactor/directive_in_function_body.ex
@@ -16,8 +16,7 @@ defmodule AshCredo.Check.Refactor.DirectiveInFunctionBody do
       `require` into every function that uses an `Ash.Query.*` or
       `Ash.Expr.*` macro, instead of requiring the module once at the top
       of the module. The result is files with three or four duplicated
-      directives, which is noisy, non-idiomatic, and a recognisable code
-      smell.
+      directives, which is noisy and not idiomatic Elixir.
 
           # Flagged
           defmodule MyApp.PostQueries do
@@ -54,7 +53,7 @@ defmodule AshCredo.Check.Refactor.DirectiveInFunctionBody do
       `directive_modules` defaults to `[Ash.Query, Ash.Expr]`. The check
       is general - any module you put in the list is checked the same way.
       Add Ash extension modules from your own codebase, or any third-party
-      module whose directives you want centralised:
+      module whose directives you want at module level:
 
           {AshCredo.Check.Refactor.DirectiveInFunctionBody,
            [directive_modules: [Ash.Query, Ash.Expr, MyApp.CustomMacros]]}
@@ -66,16 +65,16 @@ defmodule AshCredo.Check.Refactor.DirectiveInFunctionBody do
 
       The default reflects the most common cases in Ash codebases (the
       `require Ash.Query` and `require Ash.Expr` repetition AI assistants
-      love). The check itself is general; this plugin just ships
-      Ash-flavoured defaults.
+      produce). The check itself is general; this plugin just ships
+      Ash-flavored defaults.
       """,
       params: [
         directive_modules:
           "List of modules whose `require`/`import`/`alias` directives must " <>
             "live at module level rather than inside function bodies. Defaults " <>
             "to `[Ash.Query, Ash.Expr]` because those are the most common " <>
-            "offenders in Ash codebases. The check itself is general - add " <>
-            "any module whose directives your team wants centralised."
+            "cases in Ash codebases. The check itself is general - add " <>
+            "any module whose directives your team wants at module level."
       ]
     ]
 

--- a/lib/ash_credo/check/refactor/raising_call.ex
+++ b/lib/ash_credo/check/refactor/raising_call.ex
@@ -25,7 +25,7 @@ defmodule AshCredo.Check.Refactor.RaisingCall do
           end
 
       Requires the host project to be compiled with Ash loaded - same
-      contract as `UseCodeInterface`, `MissingCodeInterface`, etc. When
+      contract as `UseCodeInterface` and `MissingCodeInterface`. When
       Ash isn't loadable the check emits one `:ash_missing` diagnostic
       and becomes a no-op.
 

--- a/lib/ash_credo/check/refactor/use_code_interface.ex
+++ b/lib/ash_credo/check/refactor/use_code_interface.ex
@@ -388,9 +388,9 @@ defmodule AshCredo.Check.Refactor.UseCodeInterface do
   defp pick_suggestion(%{scope: :domain, resource_domain: domain}) when not is_nil(domain),
     do: {:define, :domain}
 
-  # Resource has no domain at all → no domain interface to point at, so we
-  # fall back to suggesting a resource-level interface even though the user
-  # preferred :domain. There's no other meaningful answer here.
+  # Resource has no domain at all, so there's no domain interface to point
+  # at. We fall back to suggesting a resource-level interface even though
+  # the user preferred :domain. There's no other meaningful answer here.
   defp pick_suggestion(%{scope: :domain}), do: {:define, :resource}
 
   # `:auto`: same-domain callers go to the resource, others to the domain.

--- a/lib/ash_credo/check/warning/actor_on_call_options.ex
+++ b/lib/ash_credo/check/warning/actor_on_call_options.ex
@@ -5,9 +5,9 @@ defmodule AshCredo.Check.Warning.ActorOnCallOptions do
     tags: [:ash, :security],
     explanations: [
       check: """
-      `actor:` and `tenant:` belong on the query/changeset/input, set when it
-      is built - not in the options of the action call. This enforces the
-      rule from Ash's authorization usage rules ("Always set the actor on the
+      Set `actor:` and `tenant:` on the query, changeset, or input when you
+      build it, not in the options of the action call. This enforces the rule
+      from Ash's authorization usage rules ("Always set the actor on the
       query/changeset/input, not when calling the action").
 
           # Bad - the query was built without the actor
@@ -20,44 +20,44 @@ defmodule AshCredo.Check.Warning.ActorOnCallOptions do
           |> Ash.Query.for_read(:read, %{}, actor: current_user)
           |> Ash.read!()
 
-      When a query, changeset, or action input is built via `for_read`,
+      When you build a query, changeset, or action input with `for_read`,
       `for_create`, and friends, everything that runs at build time sees the
-      actor and tenant it was built with; supplying them only at call time
+      actor and tenant it was built with. Supplying them only at call time
       leaves that build-time context inconsistent.
 
-      Only calls whose subject visibly went through a `for_*` builder are
-      flagged. Forms without a pre-built subject, such as
-      `Ash.read!(Post, actor: actor)` or code interface calls like
-      `MyApp.Blog.list_posts!(actor: actor)`, are sanctioned - there Ash
-      builds the action context with the given actor itself. The check is
-      purely syntactic: it follows pipes and simple variable bindings, but
-      cannot see builders hidden behind function calls.
+      The check only flags calls whose subject visibly went through a
+      `for_*` builder. Forms without a pre-built subject are fine, such as
+      `Ash.read!(Post, actor: actor)` or a code interface call like
+      `MyApp.Blog.list_posts!(actor: actor)`: there Ash builds the action
+      context with the given actor itself. The check is purely syntactic:
+      it follows pipes and simple variable bindings, but it cannot see a
+      builder hidden behind a function call.
       """
     ]
 
   alias AshCredo.Introspection.Aliases
   alias AshCredo.Introspection.AshCallScanner
 
-  # Ash action-invocation functions taking a query/changeset/input subject
-  # plus an options list. The aggregate and bulk families belong here too:
-  # their opts merge Ash's global options, so they take `actor:`/`tenant:`
-  # at call time just like `Ash.read!/2`. They are grouped by how many
+  # Ash action functions that take a query/changeset/input subject plus an
+  # options list. The aggregate and bulk families belong here too: their
+  # opts merge Ash's global options, so they take `actor:`/`tenant:` at
+  # call time just like `Ash.read!/2`. We group the functions by how many
   # arguments precede the optional trailing opts (subject included), so a
-  # required argument that happens to be a keyword-shaped list - e.g. the
-  # aggregate specs in `Ash.aggregate(query, [{:actor, :count}])` - is
-  # never mistaken for the opts.
+  # required argument that happens to be keyword-shaped, like the aggregate
+  # specs in `Ash.aggregate(query, [{:actor, :count}])`, is never mistaken
+  # for the opts.
   @subject_opts_funs ~w(read read! read_one read_one! read_first read_first! first first! stream! count count! exists exists? create create! update update! destroy destroy! run_action run_action! data_layer_query data_layer_query!)a
   @aggregate_funs ~w(aggregate aggregate! sum sum! avg avg! min min! max max! list list!)a
   @bulk_funs ~w(bulk_update bulk_update! bulk_destroy bulk_destroy!)a
   @action_funs @subject_opts_funs ++ @aggregate_funs ++ @bulk_funs
 
-  # Builders that establish the action context; actor/tenant belong in their
-  # options.
+  # Builders that establish the action context; actor/tenant belong in
+  # their options.
   @builder_funs ~w(for_read for_create for_update for_destroy for_action)a
   @builder_modules [[:Ash, :Query], [:Ash, :Changeset], [:Ash, :ActionInput]]
 
-  # `scope:` is deliberately not flagged: passing a scope at call time is a
-  # sanctioned way to inherit actor/tenant from a context.
+  # We deliberately don't flag `scope:`: passing a scope at call time is a
+  # legitimate way to inherit actor/tenant from a context.
   @flagged_keys [:actor, :tenant]
 
   @impl true
@@ -86,15 +86,15 @@ defmodule AshCredo.Check.Warning.ActorOnCallOptions do
 
   # Number of arguments (subject included, after pipe normalization) that
   # precede the optional trailing opts. Only a trailing keyword list beyond
-  # that count is the options of the call.
+  # that count counts as the call's options.
   defp required_args(fun_name) when fun_name in @aggregate_funs, do: 2
   defp required_args(fun_name) when fun_name in @bulk_funs, do: 3
   defp required_args(_fun_name), do: 1
 
-  # Descends past the required arguments, then walks to the final argument
-  # in one pass with no intermediate list, with the keyword-list shape
-  # check fused in. A call with no argument beyond the required ones has
-  # no options to scan.
+  # Skips past the required arguments, then walks to the final argument in
+  # one pass with no intermediate list, doing the keyword-list shape check
+  # along the way. A call with no argument beyond the required ones has no
+  # options to scan.
   defp flagged_keys([_arg | rest], required_args) when required_args > 0 do
     flagged_keys(rest, required_args - 1)
   end
@@ -107,8 +107,9 @@ defmodule AshCredo.Check.Warning.ActorOnCallOptions do
   defp flagged_keys(_args, _required_args), do: []
 
   # True when the call subject visibly went through a `for_*` builder:
-  # directly, anywhere in a pipe chain, or via simple variable bindings
-  # (cycle-guarded, mirroring AshCallResolver's origin tracing).
+  # directly, anywhere in a pipe chain, or through simple variable bindings.
+  # A cycle guard protects the trace, mirroring AshCallResolver's origin
+  # tracing.
   defp builder_subject?({:|>, _, [left, right]}, call_info, seen) do
     builder_call?(right, call_info) or builder_subject?(left, call_info, seen)
   end

--- a/lib/ash_credo/check/warning/authorize_false.ex
+++ b/lib/ash_credo/check/warning/authorize_false.ex
@@ -9,9 +9,9 @@ defmodule AshCredo.Check.Warning.AuthorizeFalse do
     ],
     explanations: [
       check: """
-      Using `authorize?: false` bypasses Ash authorization entirely, making it
-      easy to accidentally skip policy checks. Instead, use system actors with
-      bypass policies so that authorization is always enforced and auditable.
+      Passing `authorize?: false` bypasses Ash authorization entirely, which
+      makes it easy to skip policy checks by accident. Use system actors with
+      bypass policies instead, so authorization stays enforced and auditable.
 
           # Bad - skips all authorization
           Ash.read!(query, authorize?: false)
@@ -24,30 +24,32 @@ defmodule AshCredo.Check.Warning.AuthorizeFalse do
             authorize_if always()
           end
 
-      For code inside action changes/validations that needs to read related data,
-      use `scope: context` to inherit the caller's authorization context:
+      Code inside action changes or validations sometimes needs to read
+      related data. There, use `scope: context` to inherit the caller's
+      authorization context:
 
           Ash.get!(Resource, id, scope: context)
 
-      **Note:** By default this check flags `authorize?: false` anywhere it appears as a
-      literal - Ash API calls, action DSL definitions, variable assignments, and
-      wrapper functions. Set `include_non_ash_calls: false` to restrict detection
-      to Ash API calls and action DSL definitions only.
+      By default, the check flags `authorize?: false` anywhere it appears as
+      a literal: Ash API calls, action DSL definitions, variable assignments,
+      and wrapper functions. Set `include_non_ash_calls: false` to restrict
+      detection to Ash API calls and action DSL definitions.
 
-      Test directories are excluded by default, since bypassing authorization in
-      test setup and factories is typically intentional. Override `excluded_paths`
-      to scope the check differently.
+      The check excludes test directories by default, since bypassing
+      authorization in test setup and factories is usually intentional.
+      Override `excluded_paths` to scope the check differently.
 
-      In either mode the check is purely syntactic: it cannot follow values through
-      variables, config lookups, or function return values.
+      In either mode, the check is purely syntactic: it cannot follow values
+      through variables, config lookups, or function return values.
       """,
       params: [
         include_non_ash_calls:
-          "When `true` (default), flags `authorize?: false` anywhere in source. " <>
-            "When `false`, only checks Ash API calls and action DSL definitions.",
+          "When `true` (the default), flags `authorize?: false` anywhere it appears " <>
+            "in the source. When `false`, only checks Ash API calls and " <>
+            "action DSL definitions.",
         excluded_paths:
-          "List of paths or regexes to exclude from this check. " <>
-            "Defaults to test directories, since `authorize?: false` is intentional in test setup."
+          "Paths or regexes to exclude from this check. Defaults to the test " <>
+            "directories, since `authorize?: false` is intentional in test setup."
       ]
     ]
 
@@ -129,7 +131,7 @@ defmodule AshCredo.Check.Warning.AuthorizeFalse do
   defp has_authorize_false?(args) do
     Enum.any?(args, fn
       {:authorize?, false} -> true
-      # Bare `authorize?` variables have a 3-tuple AST ({:authorize?, meta, nil})
+      # A bare `authorize?` variable has a 3-tuple AST ({:authorize?, meta, nil})
       # that Keyword.get's :lists.keyfind would match, so only accept literal
       # 2-tuples here.
       kwl when is_list(kwl) -> Enum.any?(kwl, &match?({:authorize?, false}, &1))

--- a/lib/ash_credo/check/warning/authorizer_without_policies.ex
+++ b/lib/ash_credo/check/warning/authorizer_without_policies.ex
@@ -5,9 +5,9 @@ defmodule AshCredo.Check.Warning.AuthorizerWithoutPolicies do
     tags: [:ash, :security],
     explanations: [
       check: """
-      Resources that declare `Ash.Policy.Authorizer` but define no policies
-      will deny all actions by default. An empty `policies` block has the same
-      effect. This is almost always unintentional.
+      A resource that declares `Ash.Policy.Authorizer` but defines no
+      policies denies all actions by default. An empty `policies` block has
+      the same effect. This is almost always unintentional.
 
       Either add policies:
 
@@ -17,19 +17,20 @@ defmodule AshCredo.Check.Warning.AuthorizerWithoutPolicies do
             end
           end
 
-      Or remove the authorizer if authorization is not needed yet.
+      Or remove the authorizer if you don't need authorization yet.
 
-      This check uses Ash's runtime introspection (`Ash.Resource.Info.authorizers/1`
-      and `Ash.Policy.Info.policies/1`) to see the fully-resolved authorizer
-      and policy lists. That means it correctly handles authorizers added by
-      extensions and policies declared in `Spark.Dsl.Fragment` modules - cases
-      the AST scanner would silently miss.
+      The check uses Ash's runtime introspection
+      (`Ash.Resource.Info.authorizers/1` and `Ash.Policy.Info.policies/1`)
+      to read the fully resolved authorizer and policy lists, so it
+      correctly handles authorizers added by extensions and policies
+      declared in `Spark.Dsl.Fragment` modules - cases an AST scanner
+      cannot see.
 
       ## Requirements
 
-      Your project must be compiled before running `mix credo`. If Ash is
-      not available in the VM running Credo, the check is a no-op and emits
-      a single diagnostic.
+      Compile your project before running `mix credo`. If Ash is not
+      available in the VM running Credo, the check is a no-op and emits a
+      single diagnostic.
       """
     ]
 
@@ -55,13 +56,14 @@ defmodule AshCredo.Check.Warning.AuthorizerWithoutPolicies do
          context,
          issue_meta
        ) do
-    # `Ash.Policy.Authorizer` here is intentionally a bare atom literal, not
-    # a remote call - Elixir compiles it to `:"Elixir.Ash.Policy.Authorizer"`
-    # without ever needing the module loaded, so this file compiles cleanly
-    # in projects that don't depend on Ash. If you ever turn this into a
-    # remote call (e.g. `Ash.Policy.Authorizer.something()`), make sure
-    # `AshCredo.Introspection.Compiled`'s `@compile {:no_warn_undefined,
-    # ...}` list still covers it (it currently does, defensively).
+    # `Ash.Policy.Authorizer` here is deliberately a bare atom literal, not
+    # a remote call. Elixir compiles it to `:"Elixir.Ash.Policy.Authorizer"`
+    # without ever loading the module, so this file compiles cleanly in
+    # projects that don't depend on Ash. If you ever turn this into a
+    # remote call (e.g. `Ash.Policy.Authorizer.something()`), make sure the
+    # `@compile {:no_warn_undefined, ...}` list in
+    # `AshCredo.Introspection.Compiled` still covers it (it currently does,
+    # defensively).
     if Ash.Policy.Authorizer in authorizers and policies == [] do
       [missing_policies_issue(context, issue_meta)]
     else

--- a/lib/ash_credo/check/warning/compile_time_default.ex
+++ b/lib/ash_credo/check/warning/compile_time_default.ex
@@ -5,16 +5,16 @@ defmodule AshCredo.Check.Warning.CompileTimeDefault do
     tags: [:ash],
     explanations: [
       check: """
-      Flags `default`/`update_default` values built by calling a
-      time-or-uuid-producing function directly, like
+      Flags `default` or `update_default` values that come from a direct
+      call to a time- or UUID-producing function, like
       `default: DateTime.utc_now()`. DSL options are ordinary expressions
-      evaluated while the module compiles, so the call runs exactly once
-      and the resulting literal is baked into the resource: every record
-      gets the timestamp of the last compile, and a `Ash.UUID.generate()`
-      default hands every record the same "unique" value.
+      that Elixir evaluates while the module compiles, so the call runs
+      exactly once and the result is baked into the resource as a literal:
+      every record gets the timestamp of the last compile, and a default of
+      `Ash.UUID.generate()` gives every record the same "unique" value.
 
-      Ash only re-evaluates defaults per record when given a zero-arity
-      function (or MFA tuple); any other value is used verbatim.
+      Ash re-evaluates a default per record only when it is a zero-arity
+      function or an MFA tuple; it uses any other value verbatim.
 
           # Bad - frozen at compile time, identical for every record
           attribute :scheduled_at, :utc_datetime, default: DateTime.utc_now()
@@ -22,13 +22,14 @@ defmodule AshCredo.Check.Warning.CompileTimeDefault do
           # Good - re-evaluated for each record
           attribute :scheduled_at, :utc_datetime, default: &DateTime.utc_now/0
 
-      Action and calculation arguments resolve `default` the same way, so
-      their defaults are checked too. Values wrapped in a zero-arity `fn`
-      or a capture are fine and are not flagged.
+      Action arguments and calculation arguments resolve `default` the same
+      way, so the check covers their defaults too. It doesn't flag values
+      wrapped in a zero-arity `fn` or a capture; those forms are correct.
 
-      Nothing else catches this: it compiles without warnings, the frozen
-      value type-checks, and no error is ever raised - dev recompiles keep
-      the value looking fresh, and the freeze only shows up in production.
+      No other tool catches this bug: the code compiles without warnings,
+      the frozen value type-checks, and no error is ever raised. In
+      development each recompile refreshes the value, so the problem only
+      shows up in production.
 
       `Warning.PinnedTimeInExpression` is the sibling check for the same
       bug class inside Ash expressions (`^DateTime.utc_now()`).
@@ -41,10 +42,10 @@ defmodule AshCredo.Check.Warning.CompileTimeDefault do
   alias AshCredo.Orchestration
   alias Credo.Code.Name
 
-  # Functions whose value is only meaningful when produced per record.
-  # Matched on the module resolved through the lexical environment, like
-  # the sibling PinnedTimeInExpression, so aliased forms
-  # (`alias DateTime, as: DT`) are caught too.
+  # Functions whose value is only meaningful when each record gets its own.
+  # We match on the module resolved through the lexical environment, like
+  # the sibling PinnedTimeInExpression, so we also catch aliased forms
+  # (`alias DateTime, as: DT`).
   @frozen_calls [
     {Date, :utc_today},
     {DateTime, :utc_now},
@@ -57,7 +58,7 @@ defmodule AshCredo.Check.Warning.CompileTimeDefault do
 
   @default_options ~w(default update_default)a
 
-  # Sections where default/update_default options exist: attribute
+  # Sections where default/update_default options occur: attribute
   # entities, action arguments, and calculation arguments.
   @sections ~w(attributes actions calculations)a
 
@@ -71,12 +72,12 @@ defmodule AshCredo.Check.Warning.CompileTimeDefault do
     end)
   end
 
-  # Collects default/update_default occurrences in both forms: inline
-  # keyword options (`default: value` - a 2-tuple in the AST) and do-block
-  # option calls (`default value`). The whole module is walked (rather
-  # than each section on its own) so directives at module top are already
-  # applied to the env by the time the sections are reached;
-  # `section_depth` gates collection to the sections.
+  # Collects default/update_default occurrences in both forms: the inline
+  # keyword option (`default: value`, a 2-tuple in the AST) and the
+  # do-block option call (`default value`). We walk the whole module rather
+  # than each section on its own, so directives at the module top are
+  # already in the env by the time we reach the sections; `section_depth`
+  # gates collection to the sections.
   defp default_option_issues(module_ast, sections, issue_meta) do
     {state, _scope} =
       LexicalScopeWalker.traverse(
@@ -122,8 +123,9 @@ defmodule AshCredo.Check.Warning.CompileTimeDefault do
   defp collect_option(_node, _env, state, _issue_meta), do: state
 
   # Walks the option value for frozen calls, including inside containers
-  # (`default: %{at: DateTime.utc_now()}` is just as frozen). Subtrees under
-  # `fn` or `&` are pruned: there the call is deferred, which is the fix.
+  # (`default: %{at: DateTime.utc_now()}` is just as frozen). We prune
+  # subtrees under `fn` or `&`: there the call is deferred, which is the
+  # fix.
   defp frozen_call_issues(value, option, env, issue_meta) do
     {_ast, issues} =
       Macro.prewalk(value, [], fn

--- a/lib/ash_credo/check/warning/empty_domain.ex
+++ b/lib/ash_credo/check/warning/empty_domain.ex
@@ -5,7 +5,7 @@ defmodule AshCredo.Check.Warning.EmptyDomain do
     tags: [:ash],
     explanations: [
       check: """
-      A domain module with no resources registered is likely incomplete.
+      A domain module that registers no resources is probably incomplete.
 
           resources do
             resource MyApp.Post
@@ -14,11 +14,12 @@ defmodule AshCredo.Check.Warning.EmptyDomain do
 
       ## Limitations
 
-      This check scans the source AST, so it only sees resources registered
-      literally in the `resources` block. Resources contributed by Spark
-      transformers, extensions, or `Spark.Dsl.Fragment` modules are
-      invisible to it, so a domain whose resources come from such a source
-      may be flagged as empty even though it is not.
+      The check scans the source AST, so it only sees resources registered
+      literally in the `resources` block. It cannot see resources
+      contributed by Spark transformers, extensions, or
+      `Spark.Dsl.Fragment` modules, so when a domain gets its resources
+      from such a source, the check may flag it as empty even though it is
+      not.
       """
     ]
 

--- a/lib/ash_credo/check/warning/missing_builtin_wrapper.ex
+++ b/lib/ash_credo/check/warning/missing_builtin_wrapper.ex
@@ -8,14 +8,14 @@ defmodule AshCredo.Check.Warning.MissingBuiltinWrapper do
       Builtin change, validation, preparation, and calculation functions
       like `set_attribute`, `present`, `build`, and `concat` must be
       wrapped in their DSL entity (`change`, `validate`, `prepare`,
-      `calculate ...`) when used inside an action body, a `pipeline` body,
-      or a global section (`changes`, `validations`, `preparations`,
-      `calculations`).
+      `calculate ...`) when you use them inside an action body, a
+      `pipeline` body, or a global section (`changes`, `validations`,
+      `preparations`, `calculations`).
 
-      These builtins are plain functions imported into the DSL scope.
-      Without the wrapper, the call returns a spec tuple that is silently
-      discarded - the change/validation/preparation never runs and no error
-      or warning is raised at compile time or runtime.
+      These builtins are plain functions that Ash imports into the DSL
+      scope. Without the wrapper, the call returns a spec tuple that is
+      silently discarded: the change, validation, or preparation never
+      runs, and no error or warning is raised at compile time or runtime.
 
           # Bad - compiles but silently does nothing
           create :register do
@@ -31,52 +31,54 @@ defmodule AshCredo.Check.Warning.MissingBuiltinWrapper do
             change set_attribute(:status, :draft)
           end
 
-      Each builtin family is only checked in the scopes that import it, so
-      a bare call the compiler already rejects is never flagged. The advice
-      is position-aware for `set_context`, which exists as both a change
-      and a preparation builtin: in pipelines it gets `change`, in read and
-      generic actions `prepare`.
+      The check examines each builtin family only in the scopes that import
+      it, so it never flags a bare call the compiler already rejects. The
+      advice is position-aware for `set_context`, which exists as both a
+      change and a preparation builtin: in a pipeline the advice is
+      `change`, in a read or generic action it is `prepare`.
 
-      The builtin names are read from Ash's `*.Builtins` modules at analysis
-      time, so builtins added in newer Ash versions are covered automatically.
-      Because some of them are common words (`present`, `compare`, `match`,
-      `build`, `load`, `select`), a bare call to a same-named local helper
-      inside an action body would be flagged too; silence such a call with
-      `# credo:disable-for-next-line`.
+      The check reads the builtin names from Ash's `*.Builtins` modules at
+      analysis time, so builtins added in newer Ash versions are covered
+      automatically. Because some builtin names are common words
+      (`present`, `compare`, `match`, `build`, `load`, `select`), a bare
+      call to a same-named local helper inside an action body gets flagged
+      too; silence such a call with `# credo:disable-for-next-line`.
       """
     ]
 
   alias AshCredo.Introspection
   alias AshCredo.Orchestration
 
-  # One entry per builtin family. The builtin NAMES are read at run time from
-  # `:builtins_module` via `__info__(:functions)`, so builtins added in newer
-  # Ash versions are covered without editing this file. Everything else is the
-  # hand-tuned scoping that decides where a family is flagged and which family
-  # owns names shared by more than one (`set_context`):
+  # One entry per builtin family. We read the builtin NAMES at run time
+  # from `:builtins_module` via `__info__(:functions)`, so builtins added
+  # in newer Ash versions are covered without editing this file. Everything
+  # else is hand-tuned scoping: it decides where we flag a family, and
+  # which family owns names shared by more than one (`set_context`):
   #
-  #   * changes - no :read or :action: those import only the Preparation and
-  #     Validation builtins. The one change builtin that compiles bare in a
-  #     generic action is `set_context` (via its Preparation.Builtins twin),
-  #     which the preparations family owns there, because generic actions
-  #     take `prepare`, not `change`. The `changes` global section imports
-  #     Change.Builtins (and Validation.Builtins), so the changes family
-  #     owns `set_context` there too.
+  #   * changes - not :read or :action: those actions import only the
+  #     Preparation and Validation builtins. The one change builtin that
+  #     compiles bare in a generic action is `set_context` (via its
+  #     Preparation.Builtins twin), and the preparations family owns it
+  #     there, because generic actions take `prepare`, not `change`. The
+  #     `changes` global section imports Change.Builtins (and
+  #     Validation.Builtins), so the changes family owns `set_context`
+  #     there.
   #   * validations - includes :read: read actions import
   #     Ash.Resource.Validation.Builtins and accept `validate` entities. All
   #     three global sections import Validation.Builtins.
   #   * preparations - only :read and :action import
   #     Ash.Resource.Preparation.Builtins; among the global sections, only
-  #     `preparations` does (so `set_context` is unambiguous there).
+  #     `preparations` does, so `set_context` is unambiguous there.
   #   * calculations - the `calculations` section imports
   #     Ash.Resource.Calculation.Builtins (just `concat`); the fix is a full
-  #     `calculate` entity, reflected in the usage_prefix.
+  #     `calculate` entity, which the usage_prefix reflects.
   #
-  # `:pipeline` controls flagging inside `pipeline` bodies, which import the
-  # change/validation/preparation families at once (but NOT the calculation
-  # builtins - a bare `concat` there is a compile error). The ambiguous
-  # `set_context` is owned by the changes family in pipelines (since they
-  # accept `change` entities), so the preparations family excludes it.
+  # `:pipeline` controls which names we flag in `pipeline` bodies. Those
+  # bodies import the change/validation/preparation families at once, but
+  # NOT the calculation builtins - a bare `concat` there is a compile
+  # error. In pipelines the changes family owns the ambiguous
+  # `set_context`, since pipelines accept `change` entities, so the
+  # preparations family excludes it.
   @families [
     %{
       builtins_module: Ash.Resource.Change.Builtins,
@@ -116,8 +118,8 @@ defmodule AshCredo.Check.Warning.MissingBuiltinWrapper do
     end)
   end
 
-  # Resolve the family's builtin names from Ash and assemble the keyword opts
-  # `naked_builtin_issues/3` expects.
+  # Resolve the family's builtin names from Ash and assemble the keyword
+  # opts that `naked_builtin_issues/3` expects.
   defp family_opts(family) do
     builtins = resolve_builtins(family.builtins_module)
 
@@ -130,10 +132,10 @@ defmodule AshCredo.Check.Warning.MissingBuiltinWrapper do
     ] ++ usage_prefix_opt(family)
   end
 
-  # Read builtin function names live from the family's Ash module so new
-  # builtins are picked up automatically. When the module is not loadable
-  # (Ash absent from the VM running Credo) the family simply does not flag -
-  # without Ash there is nothing Ash-specific to check.
+  # Read the builtin function names live from the family's Ash module, so
+  # new builtins are picked up automatically. When the module isn't
+  # loadable (Ash absent from the VM running Credo), the family simply
+  # doesn't flag: without Ash there is nothing Ash-specific to check.
   defp resolve_builtins(module) do
     if Code.ensure_loaded?(module) do
       module.__info__(:functions) |> Enum.map(&elem(&1, 0)) |> Enum.uniq()
@@ -150,29 +152,32 @@ defmodule AshCredo.Check.Warning.MissingBuiltinWrapper do
   defp usage_prefix_opt(_family), do: []
 
   # Flags bare calls to configured builtin functions at statement position
-  # inside action bodies, `pipeline` bodies, and global sections, suggesting
-  # the matching DSL wrapper keyword. Ash's builtins are plain functions
-  # imported into the DSL scope that return spec tuples, so an unwrapped call
-  # is silently discarded and nothing warns at compile time or runtime.
+  # inside action bodies, `pipeline` bodies, and global sections,
+  # suggesting the matching DSL wrapper keyword. The DSL scope imports
+  # Ash's builtins as plain functions that return spec tuples, so an
+  # unwrapped call is silently discarded and nothing warns at compile time
+  # or runtime.
   #
   # Required `opts`:
   #
-  #   * `:builtins` - builtin function names to match
+  #   * `:builtins` - the builtin function names to match
   #   * `:wrapper` - the DSL keyword to suggest (e.g. `"change"`)
-  #   * `:action_types` - action entity types to scan; scoped to the actions
-  #     whose scope actually imports their builtin family, so a bare call
-  #     elsewhere is a compile error the compiler already catches
+  #   * `:action_types` - the action entity types to scan, limited to the
+  #     actions whose scope actually imports the builtin family, so a bare
+  #     call elsewhere is a compile error the compiler already catches
   #
   # Optional `opts`:
   #
-  #   * `:pipeline_builtins` - builtin names to also flag at statement position
-  #     inside `pipeline` bodies (defaults to `[]`). Pipeline bodies import all
-  #     three builtin families at once, so families split ownership of names
-  #     that exist in more than one family to avoid double-flagging.
-  #   * `:global_sections` - top-level DSL sections (e.g. `:validations`) whose
-  #     direct entries are scanned for bare builtin calls (defaults to `[]`).
-  #   * `:usage_prefix` - what to put before `builtin(...)` in the advice
-  #     (defaults to `"<wrapper> "`).
+  #   * `:pipeline_builtins` - builtin names to also flag at statement
+  #     position inside `pipeline` bodies (defaults to `[]`). Pipeline
+  #     bodies import all three builtin families at once, so for names that
+  #     exist in more than one family, exactly one family owns each name to
+  #     avoid double-flagging.
+  #   * `:global_sections` - top-level DSL sections (e.g. `:validations`)
+  #     whose direct entries we scan for bare builtin calls (defaults to
+  #     `[]`).
+  #   * `:usage_prefix` - the text to put before `builtin(...)` in the
+  #     advice (defaults to `"<wrapper> "`).
   defp naked_builtin_issues(source_file, params, opts) do
     builtins = opts |> Keyword.fetch!(:builtins) |> MapSet.new()
     wrapper = Keyword.fetch!(opts, :wrapper)
@@ -230,8 +235,8 @@ defmodule AshCredo.Check.Warning.MissingBuiltinWrapper do
     end
   end
 
-  # Works on any AST node with a do-block whose direct entries are statements:
-  # action entities, pipeline entities, and global sections.
+  # Works on any AST node with a do-block whose direct entries are
+  # statements: action entities, pipeline entities, and global sections.
   defp naked_builtin_calls(ast, builtins, advice, issue_meta) do
     for {func_name, meta, _} <- Introspection.entity_body(ast),
         MapSet.member?(builtins, func_name) do

--- a/lib/ash_credo/check/warning/missing_domain.ex
+++ b/lib/ash_credo/check/warning/missing_domain.ex
@@ -11,8 +11,8 @@ defmodule AshCredo.Check.Warning.MissingDomain do
 
       Without it, code interfaces and domain configuration do not apply,
       and callers must supply the domain themselves. A resource shared
-      across domains can opt out explicitly with `domain: nil` - the
-      check accepts that and only flags a missing option.
+      across multiple domains can opt out explicitly with `domain: nil`;
+      the check accepts that value and only flags a missing option.
       """
     ]
 

--- a/lib/ash_credo/check/warning/missing_macro_directive.ex
+++ b/lib/ash_credo/check/warning/missing_macro_directive.ex
@@ -10,10 +10,10 @@ defmodule AshCredo.Check.Warning.MissingMacroDirective do
       `Ash.Query` and `Ash.Expr`) when no matching `require` or `import` of
       the macro module is lexically in scope at the call site.
 
-      Several `Ash.Query` and `Ash.Expr` functions are actually macros -
+      Several `Ash.Query` and `Ash.Expr` functions are actually macros:
       `Ash.Query.filter/2`, `equivalent_to/2`, `superset_of/2`, `subset_of/2`
       and their `?` variants, and `Ash.Expr.expr/1`, `where/2`, `or_where/2`,
-      `calc/1..2`. Calling any of them without a matching `require` in scope
+      `calc/1..2`. Calling one of them without a matching `require` in scope
       has three different failure modes, depending on the shape of the
       argument:
 
@@ -34,9 +34,9 @@ defmodule AshCredo.Check.Warning.MissingMacroDirective do
           # ** (UndefinedFunctionError) function Ash.Query.filter/2 is
           #    undefined or private
 
-      Case #3 is the important one for a linter - the other two fail loudly
-      at compile time, but this one ships to production if the warning is
-      missed.
+      Case #3 is the important one for a linter: the other two fail loudly
+      at compile time, but this one ships to production if you miss the
+      warning.
 
           # Flagged
           defmodule MyApp.PostQueries do
@@ -58,40 +58,44 @@ defmodule AshCredo.Check.Warning.MissingMacroDirective do
             end
           end
 
-      `require` and `import` both satisfy the check - `import <Module>`
+      `require` and `import` both satisfy the check: `import <Module>`
       implies `require <Module>` in Elixir, so qualified macro calls work
       after either directive.
 
-      Only **qualified** remote calls (`Ash.Query.filter(...)`) are
-      inspected. Unqualified calls like `filter(...)` after `import Ash.Query`
-      are out of scope: if the import is missing, Elixir raises a clean
-      `undefined function filter/2` at compile time, which is obvious enough
-      to need no lint.
+      The check only inspects **qualified** remote calls
+      (`Ash.Query.filter(...)`). Unqualified calls like `filter(...)` after
+      `import Ash.Query` are out of scope: if the import is missing, Elixir
+      raises a clear `undefined function filter/2` error at compile time,
+      which is obvious enough to need no lint.
 
-      `require`/`import` are accepted in any lexical scope visible to the
-      call - module top, the enclosing `def`/`defp` body, an enclosing
-      `if`/`case`/`with` branch, etc. - matching Elixir's own scoping rules.
-      A directive in one function does not reach calls in a sibling function.
+      The check accepts `require` and `import` in any lexical scope visible
+      to the call: the module top, the enclosing `def` or `defp` body, or
+      an enclosing `if`, `case`, or `with` branch. This matches Elixir's
+      own scoping rules, so a directive in one function does not reach
+      calls in a sibling function.
 
-      Each configured module is tracked independently: `require Ash.Query`
-      does **not** cover `Ash.Expr.expr(...)`, and vice versa. A module that
-      uses macros from both modules needs both directives.
+      The check tracks each configured module independently:
+      `require Ash.Query` does **not** cover `Ash.Expr.expr(...)`, and vice
+      versa. A module that uses macros from both modules needs both
+      directives.
 
-      Calls inside `quote do ... end` blocks are deliberately ignored. A
-      macro author who writes `quote do Ash.Query.filter(...) end` is
-      injecting the call into the caller's site, not emitting it from their
-      own module, so flagging it would be a false positive.
+      The check deliberately ignores calls inside `quote do ... end`
+      blocks. A macro author who writes `quote do Ash.Query.filter(...) end`
+      is injecting the call into the caller's site, not emitting it from
+      their own module, so flagging it would be a false positive.
 
-      Nested `defmodule` blocks inherit `require`/`import` and `alias` from
-      the enclosing module the same way Elixir does, so an outer
-      `require Ash.Query` (or `alias Ash.Query, as: Q`) is honored by
-      `Ash.Query.filter(...)` (or `Q.filter(...)`) inside a nested `defmodule`.
+      Nested `defmodule` blocks inherit `require`, `import`, and `alias`
+      from the enclosing module the same way Elixir does, so an outer
+      `require Ash.Query` (or `alias Ash.Query, as: Q`) applies to
+      `Ash.Query.filter(...)` (or `Q.filter(...)`) inside a nested
+      `defmodule`.
 
-      This check is a **correctness backstop**: for projects without
+      The check is a **correctness backstop**: for projects without
       `--warnings-as-errors`, it converts the easy-to-miss runtime case
       (#3 above) into a lint issue. Style rules about *where* directives
-      live are out of scope; pair with `AshCredo.Check.Refactor.DirectiveInFunctionBody`
-      if your team wants to centralise directives at module top.
+      live are out of scope; if your team wants all directives at the
+      module top, pair this check with
+      `AshCredo.Check.Refactor.DirectiveInFunctionBody`.
 
       ## Precision
 
@@ -99,42 +103,42 @@ defmodule AshCredo.Check.Warning.MissingMacroDirective do
       to learn which functions on each configured module are actually
       macros. This means:
 
-        * It only flags real macro calls - non-macro calls on the same
-          module (`Ash.Query.new/1`, for example) are never flagged.
-        * New macros added in future Ash releases are automatically picked
-          up without code changes here.
-        * User-supplied modules in `macro_modules` are handled with the same
-          precision as `Ash.Query`/`Ash.Expr` - only their actual macros
-          are flagged, not every qualified call.
+        * It only flags real macro calls; it never flags a non-macro call
+          on the same module (`Ash.Query.new/1`, for example).
+        * New macros in future Ash releases are covered automatically,
+          without code changes here.
+        * User-supplied modules in `macro_modules` get the same precision
+          as `Ash.Query` and `Ash.Expr`: only their real macros are
+          flagged, not every qualified call.
 
       ## Requirements
 
-      Your project must be compiled before running `mix credo`. If Ash is
-      not available in the VM running Credo, the check is a no-op and emits
-      a single diagnostic. If a configured module cannot be loaded (typical
-      cause: you added one of your own modules to `macro_modules` and have
-      not compiled yet), the check emits a per-module "could not load"
-      diagnostic and skips that module for the run.
+      Compile your project before running `mix credo`. If Ash is not
+      available in the VM running Credo, the check is a no-op and emits a
+      single diagnostic. If a configured module cannot be loaded, the check
+      emits a "could not load" diagnostic for that module and skips it for
+      the run. The usual cause is adding one of your own modules to
+      `macro_modules` without compiling first.
 
       ## Configuration
 
       `macro_modules` defaults to `[Ash.Query, Ash.Expr]`. Extend the list
-      with additional macro modules your team uses:
+      with any other macro modules your team uses:
 
           {AshCredo.Check.Warning.MissingMacroDirective,
            [macro_modules: [Ash.Query, Ash.Expr, MyApp.QueryMacros]]}
       """,
       params: [
         macro_modules:
-          "List of modules whose qualified macro calls the check validates. " <>
-            "For each call to `<Module>.<macro>/n` the check requires a " <>
-            "`require` or `import` of `<Module>` to be lexically in scope - " <>
+          "Modules whose qualified macro calls the check validates. " <>
+            "For each call to `<Module>.<macro>/n`, the check requires a " <>
+            "`require` or `import` of `<Module>` lexically in scope: the " <>
             "module top, the enclosing `def` body, an enclosing branch, or " <>
-            "inherited from an enclosing `defmodule`. Defaults to " <>
-            "`[Ash.Query, Ash.Expr]`. The exact set of macros on each " <>
-            "module is read from compiled-BEAM introspection " <>
-            "(`module.__info__(:macros)`), so only real macros are flagged - " <>
-            "regular functions on the same module are ignored."
+            "a directive inherited from an enclosing `defmodule`. Defaults " <>
+            "to `[Ash.Query, Ash.Expr]`. The exact set of macros on each " <>
+            "module comes from compiled-BEAM introspection " <>
+            "(`module.__info__(:macros)`), so the check only flags real " <>
+            "macros and ignores regular functions on the same module."
       ]
     ]
 
@@ -171,9 +175,9 @@ defmodule AshCredo.Check.Warning.MissingMacroDirective do
   end
 
   # Resolves each configured module to its exact macro set via
-  # `CompiledIntrospection.macros/1`. Modules that fail to load contribute
-  # a per-module `:not_loadable` diagnostic (deduped across checks) and are
-  # dropped from the resolved map so their call sites aren't flagged this
+  # `CompiledIntrospection.macros/1`. A module that fails to load
+  # contributes one `:not_loadable` diagnostic (deduped across checks) and
+  # is dropped from the resolved map, so we don't flag its call sites this
   # run. Returns `{resolved_map, load_issues}`.
   defp resolve_macro_sets(targets, issue_meta) do
     Enum.reduce(targets, {%{}, []}, &resolve_macro_set(&1, &2, issue_meta))
@@ -195,12 +199,12 @@ defmodule AshCredo.Check.Warning.MissingMacroDirective do
   end
 
   # Walks the whole file AST and returns `{body, inherited_env}` tuples for
-  # every `defmodule` (including nested ones). `inherited_env` is the
-  # `Macro.Env` visible at the point of the `defmodule` declaration - the
-  # walker records `alias`/`require`/`import` directives into it, so nested
-  # modules inherit all three from the enclosing lexical scope, exactly as
-  # Elixir does. Defmodules inside `quote do ... end` are NOT captured (they
-  # belong to the macro caller's site).
+  # every `defmodule`, nested ones included. `inherited_env` is the
+  # `Macro.Env` visible at the `defmodule` declaration; the walker records
+  # `alias`/`require`/`import` directives into it, so nested modules
+  # inherit all three from the enclosing lexical scope, exactly as Elixir
+  # does. We do NOT capture defmodules inside `quote do ... end` blocks;
+  # they belong to the macro caller's site.
   defp collect_module_bodies(ast) do
     {%{bodies: bodies}, _scope} =
       LexicalScopeWalker.traverse(
@@ -224,20 +228,20 @@ defmodule AshCredo.Check.Warning.MissingMacroDirective do
 
   defp enter_for_bodies(_node, _scope, state), do: state
 
-  # Single-pass per-body check: walks the body with the inherited env as
-  # the base frame, and records sites only when the call's module is NOT
-  # required in the env visible at that call site.
+  # Single pass per body: walks the body with the inherited env as the base
+  # frame, recording a site only when the env visible at that call site
+  # does NOT require the call's module.
   defp check_module_body(body, inherited_env, resolved, issue_meta) do
     body
     |> collect_call_sites(inherited_env, resolved)
     |> Enum.map(&build_issue(&1, issue_meta))
   end
 
-  # The body we traverse is already the contents of the enclosing `defmodule`'s
-  # do-block - we never visit that outermost `{:do, body}` tuple ourselves, so
-  # the walker's `:initial_env` opt seeds the inherited env into the base
-  # frame. A nested module's calls then expand and resolve the same way
-  # Elixir does.
+  # The body we traverse is already the contents of the outer `defmodule`'s
+  # do-block; we never visit that outermost `{:do, body}` tuple ourselves,
+  # so the walker's `:initial_env` opt seeds the inherited env into the
+  # base frame. A nested module's calls then expand and resolve the same
+  # way they do in Elixir.
   defp collect_call_sites(body, inherited_env, resolved) do
     {%{sites: sites}, _scope} =
       LexicalScopeWalker.traverse(
@@ -251,12 +255,12 @@ defmodule AshCredo.Check.Warning.MissingMacroDirective do
     Enum.reverse(sites)
   end
 
-  # Qualified remote call: `Alias.fun(args)` parses as
+  # A qualified remote call `Alias.fun(args)` parses as
   #   {{:., _, [{:__aliases__, _, segs}, fun]}, meta, args}
-  # Expand `segs` through the env visible at the call so `alias Ash.Query,
-  # as: Q; Q.filter(...)` is matched the same as a literal
-  # `Ash.Query.filter(...)`. Skip when inside a nested `defmodule` (that
-  # body is processed separately) or inside a `quote do ... end`.
+  # Expand `segs` through the env visible at the call, so `alias Ash.Query,
+  # as: Q; Q.filter(...)` matches the same as a literal
+  # `Ash.Query.filter(...)`. Skip calls inside a nested `defmodule` (we
+  # process that body separately) or inside a `quote do ... end` block.
   defp enter_for_calls(
          {{:., _, [{:__aliases__, _, segs}, fun]}, meta, args},
          scope,
@@ -277,9 +281,9 @@ defmodule AshCredo.Check.Warning.MissingMacroDirective do
   defp enter_for_calls(_node, _scope, state, _resolved), do: state
 
   defp in_nested_module_or_quote?(scope) do
-    # `in_module?/1` (not `current_module_segments != nil`) so we also skip
-    # into nested defmodules with non-literal names like
-    # `defmodule Module.concat(...) do ... end` - those would otherwise be
+    # We use `in_module?/1`, not `current_module_segments != nil`, so we
+    # also skip nested defmodules with non-literal names like
+    # `defmodule Module.concat(...) do ... end`; those would otherwise be
     # processed as part of the outer module's call sites.
     LexicalScopeWalker.in_module?(scope) or LexicalScopeWalker.in_quote?(scope)
   end

--- a/lib/ash_credo/check/warning/overly_permissive_policy.ex
+++ b/lib/ash_credo/check/warning/overly_permissive_policy.ex
@@ -5,26 +5,29 @@ defmodule AshCredo.Check.Warning.OverlyPermissivePolicy do
     tags: [:ash, :security],
     explanations: [
       check: """
-      An unscoped policy using `authorize_if always()` allows anyone -
-      including unauthenticated requests - to perform all actions.
+      An unscoped policy using `authorize_if always()` allows anyone,
+      including unauthenticated requests, to perform all actions.
 
-      A policy is unscoped when its condition is `always()` or `expr(true)`,
-      when every element of a list condition is one of those, when it has no
-      condition at all (Ash defaults the condition to true), or when its only
-      body-level `condition` is `always()`/`expr(true)`. Conditions on
-      enclosing `policy_group`s count: Ash adds them to every policy the
-      group contains, so a policy inside `policy_group actor_attribute_equals(:role, :admin)`
+      A policy is unscoped when its condition is `always()` or
+      `expr(true)`, when every element of a list condition is one of
+      those, when it has no condition at all (Ash defaults the condition
+      to true), or when its only body-level `condition` is
+      `always()`/`expr(true)`.
+
+      Conditions on enclosing `policy_group`s count: Ash adds them to
+      every policy the group contains, so a policy inside
+      `policy_group actor_attribute_equals(:role, :admin)`
       is scoped even without a condition of its own.
 
-      Entity options do not scope: `policy description: "..." do` still
-      applies everywhere, and the condition is recognised whether passed
-      positionally or via the `condition:` option.
+      Entity options do not scope the policy: `policy description: "..." do`
+      still applies everywhere. The check recognizes the condition whether
+      you pass it positionally or via the `condition:` option.
 
       Checks apply top to bottom and the first one that reaches a decision
-      wins, so `authorize_if always()` preceded by a `forbid_if`/`forbid_unless`
-      is the deliberate allow-all-except pattern and is not flagged.
-      Guards that can never fire (`forbid_if never()`, `forbid_unless always()`,
-      boolean literals) do not count:
+      wins, so `authorize_if always()` after a `forbid_if` or
+      `forbid_unless` is the deliberate allow-all-except pattern and is
+      not flagged. Guards that can never deny do not count
+      (`forbid_if never()`, `forbid_unless always()`, boolean literals):
 
           policy always() do
             forbid_if actor_attribute_equals(:banned, true)
@@ -71,9 +74,9 @@ defmodule AshCredo.Check.Warning.OverlyPermissivePolicy do
 
   # Checks apply top to bottom and the first decision wins, so
   # `authorize_if always()` only grants unconditional access when no
-  # earlier `forbid_if`/`forbid_unless` can deny first - with one, this is
-  # the deliberate allow-all-except pattern. Guards that can never fire
-  # (`forbid_if never()`/`expr(false)`/`false`, `forbid_unless
+  # earlier `forbid_if`/`forbid_unless` can deny first; with such a guard,
+  # this is the deliberate allow-all-except pattern. Guards that can never
+  # fire (`forbid_if never()`/`expr(false)`/`false`, `forbid_unless
   # always()`/`expr(true)`/`true`) do not count. Checks accept a trailing
   # options list (`forbid_if never(), name: "..."`), which does not change
   # the check itself.
@@ -105,8 +108,8 @@ defmodule AshCredo.Check.Warning.OverlyPermissivePolicy do
 
   defp scoped_policy?({kind, _, args} = policy_ast) when kind in [:policy, :bypass] do
     case Enum.reject(args, &do_block?/1) do
-      # policy do ... end - Ash defaults the condition to static true, so the
-      # policy is only scoped if its body declares a restrictive `condition`
+      # For `policy do ... end`, Ash defaults the condition to static true, so
+      # the policy is only scoped if its body declares a restrictive `condition`
       [] -> scoped_body_condition?(policy_ast)
       [condition_or_opts | _] -> scoped_condition_arg?(condition_or_opts, policy_ast)
     end
@@ -119,7 +122,7 @@ defmodule AshCredo.Check.Warning.OverlyPermissivePolicy do
 
   # The condition arg is optional and the entity takes options
   # (`policy description: "..." do`), so a keyword list of known policy
-  # option keys is options, not a condition - the condition, if any, is
+  # option keys is options, not a condition; the condition, if any, is
   # its `:condition` key.
   @policy_option_keys ~w(description access_type condition error_message)a
 
@@ -155,7 +158,8 @@ defmodule AshCredo.Check.Warning.OverlyPermissivePolicy do
 
   # always() applies to everything; expr(true) and a bare `true` literal
   # (Ash accepts booleans as checks) are effectively unscoped. Anything
-  # else - action_type(:read), action([...]), actor checks - scopes.
+  # else (action_type(:read), action([...]), actor checks) scopes the
+  # policy.
   defp unscoped_condition?({:always, _, _}), do: true
   defp unscoped_condition?({:expr, _, [true]}), do: true
   defp unscoped_condition?(true), do: true

--- a/lib/ash_credo/check/warning/pinned_time_in_expression.ex
+++ b/lib/ash_credo/check/warning/pinned_time_in_expression.ex
@@ -5,9 +5,10 @@ defmodule AshCredo.Check.Warning.PinnedTimeInExpression do
     tags: [:ash],
     explanations: [
       check: """
-      Using `^Date.utc_today()` or `^DateTime.utc_now()` inside an Ash expression
-      freezes the value at compile time. The pinned value never changes after
-      compilation, leading to subtle bugs that only manifest after time passes.
+      Using `^Date.utc_today()` or `^DateTime.utc_now()` inside an Ash
+      expression freezes the value at compile time. The pinned value never
+      changes after compilation, leading to subtle bugs that only show up
+      after time passes.
 
       Use Ash's built-in expression functions instead:
 
@@ -23,10 +24,10 @@ defmodule AshCredo.Check.Warning.PinnedTimeInExpression do
           # Good
           filter expr(inserted_at >= now())
 
-      Only DSL-position expressions are checked. Inside function bodies
-      and anonymous functions the pin is re-evaluated on every call
+      Only expressions in DSL position are checked. Inside function
+      bodies and anonymous functions the pin is re-evaluated on every call
       (`Ash.Expr.expr/1` splices the pinned code into its call site), so
-      it is not frozen and is not flagged.
+      the value is not frozen there and is not flagged.
       """
     ]
 
@@ -38,7 +39,7 @@ defmodule AshCredo.Check.Warning.PinnedTimeInExpression do
 
   # Keyed on the module resolved through the lexical environment, so
   # aliased forms (`alias DateTime, as: DT`) match too. `Time.utc_now`
-  # maps to `nil`: Ash has no expression builtin returning the current
+  # maps to `nil`: Ash has no expression builtin that returns the current
   # time of day, so the message advises passing the value in instead of
   # naming a replacement.
   @time_calls %{
@@ -138,7 +139,8 @@ defmodule AshCredo.Check.Warning.PinnedTimeInExpression do
   end
 
   # Heads whose bodies run after compilation: the pinned call inside them
-  # is re-evaluated per invocation, so the freeze bug does not exist there.
+  # is re-evaluated per invocation, so the freeze bug does not exist
+  # there.
   @deferred_heads ~w(def defp defmacro defmacrop fn &)a
 
   defp expr_issues(ast, envs, issue_meta) do
@@ -146,7 +148,7 @@ defmodule AshCredo.Check.Warning.PinnedTimeInExpression do
       ast,
       fn
         # An immediately-invoked fn/capture runs while the DSL compiles, so
-        # its body is NOT deferred - unwrap it and keep walking the bodies.
+        # its body is NOT deferred: unwrap it and keep walking the bodies.
         # The call arguments evaluate at the call site too, so walk them
         # as well (`(fn e -> e end).(expr(^DateTime.utc_now()))`).
         {{:., _, [{:fn, _, clauses}]}, _meta, args}, acc when is_list(args) ->

--- a/lib/ash_credo/check/warning/redundant_validation.ex
+++ b/lib/ash_credo/check/warning/redundant_validation.ex
@@ -7,9 +7,9 @@ defmodule AshCredo.Check.Warning.RedundantValidation do
       check: """
       Flags `validate present(...)` where every referenced field is an
       attribute that already has `allow_nil? false`. The attribute
-      constraint guarantees presence on its own, so the validation can only
-      ever duplicate an error the changeset already carries. Straight from
-      Ash's usage rules: avoid validations that duplicate attribute
+      constraint guarantees presence on its own, so the validation can
+      only ever duplicate an error the changeset already carries. Straight
+      from Ash's usage rules: avoid validations that duplicate attribute
       constraints.
 
           # Bad - allow_nil? false already rejects nil
@@ -28,29 +28,35 @@ defmodule AshCredo.Check.Warning.RedundantValidation do
             attribute :name, :string, allow_nil?: false
           end
 
-      Fields opened up via `allow_nil_input` on an action are skipped:
-      there the attribute may legitimately be nil at validation time (for
-      example filled by the data layer during an upsert), so `present` does
-      add a real constraint. Fields shadowed by a same-named `argument` on
-      an update or destroy action are skipped too. In the atomic execution
-      path - the default for those action types (`require_atomic?`
-      defaults to `true`) - the built-in `present` validation validates
-      the argument instead of the attribute, so the validation enforces
-      "the caller supplied the argument" regardless of the attribute
-      constraint. (The non-atomic path falls back to the attribute when
-      the argument is nil, where the validation is indeed vacuous - but
-      advising removal would silently drop the atomic-path constraint, so
-      the check stays silent.) Create actions never execute atomically, so
-      a same-named argument on a create does not rescue the validation and
-      no escape applies there. Validations in read and generic actions are
-      also skipped, because `present` resolves against action arguments
-      there, not attributes.
+      Fields an action opens up via `allow_nil_input` are skipped: there
+      the attribute may legitimately be nil at validation time (for
+      example filled by the data layer during an upsert), so `present`
+      does add a real constraint.
+
+      The check also skips a field when an update or destroy action has a
+      same-named `argument`. The atomic execution path is the default for
+      those action types (`require_atomic?` defaults to `true`), and in
+      that path the built-in `present` validation validates the argument
+      instead of the attribute. The validation then enforces that the
+      caller supplied the argument, regardless of the attribute
+      constraint.
+
+      In the non-atomic path the validation falls back to the attribute
+      when the argument is nil, where it is indeed vacuous. But advising
+      removal would silently drop the atomic-path constraint, so the check
+      stays silent.
+
+      Create actions never execute atomically, so a same-named argument on
+      a create does not rescue the validation and no escape applies there.
+      Validations in read and generic actions are not examined either,
+      because `present` resolves against action arguments there, not
+      attributes.
 
       ## Requirements
 
       Your project must be compiled before running `mix credo`. If Ash is
-      not available in the VM running Credo, the check is a no-op and emits
-      a single diagnostic.
+      not available in the VM running Credo, the check is a no-op and
+      emits a single diagnostic.
       """
     ]
 
@@ -139,8 +145,9 @@ defmodule AshCredo.Check.Warning.RedundantValidation do
   # validation meaningful again, so action-level candidates always apply.
   defp scope_applies?(_rest, {:action, _name}), do: true
 
-  # Global validations default to `on: [:create, :update]`; an explicit `on`
-  # must stay within changeset action types for attribute presence to apply.
+  # Global validations default to `on: [:create, :update]`; an explicit
+  # `on` must stay within the changeset action types for attribute
+  # presence to apply.
   defp scope_applies?(rest, :global) do
     case find_on_option(rest) do
       nil -> true
@@ -200,12 +207,13 @@ defmodule AshCredo.Check.Warning.RedundantValidation do
   # non-atomic path falls back to the attribute, but removal would drop
   # the atomic-path constraint, so skip conservatively). Only update and
   # destroy actions have an atomic path (`require_atomic?` exists on
-  # neither create struct nor create execution), so on creates the
+  # neither the create struct nor the create execution), so on creates the
   # argument never rescues the validation and no escape applies.
   defp no_input_overrides?(fields, {:action, action_name}, actions) do
     case Enum.find(actions, &(&1.name == action_name)) do
-      # Source names an action the compiled module does not have (stale
-      # build or fragment drift) - do not flag what we cannot resolve.
+      # The source names an action the compiled module does not have (a
+      # stale build or fragment drift) - do not flag what we cannot
+      # resolve.
       nil -> false
       action -> Enum.all?(fields, &(&1 not in overriding_inputs(action)))
     end

--- a/lib/ash_credo/check/warning/sensitive_attribute_exposed.ex
+++ b/lib/ash_credo/check/warning/sensitive_attribute_exposed.ex
@@ -11,33 +11,37 @@ defmodule AshCredo.Check.Warning.SensitiveAttributeExposed do
     explanations: [
       check: """
       Attributes containing sensitive data should be marked with `sensitive?: true`.
-      This prevents them from being leaked in logs, error messages, and inspections.
+      This prevents them from leaking into logs, error messages, and inspections.
 
           attribute :password_hash, :string, sensitive?: true
 
-      The `sensitive_names` param accepts atoms (exact name match) and regexes
-      (matched against the attribute name), e.g. `[:ssn, ~r/_token$/]`.
+      The `sensitive_names` param accepts atoms (exact name match) and
+      regexes (matched against the attribute name), for example
+      `[:ssn, ~r/_token$/]`.
 
-      Test directories are excluded by default, since throwaway resources in
-      test support often name attributes after sensitive fields without
-      carrying real data. Override `excluded_paths` to scope the check
+      The check excludes test directories by default, since throwaway
+      resources in test support often use sensitive field names without
+      holding real data. Override `excluded_paths` to scope the check
       differently.
 
       ## Limitations
 
-      This check scans the source AST, so it only sees attributes written
+      The check scans the source AST, so it only sees attributes written
       literally in the `attributes` block. It cannot see attributes
-      contributed by Spark transformers or extensions - for example
-      `AshAuthentication`'s `:hashed_password` - and so will not flag them
-      even when they are unmarked. It also only inspects the `attribute`
-      entity: `belongs_to` foreign keys cannot be marked `sensitive?`
-      directly (declare the column as an explicit `attribute` if you need
-      that), and timestamps are not sensitive data, so neither is flagged.
+      contributed by Spark transformers or extensions, such as
+      `AshAuthentication`'s `:hashed_password`, and will not flag them
+      even when they are unmarked.
+
+      The check also only inspects the `attribute` entity: `belongs_to`
+      foreign keys cannot be marked `sensitive?` directly (declare the
+      column as an explicit `attribute` if you need that), and timestamps
+      are not sensitive data, so neither is flagged.
       """,
       params: [
         sensitive_names:
           "Attribute names considered sensitive. Atom entries match exactly; " <>
-            "`Regex` entries (e.g. `~r/_token$/`) match against the attribute name.",
+            "`Regex` entries (for example `~r/_token$/`) match against " <>
+            "the attribute name.",
         excluded_paths:
           "List of paths or regexes to exclude from this check. " <>
             "Defaults to test directories, since fake sensitive attributes " <>

--- a/lib/ash_credo/check/warning/sensitive_field_in_accept.ex
+++ b/lib/ash_credo/check/warning/sensitive_field_in_accept.ex
@@ -10,8 +10,8 @@ defmodule AshCredo.Check.Warning.SensitiveFieldInAccept do
     explanations: [
       check: """
       Actions that `accept` privilege-related fields like `:is_admin` or
-      `:permissions` can allow users to escalate their own permissions.
-      Set these fields via `change` modules instead.
+      `:permissions` can let users escalate their own permissions. Set
+      these fields via `change` modules instead.
 
           create :register do
             accept [:name, :email]
@@ -19,19 +19,19 @@ defmodule AshCredo.Check.Warning.SensitiveFieldInAccept do
             change set_attribute(:role, :user)
           end
 
-      Create, update, and soft destroy actions are checked. Hard destroy
-      actions are not: Ash resets their `accept` to `[]` at compile time,
-      so an accept list there takes no input.
+      The check covers create, update, and soft destroy actions. Hard
+      destroy actions are not checked: Ash resets their `accept` to `[]`
+      at compile time, so an accept list there takes no input.
 
-      Test directories are excluded by default, since test factories and seeds
-      often accept these fields on purpose. Override `excluded_paths` to scope
-      the check differently.
+      The check excludes test directories by default, since test factories
+      and seeds often accept these fields on purpose. Override
+      `excluded_paths` to scope the check differently.
       """,
       params: [
         dangerous_fields:
           "Field names that should not appear in accept lists. Atom entries " <>
-            "match exactly; `Regex` entries (e.g. `~r/_token$/`) match against " <>
-            "the field name.",
+            "match exactly; `Regex` entries (for example `~r/_token$/`) match " <>
+            "against the field name.",
         excluded_paths:
           "List of paths or regexes to exclude from this check. " <>
             "Defaults to test directories, since accepting these fields is " <>

--- a/lib/ash_credo/check/warning/unknown_action.ex
+++ b/lib/ash_credo/check/warning/unknown_action.ex
@@ -13,9 +13,9 @@ defmodule AshCredo.Check.Warning.UnknownAction do
           # Did you mean `:published`?
 
       The check uses Ash's runtime introspection
-      (`Ash.Resource.Info.actions/1`) to read the resource's fully-resolved
-      action list, then jaro-distance to suggest the closest known action
-      name when one is similar enough.
+      (`Ash.Resource.Info.actions/1`) to read the resource's fully
+      resolved action list, then jaro distance to suggest the closest
+      known action name when one is similar enough.
 
       Unlike `Refactor.UseCodeInterface`, this check is objective: the
       action either exists on the resource or it doesn't. There's nothing
@@ -24,9 +24,9 @@ defmodule AshCredo.Check.Warning.UnknownAction do
       It runs against the same resolved Ash call-site pipeline as
       `UseCodeInterface`, including
       `Ash.read!`/`Ash.get!`/`Ash.read_one!`/`Ash.read_first!`/`Ash.bulk_*`/
-      `Ash.Changeset.for_*`/`Ash.Query.for_read`/`Ash.ActionInput.for_action` - whenever both
-      the resource and the action argument are literal values that can be
-      resolved at lint time.
+      `Ash.Changeset.for_*`/`Ash.Query.for_read`/`Ash.ActionInput.for_action`.
+      The check applies whenever both the resource and the action argument
+      are literal values it can resolve at lint time.
 
       ## Requirements
 
@@ -58,8 +58,8 @@ defmodule AshCredo.Check.Warning.UnknownAction do
     end
   end
 
-  # `:not_loadable` resources are reported by `UseCodeInterface` (gated on its
-  # `enforce_code_interface_outside_domain` flag) - emitting a second
+  # `:not_loadable` resources are reported by `UseCodeInterface` (gated on
+  # its `enforce_code_interface_outside_domain` flag); emitting a second
   # "could not load" diagnostic from here would just double the noise.
   defp check_site(%AshCallSite{}, _issue_meta), do: []
 
@@ -81,10 +81,11 @@ defmodule AshCredo.Check.Warning.UnknownAction do
     )
   end
 
-  # Returns the known action name most similar to `target_name` (jaro distance
-  # >= 0.75), or nil if no close match exists. Pure string similarity over the
-  # already-resolved action list - no Ash runtime introspection, so it lives
-  # with its sole caller rather than in the Compiled gateway.
+  # Returns the known action name most similar to `target_name` (jaro
+  # distance >= 0.75), or nil if no close match exists. Pure string
+  # similarity over the already-resolved action list - no Ash runtime
+  # introspection - so it lives with its sole caller rather than in the
+  # Compiled gateway.
   defp suggest_action_name(known_actions, target_name)
        when is_list(known_actions) and is_atom(target_name) do
     target_str = Atom.to_string(target_name)

--- a/lib/ash_credo/check/warning/wildcard_accept_on_action.ex
+++ b/lib/ash_credo/check/warning/wildcard_accept_on_action.ex
@@ -8,9 +8,9 @@ defmodule AshCredo.Check.Warning.WildcardAcceptOnAction do
     ],
     explanations: [
       check: """
-      Using `accept :*` on create, update, or soft destroy actions accepts
-      all public attributes, which is a mass-assignment vulnerability.
-      Explicitly list the accepted attributes instead.
+      Using `accept :*` on a create, update, or soft destroy action
+      accepts all public attributes, which is a mass-assignment
+      vulnerability. Explicitly list the accepted attributes instead.
 
           create :create do
             accept [:title, :body]
@@ -21,9 +21,9 @@ defmodule AshCredo.Check.Warning.WildcardAcceptOnAction do
       destroys are updates under the hood and honor `accept` like any
       other writable action.
 
-      Test directories are excluded by default, since test factories and seeds
-      often use `accept :*` on purpose. Override `excluded_paths` to scope the
-      check differently.
+      The check excludes test directories by default, since test factories
+      and seeds often use `accept :*` on purpose. Override
+      `excluded_paths` to scope the check differently.
       """,
       params: [
         excluded_paths:
@@ -93,8 +93,8 @@ defmodule AshCredo.Check.Warning.WildcardAcceptOnAction do
   end
 
   # `default_accept` only reaches actions that can inherit it; on a
-  # resource with none (e.g. only reads and hard destroys) the option is
-  # dead configuration, not a mass-assignment surface.
+  # resource with none (for example only reads and hard destroys) the
+  # option is dead configuration, not a mass-assignment surface.
   defp default_accept_issues(actions_ast, issue_meta) do
     if Introspection.default_accept_inheritors?(actions_ast) do
       wildcard_default_accept_issues(actions_ast, issue_meta)

--- a/lib/ash_credo/clear_cache_task.ex
+++ b/lib/ash_credo/clear_cache_task.ex
@@ -1,11 +1,13 @@
 defmodule AshCredo.ClearCacheTask do
   @moduledoc false
-  # Credo pipeline task appended to `:halt_execution` by `AshCredo.init/1`.
-  # Empties the introspection cache after every Credo run so its memory does
-  # not linger between invocations in long-lived VMs.
+  # Credo pipeline task appended to `:halt_execution` by
+  # `AshCredo.init/1`. It empties the introspection cache after every
+  # Credo run so its memory doesn't linger between invocations in
+  # long-lived VMs.
   #
-  # `AshCredo.init/1` ALSO clears at the start of every run as a safety net
-  # for the case where a previous run crashed before reaching this task.
+  # `AshCredo.init/1` ALSO clears the cache at the start of every run,
+  # as a safety net for the case where a previous run crashed before
+  # reaching this task.
 
   use Credo.Execution.Task
 

--- a/lib/ash_credo/compiled_check.ex
+++ b/lib/ash_credo/compiled_check.ex
@@ -2,22 +2,24 @@ defmodule AshCredo.CompiledCheck do
   @moduledoc """
   Base for checks that introspect compiled Ash modules.
 
-  `use AshCredo.CompiledCheck` injects `use Credo.Check` (passing every option
-  through unchanged) and a generated `run/2` that guards every invocation with
-  the Ash-availability check. When Ash is not loaded in the VM running Credo,
-  the check emits a single informational diagnostic - once per run, across all
-  compiled checks - and runs no introspection; otherwise it delegates to the
-  check's `run_compiled/2` callback.
+  `use AshCredo.CompiledCheck` injects `use Credo.Check`, passing every
+  option through unchanged, plus a generated `run/2` that guards every
+  invocation with the Ash-availability check. When Ash isn't loaded in
+  the VM running Credo, the check emits a single informational
+  diagnostic, once per run across all compiled checks, and runs no
+  introspection. Otherwise the wrapper delegates to the check's
+  `run_compiled/2` callback.
 
-  This makes the wrapper structural rather than a convention. A compiled check
-  cannot run introspection without the guard, so it can never raise or silently
-  no-op when the host project is not compiled, and there is no wrapper call to
-  forget.
+  This makes the wrapper structural rather than a convention. A compiled
+  check cannot run introspection without the guard, so it can never
+  raise or silently no-op when the host project isn't compiled, and
+  there is no wrapper call to forget.
 
-  Implement `run_compiled/2`. Optionally override `active?/2` to skip the check
-  entirely - producing no issues and no ash-missing diagnostic - before the
-  guard runs; use it for checks disabled by path filters or configuration, so
-  a disabled check stays silent even when Ash is unavailable.
+  Implement `run_compiled/2`. Optionally override `active?/2` to skip
+  the check entirely before the guard runs; a skipped check produces no
+  issues and no ash-missing diagnostic. Use `active?/2` for checks
+  disabled by path filters or configuration, so a disabled check stays
+  silent even when Ash is unavailable.
   """
 
   alias AshCredo.Introspection.Compiled, as: CompiledIntrospection
@@ -26,15 +28,15 @@ defmodule AshCredo.CompiledCheck do
   alias Credo.SourceFile
 
   @doc """
-  Runs the check body. Invoked only when `active?/2` returns `true` and Ash is
-  available in the VM. Returns the list of issues.
+  Runs the check body. Invoked only when `active?/2` returns `true` and
+  Ash is available in the VM. Returns the list of issues.
   """
   @callback run_compiled(SourceFile.t(), keyword()) :: [Credo.Issue.t()]
 
   @doc """
-  Whether the check should run for this file and params at all. When `false`,
-  the check produces no issues and no ash-missing diagnostic. Defaults to
-  `true`.
+  Whether the check should run for this file and params at all. When
+  `false`, the check produces no issues and no ash-missing diagnostic.
+  Defaults to `true`.
   """
   @callback active?(SourceFile.t(), keyword()) :: boolean()
 

--- a/lib/ash_credo/introspection.ex
+++ b/lib/ash_credo/introspection.ex
@@ -1,12 +1,13 @@
 defmodule AshCredo.Introspection do
   @moduledoc """
-  Resource- and domain-level introspection of Ash DSL constructs in source AST:
-  resource/domain detection, resource contexts, DSL sections, entities, options,
-  and policies.
+  Resource- and domain-level introspection of Ash DSL constructs in the
+  source AST: resource/domain detection, resource contexts, DSL
+  sections, entities, options, and policies.
 
-  This module owns only those DSL/resource semantics. Lower-level tools live in
-  sibling modules under `AshCredo.Introspection.*` and are called directly by
-  consumers; there is intentionally no single facade re-exporting them:
+  This module owns only those DSL and resource semantics. Lower-level
+  tools live in sibling modules under `AshCredo.Introspection.*` and are
+  called directly by consumers; there is intentionally no single facade
+  re-exporting them:
 
     * `Aliases` - `Macro.Env`-backed directive application and resolution
     * `AshCallScanner` / `AshCallResolver` / `AshCallSite` - `Ash.*` API call detection
@@ -14,43 +15,47 @@ defmodule AshCredo.Introspection do
     * `Block` - do-block and module-body AST access
     * `LexicalScopeWalker` - scope-aware traversal
     * `ResourceContext` / `UseMetadata` - shared data structs
-    * `Compiled` - compile-time/runtime metadata, and the sole gateway for it.
-      The boundary (only `Compiled` may call Ash's runtime introspection
-      modules) is enforced structurally by the `calls.forbidden` policy in
-      `.reach.exs`.
+    * `Compiled` - compile-time/runtime metadata, and the sole gateway
+      for it. Only `Compiled` may call Ash's runtime introspection
+      modules; the `calls.forbidden` policy in `.reach.exs` enforces
+      this boundary structurally.
 
-  Do not add thin pass-through wrappers here for those modules; call the owning
-  module directly so dependencies stay honest.
+  Do not add thin pass-through wrappers here for those modules. Call the
+  owning module directly so dependencies stay honest.
 
   ## Why two introspection worlds
 
   Checks draw on two complementary sources, and both are load-bearing:
 
-    * **Source AST** (this module and its `*Scanner`/`*Walker` siblings) works
-      without compiling the host project and carries source positions, which
-      diagnostics anchor to. It is the only way to find *call sites* -
-      `Ash.read!(...)` scattered across a codebase - because compiled
-      introspection knows resource definitions, not where they are called.
-    * **`Compiled`** reads the fully-resolved DSL state of loaded modules,
-      including attributes/actions/policies that Spark transformers and
-      extensions contribute and that the source AST never sees.
+    * **Source AST** (this module and its `*Scanner`/`*Walker` siblings)
+      works without compiling the host project and carries source
+      positions, which diagnostics anchor to. It is the only way to find
+      *call sites*, such as `Ash.read!(...)` calls scattered across a
+      codebase: compiled introspection knows resource definitions, not
+      where they are called.
+    * **`Compiled`** reads the fully resolved DSL state of loaded
+      modules, including attributes, actions, and policies that Spark
+      transformers and extensions contribute and that the source AST
+      never sees.
 
-  Source-AST lexical resolution is built on real `Macro.Env` values:
+  Source-AST lexical resolution is built on real `Macro.Env` values.
   `Aliases` applies `alias`/`require`/`import` nodes to an env via
   `Macro.Env.define_alias/4` and `define_require/4`, and resolves
-  references via `Macro.Env.expand_alias/4` and `Macro.Env.required?/2`
-  (Elixir 1.17+ APIs added for exactly this kind of tooling). The walkers
+  references via `Macro.Env.expand_alias/4` and `Macro.Env.required?/2`,
+  APIs Elixir 1.17 added for exactly this kind of tooling. The walkers
   (`LexicalScopeWalker`, `AshCallScanner`) own only what an env cannot
-  know from source: scope-frame push/pop for blocks and branches, quote
-  suppression, and the `defmodule` module stack that substitutes
-  `__MODULE__` targets at declaration time. `Credo.Code.Module.aliases/1`
-  remains unsuitable - it collects alias names flat across a module,
-  dropping `as:` renames and lexical scoping.
+  know from source: scope-frame push and pop for blocks and branches,
+  quote suppression, and the `defmodule` module stack that substitutes
+  `__MODULE__` targets at declaration time.
+  `Credo.Code.Module.aliases/1` remains unsuitable: it collects alias
+  names flat across a module, dropping `as:` renames and lexical scope
+  information.
 
-  Each file is parsed once (Credo caches `SourceFile.ast/1`) and each derived
-  view is memoized on `{filename, source_hash/1}` - `resource_contexts/1` here,
-  `AshCallResolver.sites/1` next door - so the several specialised walkers each
-  run once per file, not once per consuming check.
+  Each file is parsed once (Credo caches `SourceFile.ast/1`), and the
+  cache memoizes each derived view on `{filename, source_hash/1}`
+  (`resource_contexts/1` here, `AshCallResolver.sites/1` next door), so
+  each specialised walker runs once per file rather than once per
+  consuming check.
   """
 
   alias AshCredo.Cache
@@ -72,15 +77,16 @@ defmodule AshCredo.Introspection do
   def resource_modules(source_file), do: modules_using(source_file, [:Ash, :Resource])
 
   @doc """
-  Returns resource contexts for all resource modules in the source file, in
-  file order. Each context now includes `:absolute_segments` - the full
-  enclosing path of the resource's `defmodule` name (e.g. `[:MyApp, :Blog, :Post]`
-  for a nested `defmodule Post` inside `defmodule MyApp.Blog`). This lets
-  compiled-introspection checks resolve the resource to its runtime module atom.
+  Returns the resource contexts for all resource modules in the source
+  file, in file order. Each context includes `:absolute_segments`, the
+  full enclosing path of the resource's `defmodule` name (e.g.
+  `[:MyApp, :Blog, :Post]` for a nested `defmodule Post` inside
+  `defmodule MyApp.Blog`). This lets compiled-introspection checks
+  resolve the resource to its runtime module atom.
 
-  Memoized in the run-scoped cache keyed on filename plus source hash, so the
-  underlying scope-tracking traversal runs once per file per Credo run instead
-  of once per enabled check.
+  Memoized in the run-scoped cache, keyed on filename plus source hash,
+  so the underlying scope-tracking traversal runs once per file per
+  Credo run instead of once per enabled check.
   """
   def resource_contexts(source_file) do
     key = {@resource_contexts_key_tag, source_file.filename, source_hash(source_file)}
@@ -96,10 +102,10 @@ defmodule AshCredo.Introspection do
   end
 
   @doc """
-  Hashes a source file's content for use in content-addressed cache keys.
-  Filename alone is not a safe key: distinct `SourceFile`s regularly share a
-  filename with different content (most prominently in this project's own
-  test suite).
+  Hashes a source file's content for use in content-addressed cache
+  keys. The filename alone is not a safe key: distinct `SourceFile`s
+  regularly share a filename with different content, most prominently in
+  this project's own test suite.
   """
   def source_hash(source_file), do: :erlang.md5(SourceFile.source(source_file))
 
@@ -107,10 +113,11 @@ defmodule AshCredo.Introspection do
   Walks every `defmodule` in a source file and returns
   `{module_ast, absolute_segments}` tuples in file order.
 
-  `absolute_segments` is the concatenation of all enclosing `defmodule` names
-  (top-to-bottom), so a `defmodule Bar` nested inside `defmodule Foo` is
-  reported as `[:Foo, :Bar]`. Modules whose name is not a literal alias are
-  reported with `absolute_segments: nil` (they still appear in the output).
+  `absolute_segments` is the concatenation of all enclosing `defmodule`
+  names, top to bottom, so a `defmodule Bar` nested inside
+  `defmodule Foo` is reported as `[:Foo, :Bar]`. Modules whose name is
+  not a literal alias are reported with `absolute_segments: nil` (they
+  still appear in the output).
   """
   def all_modules_with_path(source_file) do
     {%{out: out}, _scope} =
@@ -125,10 +132,11 @@ defmodule AshCredo.Introspection do
     Enum.reverse(out)
   end
 
-  # Only literal `defmodule Name do ... end` forms are emitted; non-literal
-  # names (e.g. `defmodule unquote(name) do ... end`) are skipped to match
-  # the pre-walker behaviour. The walker still tracks them on the module
-  # stack so nested modules under a non-literal parent are reported as nil.
+  # Only literal `defmodule Name do ... end` forms are emitted;
+  # non-literal names (e.g. `defmodule unquote(name) do ... end`) are
+  # skipped to match the pre-walker behaviour. The walker still tracks
+  # them on the module stack, so nested modules under a non-literal
+  # parent are reported as nil.
   defp collect_module_with_path(
          {:defmodule, _, [{:__aliases__, _, segs}, [do: _body]]} = ast,
          scope,
@@ -188,7 +196,7 @@ defmodule AshCredo.Introspection do
     end
   end
 
-  @doc "Extracts keyword options from a `use` call matching the given module aliases."
+  @doc "Extracts the keyword options from a `use` call matching the given module aliases."
   def use_opts({:defmodule, _, _} = module_ast, module_aliases) do
     module_ast
     |> find_use(module_aliases)
@@ -202,12 +210,12 @@ defmodule AshCredo.Introspection do
   end
 
   @doc """
-  Finds the AST node of the first top-level DSL section (e.g. :attributes)
-  in a module AST or resource/domain context.
+  Finds the AST node of the first top-level DSL section (e.g.
+  :attributes) in a module AST or a resource/domain context.
 
   Suitable only for line anchoring: Spark merges multiple same-named
-  top-level blocks into one section, so entries may live in later blocks.
-  Use `find_dsl_sections/2` to enumerate entries.
+  top-level blocks into one section, so entries may live in later
+  blocks. Use `find_dsl_sections/2` to enumerate the entries.
   """
   def find_dsl_section(%ResourceContext{module_ast: module_ast}, section_name) do
     find_dsl_section(module_ast, section_name)
@@ -226,7 +234,8 @@ defmodule AshCredo.Introspection do
 
   @doc """
   Finds the AST nodes of all same-named top-level DSL sections (e.g.
-  :attributes) in a module AST or resource/domain context, in source order.
+  :attributes) in a module AST or a resource/domain context, in source
+  order.
 
   Spark merges multiple same-named top-level blocks into one section, so
   entry enumeration must consider every block, not just the first.
@@ -282,10 +291,11 @@ defmodule AshCredo.Introspection do
   end
 
   @doc """
-  Returns the explicit action entities whose `accept` option is honored at
-  runtime: creates, updates, and soft destroys. Ash's `DefaultAccept`
-  transformer resets `accept` to `[]` on hard destroys (`soft?` false), so
-  an accept list there is dead configuration rather than an input surface.
+  Returns the explicit action entities whose `accept` option is honored
+  at runtime: creates, updates, and soft destroys. Ash's `DefaultAccept`
+  transformer resets `accept` to `[]` on hard destroys (`soft?` false),
+  so an accept list there is dead configuration rather than an input
+  surface.
   """
   def accepting_action_entities(actions_ast) do
     action_entities(actions_ast, ~w(create update)a) ++
@@ -294,16 +304,16 @@ defmodule AshCredo.Introspection do
 
   @doc """
   Returns true when some action in the section can inherit
-  `default_accept`: an accepting action (create, update, soft destroy)
-  without its own `accept` option, or a bare `:create`/`:update` atom in
-  `defaults`. Ash's DefaultAccept transformer applies the default only to
-  those - explicit accept lists override it, and hard destroys and reads
-  never take one.
+  `default_accept`. Two shapes qualify: an accepting action (create,
+  update, soft destroy) without its own `accept` option, or a bare
+  `:create`/`:update` atom in `defaults`. Ash's DefaultAccept
+  transformer applies the default only to those: explicit accept lists
+  override it, and hard destroys and reads never take one.
 
   Non-literal shapes count as inheritors: `defaults @actions` may expand
-  to inheriting entries and `soft? @soft` may compile a destroy soft, so
-  silencing a warning based on an unreadable value would hide a real
-  mass-assignment surface.
+  to entries that inherit, and `soft? @soft` may compile a destroy as
+  soft, so silencing a warning based on an unreadable value would hide a
+  real mass-assignment surface.
   """
   def default_accept_inheritors?(actions_ast) do
     inheriting_accepting_entity?(actions_ast) or
@@ -328,8 +338,8 @@ defmodule AshCredo.Introspection do
   end
 
   # A destroy whose `soft?` value is anything but the literal `false` may
-  # compile soft and then inherits like an update, unless it carries its
-  # own accept list.
+  # compile as soft and then inherits like an update, unless it carries
+  # its own accept list.
   defp potentially_soft_destroy_inheritor?(actions_ast) do
     actions_ast
     |> action_entities([:destroy])
@@ -533,11 +543,12 @@ defmodule AshCredo.Introspection do
   Returns `{entity, inherited_conditions}` pairs for all `policy` and
   `bypass` entities in a policies section, in source order.
 
-  `policy_group`s are descended at any depth (`policy_group` is declared
-  `recursive_as: :policies` in Ash) and their condition arguments are
-  accumulated, outermost first: Ash adds the group conditions to each
-  policy the group contains, so `inherited_conditions` is part of every
-  contained policy's effective condition.
+  `policy_group`s are descended at any depth (Ash declares
+  `policy_group` as `recursive_as: :policies`) and their condition
+  arguments are accumulated, outermost first. Ash adds the group
+  conditions to each policy the group contains, so
+  `inherited_conditions` is part of every contained policy's effective
+  condition.
   """
   def policy_entities_with_conditions(policies_ast) do
     policies_ast
@@ -573,7 +584,7 @@ defmodule AshCredo.Introspection do
   def find_in_body(ast, call_name),
     do: Enum.find(Block.do_block_entries(ast), &match?({^call_name, _, _}, &1))
 
-  @doc "Extracts the first atom argument from an entity call (e.g. action name)."
+  @doc "Extracts the first atom argument from an entity call (e.g. the action name)."
   def entity_name({_call, _meta, [name | _]}) when is_atom(name), do: name
   def entity_name(_), do: nil
 

--- a/lib/ash_credo/introspection/aliases.ex
+++ b/lib/ash_credo/introspection/aliases.ex
@@ -7,9 +7,10 @@ defmodule AshCredo.Introspection.Aliases do
   Returns a fresh `Macro.Env` for accumulating lexical directives.
 
   Built via `Code.env_for_eval/1`, so `Kernel` is pre-required and
-  pre-imported exactly as in any real compilation unit. Only observable
-  when a consumer asks `Macro.Env.required?(env, Kernel)` before any
-  directive was applied - which mirrors real Elixir semantics anyway.
+  pre-imported exactly as in any real compilation unit. This is only
+  observable when a consumer asks `Macro.Env.required?(env, Kernel)`
+  before any directive was applied, which mirrors real Elixir semantics
+  anyway.
   """
   def base_env do
     Code.env_for_eval(file: "nofile")
@@ -17,9 +18,9 @@ defmodule AshCredo.Introspection.Aliases do
 
   @doc """
   Applies an `alias`/`require`/`import` directive AST node to `env` and
-  returns the updated env. Malformed or unresolvable directives leave the
-  env unchanged (graceful skip), matching how unparsable directives
-  produced no alias entry before.
+  returns the updated env. Malformed or unresolvable directives leave
+  the env unchanged (a graceful skip), matching how unparsable
+  directives produced no alias entry before.
 
   `enclosing` is the absolute segment list of the innermost literal
   `defmodule`, or `nil` when unknown; it substitutes a leading
@@ -27,11 +28,11 @@ defmodule AshCredo.Introspection.Aliases do
   declaration time, which is where Elixir itself resolves it.
 
   `require Mod, as: Q` registers both the require and the alias.
-  `import Mod` is registered via `Macro.Env.define_require/4` rather than
-  `define_import/4`: consumers only ask "is a require satisfied here?"
-  (import implies require in Elixir), and `define_import` raises for
-  modules not loaded in the linting VM, which source-only references
-  regularly are.
+  `import Mod` is registered via `Macro.Env.define_require/4` rather
+  than `define_import/4`: consumers only ask whether a require holds at
+  a point (import implies require in Elixir), and `define_import/4`
+  raises for modules not loaded in the linting VM, which source-only
+  references regularly are.
   """
   def apply_directive(%Macro.Env{} = env, directive_ast, enclosing) do
     directive_ast
@@ -42,10 +43,10 @@ defmodule AshCredo.Introspection.Aliases do
   end
 
   @doc """
-  Resolves alias segments to a module atom through `env`, falling back to
-  plain concatenation when no alias matches. Returns `:error` when the
-  segments are not a non-empty list of plain atoms (e.g. they still carry
-  an `unquote` or `__MODULE__` node).
+  Resolves alias segments to a module atom through `env`, falling back
+  to plain concatenation when no alias matches. Returns `:error` when
+  the segments are not a non-empty list of plain atoms (e.g. they still
+  carry an `unquote` or `__MODULE__` node).
   """
   def expand_to_module(segments, %Macro.Env{} = env) when is_list(segments) do
     if atom_segments?(segments) do
@@ -61,8 +62,9 @@ defmodule AshCredo.Introspection.Aliases do
   def expand_to_module(_segments, %Macro.Env{}), do: :error
 
   @doc """
-  Extracts the literal alias segments from a `defmodule` AST node, or `nil`
-  when the module name is not a literal alias (e.g. `Module.concat(...)`).
+  Extracts the literal alias segments from a `defmodule` AST node, or
+  `nil` when the module name is not a literal alias (e.g.
+  `Module.concat(...)`).
   """
   def defmodule_literal_segments({:defmodule, _, [{:__aliases__, _, segs}, _]})
       when is_list(segs), do: segs
@@ -89,15 +91,15 @@ defmodule AshCredo.Introspection.Aliases do
   end
 
   @doc """
-  Resolves a literal `defmodule` name into absolute module segments through
-  the visible env.
+  Resolves a literal `defmodule` name into absolute module segments
+  through the visible env.
 
-  When `parent_absolute` is empty, the module is top-level and visible
-  aliases apply to its literal segments. When it is a module path, the
-  module is nested and Elixir resolves it by prepending the enclosing path
-  without applying lexical aliases to the nested name itself. Returns `nil`
-  when the segments are not a literal alias or the enclosing module path is
-  already unknown.
+  When `parent_absolute` is empty, the module is top-level and the
+  visible aliases apply to its literal segments. When it is a module
+  path, the module is nested, and Elixir resolves it by prepending the
+  enclosing path without applying lexical aliases to the nested name
+  itself. Returns `nil` when the segments are not a literal alias or the
+  enclosing module path is already unknown.
   """
   def absolute_module_segments(literal_segments, parent_absolute, %Macro.Env{} = env)
       when is_list(literal_segments) do
@@ -113,7 +115,7 @@ defmodule AshCredo.Introspection.Aliases do
 
   @doc """
   Expands module alias segments through `env` using the compiler's own
-  resolution (`Macro.Env.expand_alias/4`). Segments-in / segments-out:
+  resolution (`Macro.Env.expand_alias/4`). Segments in, segments out:
   unresolvable input (non-atom segments, no matching alias) is returned
   unchanged.
   """
@@ -129,11 +131,12 @@ defmodule AshCredo.Introspection.Aliases do
 
   @doc """
   Substitutes `__MODULE__` elements in expanded alias segments with the
-  enclosing `defmodule`'s absolute segments (`alias __MODULE__.Post` targets
-  carry the raw `__MODULE__` AST tuple). Returns `{:ok, segments}` only when
-  every resulting segment is an atom - `Module.concat/1` raises on anything
-  else - and `:error` when substitution is impossible (no enclosing literal
-  module) or non-atom segments remain.
+  enclosing `defmodule`'s absolute segments (`alias __MODULE__.Post`
+  targets carry the raw `__MODULE__` AST tuple). Returns
+  `{:ok, segments}` only when every resulting segment is an atom,
+  because `Module.concat/1` raises on anything else, and `:error` when
+  substitution is impossible (no enclosing literal module) or non-atom
+  segments remain.
   """
   def resolve_module_self(segments, enclosing) when is_list(segments) do
     resolved =
@@ -166,8 +169,8 @@ defmodule AshCredo.Introspection.Aliases do
   # as_opts}` tuples. Grouped forms (`alias P.{A, B}`) yield one tuple per
   # suffix; `require`/`import` share the same shapes. Anything else yields
   # no tuples. `as_opts` is `[]`, `[as: Module]`, or the `:invalid` marker
-  # for a multi-segment `as:` (invalid Elixir - the whole entry is skipped
-  # rather than misregistered under a guessed name).
+  # for a multi-segment `as:` (invalid Elixir), in which case the whole
+  # entry is skipped rather than misregistered under a guessed name.
   defp directive_targets({kind, meta, [target]}) when kind in @directive_kinds do
     directive_targets({kind, meta, [target, []]})
   end

--- a/lib/ash_credo/introspection/ash_call_resolver.ex
+++ b/lib/ash_credo/introspection/ash_call_resolver.ex
@@ -2,39 +2,41 @@ defmodule AshCredo.Introspection.AshCallResolver do
   @moduledoc """
   Upper layer of the Ash call pipeline: consumes the call stream from
   `AshCredo.Introspection.AshCallScanner` and yields *resolved* Ash call
-  sites - calls where both the resource and the action arguments are
+  sites, calls where both the resource and the action arguments are
   literal values that map to a real module atom and a real action atom.
 
-  Knows the specific Ash API entry-point shapes; the lower layer doesn't.
-  Four dispatch patterns are recognised:
+  This module knows the specific Ash API entry-point shapes; the lower
+  layer doesn't. It recognises four dispatch patterns:
 
-    * Pattern A - resource at arg 0, `:action` in keyword opts (`Ash.read!`,
-      `Ash.get`, `Ash.read_one`, `Ash.stream!`, ...). When no `:action` is present, read-like
-      calls resolve to the resource's primary `:read` action, but still carry
-      their original call shape so checks can preserve list/get/stream
-      semantics in suggestions.
-    * Pattern B - `Ash.bulk_create/3` (resource at arg 1, action at arg 2).
-    * Pattern C - `Ash.bulk_update`/`bulk_destroy` (query/stream at arg 0,
-      action at arg 1, resource traced through the query origin).
-    * Pattern D - builders `Ash.Changeset.for_*`/`Ash.Query.for_read`/
+    * Pattern A - resource at arg 0, `:action` in the keyword opts
+      (`Ash.read!`, `Ash.get`, `Ash.read_one`, `Ash.stream!`, ...).
+      When no `:action` is present, read-like calls resolve to the
+      resource's primary `:read` action, but still carry their original
+      call shape so checks can preserve list/get/stream semantics in
+      suggestions.
+    * Pattern B - `Ash.bulk_create/3` (resource at arg 1, action at
+      arg 2).
+    * Pattern C - `Ash.bulk_update`/`bulk_destroy` (query/stream at
+      arg 0, action at arg 1, resource traced through the query origin).
+    * Pattern D - the builders `Ash.Changeset.for_*`/`Ash.Query.for_read`/
       `Ash.ActionInput.for_action` (resource at arg 0, action at arg 1).
 
-  For pattern D record-first builders (`for_update`/`for_destroy`) the
-  resolver additionally traces the first argument back through bindings
-  and pipe chains to find the originating literal resource.
+  For the pattern D record-first builders (`for_update`/`for_destroy`),
+  the resolver additionally traces the first argument back through
+  bindings and pipe chains to find the originating literal resource.
 
-  Each yielded site has the resource lookup result attached - either
+  Each yielded site has the resource lookup result attached, either
   `{:ok, atom, info}`, `{:not_loadable, atom}`, `:not_a_resource`, or
-  `:ash_missing` - so consumers can apply their own emission logic without
-  re-running `Compiled.inspect_module/1`.
+  `:ash_missing`, so consumers can apply their own emission logic
+  without re-running `Compiled.inspect_module/1`.
 
-  Used by:
+  Consumers:
 
-    * `AshCredo.Check.Refactor.UseCodeInterface` - interface-suggestion
-      logic on loaded resources plus the `:not_loadable` diagnostic for
-      unreachable modules.
-    * `AshCredo.Check.Warning.UnknownAction` - flags references to actions
-      that do not exist on the resolved resource.
+    * `AshCredo.Check.Refactor.UseCodeInterface` - the
+      interface-suggestion logic on loaded resources, plus the
+      `:not_loadable` diagnostic for unreachable modules.
+    * `AshCredo.Check.Warning.UnknownAction` - flags references to
+      actions that don't exist on the resolved resource.
   """
 
   alias AshCredo.Cache
@@ -67,8 +69,8 @@ defmodule AshCredo.Introspection.AshCallResolver do
                          {[:Ash, :ActionInput], :for_action}
                        ])
 
-  # Builders whose arg 0 is typically a record (struct or variable bound to
-  # one) rather than a literal resource module. For these we additionally
+  # Builders whose arg 0 is typically a record (a struct or a variable
+  # bound to one) rather than a literal resource module. For these we also
   # try to trace the argument's provenance back to a literal resource origin.
   @record_first_builders MapSet.new([
                            {[:Ash, :Changeset], :for_update},
@@ -76,20 +78,21 @@ defmodule AshCredo.Introspection.AshCallResolver do
                          ])
 
   # Origin calls from which a bound variable carries a single record whose
-  # resource type is the first argument (e.g. `post = Ash.get!(MyApp.Post, id)`).
-  # Only the bang variant qualifies: `Ash.get/3` returns `{:ok, record}`, so a
-  # binding like `post = Ash.get(Post, id)` holds a result tuple, not a record.
+  # resource type is the first argument (e.g.
+  # `post = Ash.get!(MyApp.Post, id)`). Only the bang variant qualifies:
+  # `Ash.get/3` returns `{:ok, record}`, so a binding like
+  # `post = Ash.get(Post, id)` holds a result tuple, not a record.
   @record_origin_funs ~w(get!)a
 
   @doc """
   Walks `source_file` and returns the list of resolved Ash call sites in
   source order.
 
-  Memoized in the run-scoped cache keyed on filename plus source hash, so
-  the scan-and-resolve pass runs once per file per Credo run instead of
-  once per consuming check. Safe to cache despite embedding compiled
-  resolution results: the compiled world is fixed within a run, and the
-  cache is cleared at run boundaries.
+  Memoized in the run-scoped cache, keyed on filename plus source hash,
+  so the scan-and-resolve pass runs once per file per Credo run instead
+  of once per consuming check. Safe to cache despite embedding compiled
+  resolution results: the compiled world is fixed within a run, and
+  `AshCredo.init/1` clears the cache at the run boundaries.
   """
   @spec sites(Credo.SourceFile.t()) :: [AshCallSite.t()]
   def sites(source_file) do
@@ -110,9 +113,9 @@ defmodule AshCredo.Introspection.AshCallResolver do
     do: Name.full(module) <> ".#{fun_name}"
 
   @doc """
-  Returns `true` if the call uses a bang-style function name (e.g. `read!`).
-  Builder calls (`changeset_to_*`/`query_to_*`/`input_to_*`) are never
-  bang-suffixed because their generated helpers do not raise.
+  Returns `true` if the call uses a bang-style function name (e.g.
+  `read!`). Builder calls (`changeset_to_*`/`query_to_*`/`input_to_*`)
+  are never bang-suffixed because their generated helpers don't raise.
   """
   @spec bang?(AshCallSite.t()) :: boolean()
   def bang?(%AshCallSite{builder_prefix: prefix}) when not is_nil(prefix), do: false
@@ -150,8 +153,8 @@ defmodule AshCredo.Introspection.AshCallResolver do
   defp dispatch_site([:Ash], fun_name, args, ctx) when fun_name in @bulk_query_funs,
     do: extract_bulk_query(args, ctx)
 
-  # `@positional_0_1_funs`/`@record_first_builders` are MapSets, so this case
-  # cannot be a function-head guard - it falls through to the catch-all.
+  # `@positional_0_1_funs`/`@record_first_builders` are MapSets, so this
+  # case cannot be a function-head guard; it falls through to the catch-all.
   defp dispatch_site(module, fun_name, args, ctx) do
     if MapSet.member?(@positional_0_1_funs, {module, fun_name}) do
       extract_positional(args, 0, 1, %{
@@ -171,9 +174,9 @@ defmodule AshCredo.Introspection.AshCallResolver do
       case action_in_opts(args, ctx.fun_name) do
         {:literal, action} -> [build_site(segs, action, ctx)]
         :absent -> implicit_read_sites(segs, ctx)
-        # `:action` is present but not a literal atom (e.g. a bound variable).
-        # Caller intends a specific runtime action; do not silently fall back
-        # to `:read`.
+        # `:action` is present but not a literal atom (e.g. a bound
+        # variable). The caller intends a specific runtime action, so
+        # don't silently fall back to `:read`.
         :non_literal -> []
       end
     else
@@ -184,8 +187,9 @@ defmodule AshCredo.Introspection.AshCallResolver do
   # `Ash.read!/get!/stream!` without an `:action` keyword dispatches to the
   # resource's primary :read action at runtime. Mirror that here so bare
   # `Ash.read!(MyApp.Post)` gets the same code-interface suggestion as the
-  # explicit `Ash.read!(MyApp.Post, action: :read)` form, and so a `:not_loadable`
-  # diagnostic still fires for projects that only ever call the bare shape.
+  # explicit `Ash.read!(MyApp.Post, action: :read)` form, and so a
+  # `:not_loadable` diagnostic still fires for projects that only ever call
+  # the bare shape.
   defp implicit_read_sites(segments, ctx) do
     case resolve_resource(segments) do
       {:ok, _resource, %{actions: actions}} = resolution ->
@@ -195,9 +199,9 @@ defmodule AshCredo.Introspection.AshCallResolver do
         end
 
       {:not_loadable, _resource} = resolution ->
-        # action_name is only used by the `{:ok, ...}` branch in checks; the
+        # Only the `{:ok, ...}` branch in checks uses action_name. The
         # `:not_loadable` branch ignores it. We pass `:read` as a stable
-        # placeholder rather than a sentinel so any future inspection reads
+        # placeholder, not a sentinel, so any future inspection reads
         # naturally.
         [build_site_with(ctx, :read, resolution)]
 
@@ -207,9 +211,9 @@ defmodule AshCredo.Introspection.AshCallResolver do
   end
 
   defp build_site_with(ctx, action_name, resolution) do
-    # `:trace_record?` is resolver-local scratch (drives resource_segments/3
-    # dispatch); it is not part of the AshCallSite contract, so drop it before
-    # building the struct.
+    # `:trace_record?` is resolver-local scratch (it drives the
+    # resource_segments/3 dispatch) and not part of the AshCallSite
+    # contract, so drop it before building the struct.
     fields =
       ctx
       |> Map.delete(:trace_record?)
@@ -365,14 +369,14 @@ defmodule AshCredo.Introspection.AshCallResolver do
     end
   end
 
-  # Struct literal: `%MyApp.Post{...}` - extract the inner alias AST.
+  # Struct literal like `%MyApp.Post{...}`: extract the inner alias AST.
   defp literal_segments({:%, _, [alias_ast, {:%{}, _, _}]}, context),
     do: literal_segments(alias_ast, context)
 
   defp literal_segments(_, _), do: :error
 
   # Builders that carry the record/changeset as arg0 may receive it via a
-  # pipeline or binding, so trace the origin back to a literal; plain
+  # pipeline or a binding, so trace the origin back to a literal; plain
   # positional calls name the resource directly.
   defp resource_segments(ast, context, %{trace_record?: true}) do
     case literal_segments(ast, context) do
@@ -447,9 +451,9 @@ defmodule AshCredo.Introspection.AshCallResolver do
 
   defp arg_at(args, idx), do: Enum.fetch(args, idx)
 
-  # `Ash.get/2`'s second argument is always the identifier, even when it is a
-  # keyword list containing an `:action` attribute. Only `Ash.get/3` has call
-  # options. The other Pattern A functions take options at index 1.
+  # `Ash.get/2`'s second argument is always the identifier, even when it is
+  # a keyword list containing an `:action` attribute. Only `Ash.get/3` has
+  # call options. The other Pattern A functions take options at index 1.
   defp action_in_opts(args, fun_name) do
     opts_idx = if fun_name in @get_funs, do: 2, else: 1
 

--- a/lib/ash_credo/introspection/ash_call_scanner.ex
+++ b/lib/ash_credo/introspection/ash_call_scanner.ex
@@ -1,14 +1,14 @@
 defmodule AshCredo.Introspection.AshCallScanner do
   @moduledoc """
-  Lower layer of the Ash call pipeline: scans a source file's AST and yields
-  every `Ash.*` call together with the lexical environment visible at that
-  point - alias frames, binding frames, branch depth, pipe origins, and the
-  enclosing `defmodule` segments.
+  Lower layer of the Ash call pipeline: scans a source file's AST and
+  yields every `Ash.*` call together with the lexical environment
+  visible at that point - alias frames, binding frames, branch depth,
+  pipe origins, and the enclosing `defmodule` segments.
 
-  Knows nothing about specific Ash API entry points. The semantic
-  interpretation - "this call has a literal resource at arg 0 and an action
-  in the keyword opts, resolve it to a real module" - lives one layer up in
-  `AshCredo.Introspection.AshCallResolver`.
+  This module knows nothing about specific Ash API entry points. The
+  semantic interpretation ("this call has a literal resource at arg 0
+  and an action in the keyword opts, resolve it to a real module")
+  lives one layer up in `AshCredo.Introspection.AshCallResolver`.
 
   Three output flavours of increasing richness:
 
@@ -84,9 +84,9 @@ defmodule AshCredo.Introspection.AshCallScanner do
   end
 
   # `require ..., as:` sets up an alias too; `apply_directive/3` records
-  # exactly the shapes that create one. Unlike the walker, the scanner has
-  # no quote tracking: directives inside `quote do ... end` are recorded,
-  # preserving long-standing scanner behavior.
+  # exactly the shapes that create one. Unlike the walker, the scanner
+  # has no quote tracking: directives inside `quote do ... end` are
+  # recorded, preserving long-standing scanner behavior.
   defp enter_node({directive, _, _} = ast, state, _collect_fn)
        when directive in [:alias, :require] do
     {ast, capture_directive(state, ast)}
@@ -222,7 +222,7 @@ defmodule AshCredo.Introspection.AshCallScanner do
   end
 
   # A pushed frame starts as a copy of its parent env; the pop discards
-  # additions made inside the scope.
+  # the additions made inside the scope.
   defp push_alias_frame(state) do
     update_in(state.env_frames, &[current_env(state) | &1])
   end

--- a/lib/ash_credo/introspection/ash_call_site.ex
+++ b/lib/ash_credo/introspection/ash_call_site.ex
@@ -1,6 +1,6 @@
 defmodule AshCredo.Introspection.AshCallSite do
   @moduledoc """
-  A resolved Ash API call site discovered in source AST. Produced by
+  A resolved Ash API call site discovered in the source AST. Produced by
   `AshCredo.Introspection.AshCallResolver.sites/1` and consumed by the
   checks that flag or refine specific Ash call patterns
   (`AshCredo.Check.Refactor.UseCodeInterface`,
@@ -9,27 +9,32 @@ defmodule AshCredo.Introspection.AshCallSite do
   Fields:
 
     * `:resolution` - lookup result for the called resource module:
-      `{:ok, module, info_map}` when loaded, `{:not_loadable, module}` when
-      unreachable, `:not_a_resource` for non-Ash modules, or `:ash_missing`
-      when Ash itself is not loaded.
-    * `:action_name` - atom of the action this call targets (literal `:action`
-      keyword for `Ash.read/get/read_one/read_first/stream!`, positional arg for `bulk_*`/builders,
-      or the resource's primary `:read` for the bare-form Ash.read! shape).
-    * `:fun_name` - the function called (e.g. `:read!`, `:bulk_create`).
+      `{:ok, module, info_map}` when the module is loaded,
+      `{:not_loadable, module}` when it is unreachable,
+      `:not_a_resource` for non-Ash modules, or `:ash_missing` when Ash
+      itself is not loaded.
+    * `:action_name` - atom of the action this call targets (the literal
+      `:action` keyword for `Ash.read/get/read_one/read_first/stream!`,
+      the positional arg for `bulk_*`/builders, or the resource's
+      primary `:read` for the bare-form Ash.read! shape).
+    * `:fun_name` - the function called (e.g. `:read!`,
+      `:bulk_create`).
     * `:module` - alias-expanded segments of the called module.
     * `:arity` - arity of the call.
-    * `:call_meta` - `Macro.t()` meta keyword list of the call (for `:line`).
-    * `:call_info` - the original scanner `call_info` map; carries pipe
-      origins, bindings, and enclosing module segments needed by downstream
-      resolution.
-    * `:builder_prefix` - `:changeset_to | :query_to | :input_to | nil` for
-      the corresponding `for_*` builder shape, otherwise `nil`.
-    * `:call_kind` - high-level call shape used to pick the right interface
-      suggestion (`:read_many`, `:read_one`, `:read_first`, `:get_one`,
-      `:stream_many`, `:builder`, `:bulk`, or `nil`).
-    * `:lookup_keys` - the list of attribute names a `get_one` call looks up
-      by (from a literal map / kw arg, or the resource's single-key primary
-      key); `nil` for non-`:get_one` calls.
+    * `:call_meta` - the `Macro.t()` meta keyword list of the call (for
+      `:line`).
+    * `:call_info` - the original scanner `call_info` map; it carries
+      the pipe origins, bindings, and enclosing module segments that
+      downstream resolution needs.
+    * `:builder_prefix` - `:changeset_to | :query_to | :input_to | nil`
+      for the corresponding `for_*` builder shape, otherwise `nil`.
+    * `:call_kind` - the high-level call shape, used by checks to pick
+      the right interface suggestion (`:read_many`, `:read_one`,
+      `:read_first`, `:get_one`, `:stream_many`, `:builder`, `:bulk`,
+      or `nil`).
+    * `:lookup_keys` - the list of attribute names a `get_one` call
+      looks up by (from a literal map / kw arg, or the resource's
+      single-key primary key); `nil` for non-`:get_one` calls.
   """
 
   @enforce_keys [

--- a/lib/ash_credo/introspection/compiled.ex
+++ b/lib/ash_credo/introspection/compiled.ex
@@ -1,44 +1,47 @@
 defmodule AshCredo.Introspection.Compiled do
   @moduledoc """
-  Introspection that reads **compiled BEAM metadata** - a wrapper around
+  Introspection that reads **compiled BEAM metadata**, a wrapper around
   `Ash.Resource.Info` and `Ash.Domain.Info`.
 
-  Sibling of `AshCredo.Introspection` (AST-level) and
-  `AshCredo.Introspection.AshCallScanner` (AST-level Ash call discovery). This is
-  the module that reaches for the compiled artifact: it loads target
-  modules on demand, reads their DSL metadata through Ash's own
-  introspection API, and caches the results per-module in the run-scoped
-  `AshCredo.Cache` so repeated lookups during a single `mix credo` run are
-  cheap.
+  This module is a sibling of `AshCredo.Introspection` (AST-level) and
+  `AshCredo.Introspection.AshCallScanner` (AST-level Ash call
+  discovery). It's the module that reaches for the compiled artifact: it
+  loads target modules on demand, reads their DSL metadata through Ash's
+  own introspection API, and caches the results per module in the
+  run-scoped `AshCredo.Cache`, so repeated lookups in a single
+  `mix credo` run are cheap.
 
   The cache is a named ETS table owned by a supervised GenServer (see
-  `AshCredo.Cache`). Credo dispatches each check × source_file pair into
-  its own short-lived Task.Supervised process, so the table must not be
-  owned by any of those tasks - the dedicated owner keeps it alive across
-  arbitrary task churn. `AshCredo.init/1` clears the table at run
-  boundaries, so cached metadata never goes stale across runs in a
+  `AshCredo.Cache`). Credo dispatches each check and source_file pair
+  into its own short-lived Task.Supervised process, so the table must
+  not be owned by any of those tasks; the dedicated owner keeps it alive
+  across arbitrary task churn. `AshCredo.init/1` clears the table at the
+  run boundaries, so cached metadata never goes stale across runs in a
   long-lived VM.
 
-  Checks in `AshCredo` that need authoritative metadata about a referenced
-  module (its domain, its actions, its code interfaces, whether it is even
-  an Ash resource) call into this module instead of scanning source AST.
+  Checks in `AshCredo` that need authoritative metadata about a
+  referenced module (its domain, its actions, its code interfaces,
+  whether it's even an Ash resource) call into this module instead of
+  scanning the source AST for that data.
 
   ## Error modes
 
-    * `{:error, :ash_missing}` - Ash itself is not loaded in the VM running
-      Credo. This happens when `ash_credo` is used in a project that does not
-      depend on Ash. Callers should treat this as "Ash-aware checks are a
-      no-op in this project" and emit a single diagnostic.
-    * `{:error, :not_loadable}` - `Code.ensure_compiled/1` returned an error,
-      typically because the host project has not been compiled yet. The
-      caller should surface a "run `mix compile` first" hint.
-    * `{:error, :not_a_resource}` - the module loaded successfully but is
-      not an Ash resource. Checks targeting resources should silently skip.
+    * `{:error, :ash_missing}` - Ash itself is not loaded in the VM
+      running Credo. This happens when `ash_credo` is used in a project
+      that doesn't depend on Ash. Callers should treat this as
+      "Ash-aware checks are a no-op in this project" and emit a single
+      diagnostic.
+    * `{:error, :not_loadable}` - `Code.ensure_compiled/1` returned an
+      error, typically because the host project hasn't been compiled
+      yet. The caller should surface a "run `mix compile` first" hint.
+    * `{:error, :not_a_resource}` - the module loaded successfully but
+      is not an Ash resource. Checks targeting resources should silently
+      skip it.
   """
 
   # Ash is not a runtime dependency of ash_credo - users bring their own.
-  # Suppress compile-time warnings for the remote calls below; they are guarded
-  # at runtime by `ash_available?/0`.
+  # Suppress compile-time warnings for the remote calls below; they are
+  # guarded at runtime by `ash_available?/0`.
   alias Ash.Resource.Info, as: ResourceInfo
   alias Ash.Type.NewType
   alias AshCredo.Cache
@@ -53,7 +56,7 @@ defmodule AshCredo.Introspection.Compiled do
               Ash.Type.NewType
             ]}
 
-  # Tags namespace per-key entries inside the shared cache table.
+  # Tags that namespace the per-key entries inside the shared cache table.
   @cache_key_tag {__MODULE__, :cache}
   @domain_refs_key_tag {__MODULE__, :domain_refs}
   @macros_key_tag {__MODULE__, :macros}
@@ -65,11 +68,11 @@ defmodule AshCredo.Introspection.Compiled do
   @ash_missing_warned_key {__MODULE__, :ash_missing_warned}
   @not_loadable_warned_key_tag {__MODULE__, :not_loadable_warned}
 
-  # Behaviours that mark a module as an Ash resource auxiliary - i.e. a
+  # Behaviours that mark a module as an Ash resource auxiliary, i.e. a
   # module that gets attached to a resource via `change`, `preparation`,
   # `validation`, `calculate`, or a `manual` action option. These modules
-  # don't themselves declare a `:domain`, but conventionally belong to the
-  # domain of the resource that references them.
+  # don't themselves declare a `:domain`, but conventionally belong to
+  # the domain of the resource that references them.
   @ash_callback_behaviours [
     Ash.Resource.Change,
     Ash.Resource.Preparation,
@@ -101,7 +104,7 @@ defmodule AshCredo.Introspection.Compiled do
   @doc """
   Returns `true` if `Ash.Resource.Info` is loadable in the current VM.
 
-  Cached after the first call so subsequent calls are essentially free.
+  Cached after the first call, so subsequent calls are essentially free.
   """
   @spec ash_available?() :: boolean()
   def ash_available? do
@@ -121,8 +124,8 @@ defmodule AshCredo.Introspection.Compiled do
   @doc """
   Returns a map of introspection facts about `module`, or an error tuple.
 
-  The map has keys `:resource?`, `:domain`, `:interfaces`, `:actions`.
-  Results are cached per-module.
+  The map has the keys `:resource?`, `:domain`, `:interfaces`,
+  `:actions`. Results are cached per module.
   """
   @spec inspect_module(module()) :: {:ok, info_map()} | {:error, error()}
   def inspect_module(module) when is_atom(module) do
@@ -207,7 +210,7 @@ defmodule AshCredo.Introspection.Compiled do
 
   @doc """
   Returns the resource's policy entries from `Ash.Policy.Info.policies/1`.
-  Returns `[]` for resources without `Ash.Policy.Authorizer` declared.
+  Returns `[]` for resources that don't declare `Ash.Policy.Authorizer`.
   """
   @spec policies(module()) :: {:ok, [struct()]} | {:error, error()}
   def policies(module) do
@@ -218,8 +221,9 @@ defmodule AshCredo.Introspection.Compiled do
   end
 
   @doc """
-  Returns the list of resources registered inside `domain`'s `resources do
-  ... end` block, or an error tuple if `domain` is not a loaded Ash.Domain.
+  Returns the list of resources registered in `domain`'s
+  `resources do ... end` block, or an error tuple if `domain` is not a
+  loaded Ash.Domain.
   """
   @spec domain_resources(module()) :: {:ok, [module()]} | {:error, error()}
   def domain_resources(module) when is_atom(module) do
@@ -247,7 +251,7 @@ defmodule AshCredo.Introspection.Compiled do
 
   @doc """
   Returns the action struct for `action_name` on `module`, or
-  `{:error, :unknown_action}` if the action is not defined.
+  `{:error, :unknown_action}` if the action doesn't exist.
   """
   @spec action(module(), atom()) :: {:ok, struct()} | {:error, error()}
   def action(module, action_name) when is_atom(action_name) do
@@ -264,14 +268,15 @@ defmodule AshCredo.Introspection.Compiled do
   end
 
   @doc """
-  Returns the set of macro names defined by `module` (read from
-  `module.__info__(:macros)`), or `{:error, :not_loadable}` if the module
-  cannot be loaded. Cached per-module in the run-scoped `AshCredo.Cache`.
+  Returns the set of macro names that `module` defines (read from
+  `module.__info__(:macros)`), or `{:error, :not_loadable}` if the
+  module cannot be loaded. Cached per module in the run-scoped
+  `AshCredo.Cache`.
 
-  Unlike `inspect_module/1`, this does not require the target to be an Ash
-  resource. It works for any compiled Elixir module and exists so checks can
-  ask "which functions on this module are macros?" without hardcoding a list
-  that drifts from reality when upstream adds or renames macros.
+  Unlike `inspect_module/1`, this doesn't require the target to be an
+  Ash resource. It works for any compiled Elixir module and exists so
+  checks can find a module's macros without hardcoding a list that
+  drifts from reality when upstream adds or renames macros.
 
   Used by `Warning.MissingMacroDirective` to resolve its configured
   `macro_modules` list to exact macro sets per module.
@@ -338,9 +343,10 @@ defmodule AshCredo.Introspection.Compiled do
   behaviours (`Ash.Resource.Change`, `Preparation`, `Validation`,
   `Calculation`, or any of the `Manual*` action behaviours).
 
-  Detected by inspecting the module's `:behaviour` attribute, populated by
-  `use Ash.Resource.Change` and siblings at compile time. Cached per module,
-  so only the first probe pays the `Code.ensure_compiled/1` cost.
+  Detected by inspecting the module's `:behaviour` attribute, which
+  `use Ash.Resource.Change` and its siblings populate at compile time.
+  Cached per module, so only the first probe pays the
+  `Code.ensure_compiled/1` cost.
   """
   @spec ash_callback_module?(module()) :: boolean()
   def ash_callback_module?(module) when is_atom(module) do
@@ -369,10 +375,11 @@ defmodule AshCredo.Introspection.Compiled do
   end
 
   @doc """
-  Given a resource's `interfaces` list (as returned by `interfaces/1`) and an
-  action name, returns the `%Ash.Resource.Interface{}` whose action matches
-  (either via the explicit `:action` field or by name equality when the
-  interface uses its own name as the action). Returns `nil` if no match.
+  Given a resource's `interfaces` list (as returned by `interfaces/1`)
+  and an action name, returns the `%Ash.Resource.Interface{}` whose
+  action matches, either via the explicit `:action` field or by name
+  equality when the interface uses its own name as the action. Returns
+  `nil` when there is no match.
   """
   @spec find_interface([struct()], atom()) :: struct() | nil
   def find_interface(interfaces, action_name) when is_list(interfaces) and is_atom(action_name) do
@@ -382,21 +389,23 @@ defmodule AshCredo.Introspection.Compiled do
   end
 
   @doc """
-  Returns `{:ok, info}` if `Mod.fun!` resolves to an Ash code-interface bang
-  - i.e. `Mod` is either a resource whose `code_interface` defines `fun`
-  without the trailing `!`, or a domain whose `resources` block declares a
-  matching `define`. `info` is `%{scope: :resource | :domain, interface:
-  struct(), resource: module()}`, where `:resource` is the resource the
-  interface acts on (same as `Mod` for `:resource` scope, the
-  domain-referenced target for `:domain` scope).
+  Returns `{:ok, info}` if `Mod.fun!` resolves to an Ash code-interface
+  bang, i.e. `Mod` is either a resource whose `code_interface` defines
+  `fun` without the trailing `!`, or a domain whose `resources` block
+  declares a matching `define`. `info` is
+  `%{scope: :resource | :domain, interface: struct(), resource: module()}`,
+  where `:resource` is the resource the interface acts on: the same as
+  `Mod` for the `:resource` scope, the domain-referenced target for the
+  `:domain` scope.
 
   Returns `{:error, :not_code_interface}` for everything else, including
   non-bang function names, modules that aren't Ash resources or domains,
-  and modules whose interfaces do not declare a matching name. Results
-  (including negatives) are cached per `{module, fun}` so repeated probes
-  of non-Ash modules don't re-run `Code.ensure_compiled/1` on every call.
+  and modules whose interfaces don't declare a matching name. Results
+  (negatives included) are cached per `{module, fun}`, so repeated
+  probes of non-Ash modules don't re-run `Code.ensure_compiled/1` on
+  every call.
 
-  Match is by interface `:name` - i.e. the generated function name -
+  The match is by interface `:name`, i.e. the generated function name,
   not by `:action`. For `define :publish_post, action: :publish`, the
   generated function is `publish_post!`, which matches against
   `iface.name == :publish_post`.
@@ -462,9 +471,10 @@ defmodule AshCredo.Introspection.Compiled do
   defp interface_named?(_iface, _non_bang), do: false
 
   @doc """
-  Returns the domain-level interface definition for `resource`'s `action_name`
-  declared inside `domain`'s `resources do ... end` block, or `nil` if no
-  matching definition exists. `domain == nil` is handled gracefully.
+  Returns the domain-level interface definition for `resource`'s
+  `action_name` declared in `domain`'s `resources do ... end` block, or
+  `nil` if no matching definition exists. `domain == nil` is handled
+  gracefully and returns `nil`.
   """
   @spec domain_interface(module() | nil, module(), atom()) :: struct() | nil
   def domain_interface(nil, _resource, _action_name), do: nil
@@ -483,9 +493,10 @@ defmodule AshCredo.Introspection.Compiled do
   end
 
   @doc """
-  Returns all domain-level interface definitions (as `%Ash.Resource.Interface{}`)
-  declared for `resource` inside `domain`'s `resources do ... end` block, or
-  `[]` if the resource is not referenced.
+  Returns all domain-level interface definitions (as
+  `%Ash.Resource.Interface{}`) declared for `resource` in `domain`'s
+  `resources do ... end` block, or `[]` if the domain doesn't reference
+  the resource.
   """
   @spec domain_interfaces(module() | nil, module()) :: [struct()]
   def domain_interfaces(nil, _resource), do: []
@@ -506,13 +517,12 @@ defmodule AshCredo.Introspection.Compiled do
     |> Enum.find(fn ref -> ref.resource == resource end)
   end
 
-  # Cached per-domain in the run-scoped `AshCredo.Cache`. A domain's
-  # reference list is constant for the VM lifetime (set at compile time by
-  # Ash), so we read it
-  # from Ash once per `mix credo` run and reuse the same list for every
-  # subsequent `domain_interface/3` / `domain_interfaces/2` lookup. Keeps
-  # `UseCodeInterface` at O(N) across a file with N `Ash.*` calls into the
-  # same domain instead of O(N*M).
+  # Cached per domain in the run-scoped `AshCredo.Cache`. A domain's
+  # reference list is constant for the VM lifetime (Ash sets it at
+  # compile time), so we read it from Ash once per `mix credo` run and
+  # reuse the same list for every subsequent `domain_interface/3` /
+  # `domain_interfaces/2` lookup. This keeps `UseCodeInterface` at O(N)
+  # across a file with N `Ash.*` calls into the same domain, not O(N*M).
   defp cached_domain_references(domain) do
     Cache.memoize({@domain_refs_key_tag, domain}, fn ->
       Ash.Domain.Info.resource_references(domain)
@@ -520,17 +530,17 @@ defmodule AshCredo.Introspection.Compiled do
   end
 
   @doc """
-  Builds a `:not_loadable` diagnostic for `module` only the first time it is
-  seen this run. Subsequent calls for the same module return `[]`, so an
-  unloadable resource produces at most ONE diagnostic across all
-  compile-dependent checks per `mix credo` invocation. Atomic across
-  concurrent Credo tasks.
+  Builds a `:not_loadable` diagnostic for `module` only the first time
+  it is seen this run. Subsequent calls for the same module return `[]`,
+  so an unloadable resource produces at most ONE diagnostic across all
+  compile-dependent checks per `mix credo` invocation. The
+  check-and-insert is atomic across concurrent Credo tasks.
 
   `build_issue_fn` is a 0-arity function that returns a single
   `Credo.Issue.t()`. Checks with the standard message go through
-  `AshCredo.Orchestration.unique_not_loadable_issues/4`, which wraps this
-  function; checks with a bespoke message call this directly with their own
-  `format_issue/2`.
+  `AshCredo.Orchestration.unique_not_loadable_issues/4`, which wraps
+  this function; checks with a custom message call this directly with
+  their own `format_issue/2`.
   """
   @spec with_unique_not_loadable(module(), (-> struct())) :: [struct()]
   def with_unique_not_loadable(module, build_issue_fn)
@@ -543,20 +553,21 @@ defmodule AshCredo.Introspection.Compiled do
   end
 
   @doc """
-  Shared scaffold for compile-dependent checks. Wraps the common pattern of:
+  Shared scaffold for compile-dependent checks. It wraps this common
+  pattern:
 
-    * bail out early with an `:ash_missing` diagnostic (emitted at most once
-      per `mix credo` run across all compile-dependent checks) if Ash is not
-      loaded in the VM;
-    * otherwise run the check body.
+    * If Ash is not loaded in the VM, bail out early with an
+      `:ash_missing` diagnostic, emitted at most once per `mix credo`
+      run across all compile-dependent checks.
+    * Otherwise, run the check body.
 
   `missing_issue_fn` must be a 0-arity function that returns a single
-  `Credo.Issue.t()` (typically a `format_issue/2` call - which is a macro
-  from `use Credo.Check`, so it can only be built from inside the check
-  module itself).
+  `Credo.Issue.t()`, typically a `format_issue/2` call. `format_issue/2`
+  is a macro from `use Credo.Check`, so only the check module itself can
+  build the call.
 
-  `check_fn` is the 0-arity function that runs the actual check and returns
-  the list of issues.
+  `check_fn` is the 0-arity function that runs the actual check and
+  returns the list of issues.
 
   Returns a list of issues either way.
   """
@@ -571,21 +582,22 @@ defmodule AshCredo.Introspection.Compiled do
   end
 
   @doc """
-  Walks `module`'s name segments upward and returns the innermost ancestor
-  that is a loaded `Ash.Domain`, or `nil` if none is found.
+  Walks `module`'s name segments upward and returns the innermost
+  ancestor that is a loaded `Ash.Domain`, or `nil` when there is none.
 
-  Used to give Ash callback modules (`Change`/`Preparation`/`Validation`/
-  `Calculation`/`Manual*`) a domain by namespace convention - e.g.
-  `MyApp.Blog.Changes.Archive` resolves to `MyApp.Blog` when that module is
-  a loaded domain.
+  Checks use this to give Ash callback modules
+  (`Change`/`Preparation`/`Validation`/`Calculation`/`Manual*`) a domain
+  by namespace convention: `MyApp.Blog.Changes.Archive` resolves to
+  `MyApp.Blog` when that module is a loaded domain.
 
-  **Heuristic, not authoritative.** This is a namespace-convention guess,
-  not a reverse lookup of which resources actually reference the callback
-  module. A "shared infrastructure" change module nested under one domain's
-  namespace but used by resources in multiple domains will be classified as
-  belonging to the namespace's domain, which can occasionally surface a
-  misleading suggestion. Acceptable tradeoff for the common case of teams
-  that organise callback modules under their owning domain.
+  **This is a heuristic, not authoritative.** It's a namespace-convention
+  guess, not a reverse lookup of the resources that actually reference
+  the callback module. A "shared infrastructure" change module nested
+  under one domain's namespace but serving resources in multiple domains
+  gets classified under the namespace's domain, which can occasionally
+  surface a misleading suggestion. That's an acceptable tradeoff for the
+  common case of teams that organise callback modules under their owning
+  domain.
   """
   @spec enclosing_domain(module()) :: module() | nil
   def enclosing_domain(module) when is_atom(module) do
@@ -603,13 +615,13 @@ defmodule AshCredo.Introspection.Compiled do
   end
 
   @doc """
-  Clears every cache entry: per-module introspection results, per-domain
-  resource-reference lists, the `ash_available?` probe, and the one-shot
-  `:ash_missing` / `:not_loadable` diagnostic flags.
+  Clears every cache entry: the per-module introspection results, the
+  per-domain resource-reference lists, the `ash_available?` probe, and
+  the one-shot `:ash_missing` / `:not_loadable` diagnostic flags.
 
-  Called automatically by `AshCredo.init/1` at the start of every Credo
-  run, so callers rarely need to invoke it directly. Useful in tests that
-  need a clean slate between assertions.
+  `AshCredo.init/1` calls this automatically at the start of every Credo
+  run, so callers rarely need to invoke it directly. It's useful in
+  tests that need a clean slate between assertions.
   """
   @spec clear_cache() :: :ok
   def clear_cache do
@@ -624,10 +636,10 @@ defmodule AshCredo.Introspection.Compiled do
   ]
 
   @doc """
-  Returns `true` if `type` is a datetime attribute type, resolving through
-  `Ash.Type.NewType.subtype_of/1` for custom NewTypes (e.g.
-  `AshPostgres.TimestamptzUsec`) whose `storage_type/1` returns a DB-specific
-  atom rather than a standard Ecto datetime type.
+  Returns `true` if `type` is a datetime attribute type, resolving
+  through `Ash.Type.NewType.subtype_of/1` for custom NewTypes (e.g.
+  `AshPostgres.TimestamptzUsec`) whose `storage_type/1` returns a
+  DB-specific atom rather than a standard Ecto datetime type.
   """
   @spec datetime_type?(term()) :: boolean()
   def datetime_type?(type) when is_atom(type) and not is_nil(type) do
@@ -668,16 +680,17 @@ defmodule AshCredo.Introspection.Compiled do
     end
   rescue
     # The `Ash.Resource.Info` accessors bottom out in `Spark.Dsl.Extension`,
-    # which raises `ArgumentError` when `module` is not (or no longer) a Spark
-    # DSL module and `UndefinedFunctionError` when it was purged. Both can
-    # occur after `resource?/1` succeeded if the module is recompiled or
-    # purged mid-run; the memoized error also stops per-call re-raising.
+    # which raises `ArgumentError` when `module` is not (or no longer) a
+    # Spark DSL module and `UndefinedFunctionError` when it was purged.
+    # Both can occur after `resource?/1` succeeded, if the module is
+    # recompiled or purged mid-run; the memoized error also stops a
+    # re-raise on every call.
     _ in [ArgumentError, UndefinedFunctionError] -> {:error, :not_loadable}
   end
 
-  # Policies live in `Ash.Policy.Info` (a separate module from `Ash.Resource.Info`).
-  # `Ash.Policy.Info.policies/1` always returns a list - `[]` for resources
-  # without `Ash.Policy.Authorizer`.
+  # Policies live in `Ash.Policy.Info` (a separate module from
+  # `Ash.Resource.Info`). `Ash.Policy.Info.policies/1` always returns a
+  # list - `[]` for resources without `Ash.Policy.Authorizer`.
   defp read_policies(module) do
     Ash.Policy.Info.policies(module)
   rescue

--- a/lib/ash_credo/introspection/lexical_scope_walker.ex
+++ b/lib/ash_credo/introspection/lexical_scope_walker.ex
@@ -1,34 +1,36 @@
 defmodule AshCredo.Introspection.LexicalScopeWalker do
   @moduledoc """
-  Thin wrapper around `Macro.traverse/4` that owns the lexical-scope plumbing
-  (`Macro.Env` frames, `quote` depth, the `defmodule` module stack) and
-  exposes a callback API to consumers.
+  Thin wrapper around `Macro.traverse/4` that owns the lexical-scope
+  plumbing (`Macro.Env` frames, the `quote` depth, the `defmodule`
+  module stack) and exposes a callback API to consumers.
 
   Each scope frame holds a `Macro.Env` snapshot: entering a block copies
-  the parent env, `alias`/`require`/`import` nodes are applied to the head
-  env via `AshCredo.Introspection.Aliases.apply_directive/3`, and leaving
-  the block discards the copy. Resolution semantics therefore come from
-  the compiler's own `Macro.Env` APIs; the walker only decides WHERE
-  scopes begin and end and what to suppress inside `quote`.
+  the parent env, `alias`/`require`/`import` nodes are applied to the
+  head env via `AshCredo.Introspection.Aliases.apply_directive/3`, and
+  leaving the block discards the copy. Resolution semantics therefore
+  come from the compiler's own `Macro.Env` APIs; the walker only decides
+  WHERE scopes start and end, and what to suppress inside `quote`.
 
-  **Note on `AshCallScanner`:** that module deliberately stays outside the
-  walker. Its state (`binding_frames`, `branch_depth`, `pipe_origins`, plus
-  `:=` LHS-binding capture) is heterogeneous enough that routing it through
-  callbacks would cost more clarity than the env/quote plumbing saves.
-  The scanner maintains its own env frames via `Aliases.apply_directive/3`.
+  **Note on `AshCallScanner`:** that module deliberately stays outside
+  the walker. Its state (`binding_frames`, `branch_depth`,
+  `pipe_origins`, plus the `:=` LHS-binding capture) is heterogeneous
+  enough that routing it through callbacks would cost more clarity than
+  the env/quote plumbing saves. The scanner maintains its own env frames
+  via `Aliases.apply_directive/3`.
 
   ## API
 
       LexicalScopeWalker.traverse(ast, user_state, on_enter, on_leave, opts)
 
   - `ast` - any Macro AST.
-  - `user_state` - opaque caller state (any term). The walker does not touch it.
+  - `user_state` - opaque caller state (any term). The walker doesn't
+    touch it.
   - `on_enter` / `on_leave` - 3-arity callbacks
-    `(ast_node, %Scope{}, user_state) :: user_state`. Callbacks return ONLY
-    `user_state`; the walker manages scope and AST. Allowing callbacks to
-    rewrite the AST would be a landmine - the leave handler pattern-matches
-    the original node shape, and a transformed node could silently skip
-    scope pops.
+    `(ast_node, %Scope{}, user_state) :: user_state`. Callbacks return
+    ONLY `user_state`; the walker manages the scope and the AST.
+    Letting a callback rewrite the AST would be dangerous: the leave
+    handler pattern-matches the original node shape, and a transformed
+    node could silently skip scope pops.
 
   Returns `{final_user_state, final_scope}`.
 
@@ -38,31 +40,34 @@ defmodule AshCredo.Introspection.LexicalScopeWalker do
     frame, or applies a directive to the current env), THEN invokes
     `on_enter` with the updated scope. So inside `on_enter` for an
     `{:alias, ...}` node, `env/1` already includes the alias.
-  - On leave: `on_leave` runs FIRST (with the still-current scope), THEN the
-    walker pops. So a callback that wants to read the final scope state of a
-    do-block can do so before the pop.
+  - On leave: `on_leave` runs FIRST, with the still-current scope, THEN
+    the walker pops. So a callback that wants to read the final scope
+    state of a do-block can do so before the pop.
 
   ## Opts
 
-  - `:lexical_scope_nodes` - extra atoms for which to push an alias scope
-    frame on entry and pop on exit. Defaults to `[:with, :for]` because
-    these constructs ARE empirically-verified separate scopes in Elixir
-    (a `require`/`alias` declared inside a `with` clause or `for`
-    generator does NOT propagate past the construct). The walker always
-    additionally pushes for `@scope_keys` (`do/else/after/rescue/catch`)
-    and `:->` arrows. Pass `lexical_scope_nodes: []` to opt out (only
-    sensible if you have a specific reason; doing so will let
-    `with`/`for` clause-level aliases leak into the enclosing scope).
-  - `:track_quote` (default `true`) - track `{:quote, _, _}` depth. When
-    truthy, `in_quote?/1` and `quote_depth/1` reflect it, and aliases
-    declared inside `quote` are dropped (see `:track_aliases_in_quote`
-    to override).
+  - `:lexical_scope_nodes` - extra atoms for which the walker pushes an
+    alias scope frame on entry and pops it on exit. Defaults to
+    `[:with, :for]` because these constructs ARE separate scopes in
+    Elixir (verified empirically): a `require`/`alias` declared inside a
+    `with` clause or `for` generator does NOT propagate past the
+    construct. The walker always additionally pushes for `@scope_keys`
+    (`do/else/after/rescue/catch`) and `:->` arrows. Pass
+    `lexical_scope_nodes: []` to opt out, but only with a specific
+    reason: `with`/`for` clause-level aliases then leak into the
+    enclosing scope.
+  - `:track_quote` (default `true`) - track the `{:quote, _, _}` depth.
+    When truthy, `in_quote?/1` and `quote_depth/1` reflect it, and
+    aliases declared inside `quote` are dropped (see
+    `:track_aliases_in_quote` to override this).
   - `:track_aliases_in_quote` (default `false`) - when `false`, aliases
     declared inside a `quote do ... end` are NOT recorded into frames.
-    They belong to the macro caller, not the macro author. Set `true`
-    only if you specifically need to model the author's lexical view.
+    They belong to the macro caller, not the macro author. Set this to
+    `true` only if you specifically need to model the author's lexical
+    view.
   - `:initial_env` - a `Macro.Env` seeding the base frame, for walking a
-    defmodule body that inherits directives from an enclosing scope.
+    defmodule body that should inherit directives from an enclosing
+    scope.
 
   The module stack is always maintained: `current_module_segments/1`
   returns the absolute segments of the innermost enclosing `defmodule`,
@@ -97,8 +102,8 @@ defmodule AshCredo.Introspection.LexicalScopeWalker do
   @type callback :: (Macro.t(), Scope.t(), user_state() -> user_state())
 
   @typedoc """
-  Walker options (see module docs). `:initial_env` seeds the base env
-  frame - useful when the walker is invoked on a defmodule body that
+  Walker options (see the module docs). `:initial_env` seeds the base
+  env frame; useful when the walker is invoked on a defmodule body that
   should inherit directives from an enclosing scope.
   """
   @type opts :: [
@@ -128,10 +133,11 @@ defmodule AshCredo.Introspection.LexicalScopeWalker do
   def in_quote?(%Scope{quote_depth: depth}), do: depth > 0
 
   @doc """
-  Returns the absolute module segments of the innermost enclosing `defmodule`,
-  or `nil` if there is no enclosing module. Top-level modules have visible
-  aliases applied to their literal segments; nested modules prepend the
-  enclosing path without re-aliasing (matches Elixir's actual resolution).
+  Returns the absolute module segments of the innermost enclosing
+  `defmodule`, or `nil` if there is no enclosing module. Top-level
+  modules have the visible aliases applied to their literal segments;
+  nested modules prepend the enclosing path without re-aliasing the
+  nested name, matching Elixir's actual resolution.
   """
   @spec current_module_segments(Scope.t()) :: [atom()] | nil
   def current_module_segments(%Scope{module_stack: []}), do: nil
@@ -139,11 +145,11 @@ defmodule AshCredo.Introspection.LexicalScopeWalker do
 
   @doc """
   Returns `true` if the current traversal point is lexically inside ANY
-  `defmodule` (including ones with non-literal names like
-  `defmodule Module.concat(...) do ... end`). Distinct from
-  `current_module_segments/1`, which returns `nil` both for "not in a module"
-  AND for "in a module with a non-literal name." Use this when you need to
-  decide whether to skip into a nested-module body.
+  `defmodule`, including ones with non-literal names like
+  `defmodule Module.concat(...) do ... end`. Distinct from
+  `current_module_segments/1`, which returns `nil` both for "not in a
+  module" AND for "in a module with a non-literal name." Use this when
+  you need to decide whether to skip into a nested-module body.
   """
   @spec in_module?(Scope.t()) :: boolean()
   def in_module?(%Scope{module_stack: []}), do: false
@@ -152,8 +158,8 @@ defmodule AshCredo.Introspection.LexicalScopeWalker do
   # ── Public traverse ──
 
   @doc """
-  Walk `ast` with lexical-scope tracking. See module docs for the API,
-  callback timing, and opts.
+  Walks `ast` with lexical-scope tracking. See the module docs for the
+  API, callback timing, and opts.
   """
   @spec traverse(Macro.t(), user_state(), callback(), callback(), opts()) ::
           {user_state(), Scope.t()}
@@ -190,13 +196,13 @@ defmodule AshCredo.Introspection.LexicalScopeWalker do
 
   # Each `enter`/`leave` clause:
   #   1. updates `scope` for its node kind (push frames, capture aliases,
-  #      adjust quote depth, push module stack)
+  #      adjust the quote depth, push the module stack)
   #   2. invokes the user callback with the updated scope
   # The order here matters: more-specific patterns (`:alias`, `:quote`,
   # `:defmodule`) take precedence over the generic scope-key/arrow/extras
-  # patterns. A node that matches multiple kinds (e.g. a `{form, _, _}` that
-  # is also in `lexical_scope_nodes`) is handled by exactly one clause -
-  # follow each clause's chain to confirm.
+  # patterns. A node that matches multiple kinds (e.g. a `{form, _, _}`
+  # that is also in `lexical_scope_nodes`) is handled by exactly one
+  # clause - follow each clause's chain to confirm.
 
   # `capture_directive/3` applies the node to the head env; shapes that
   # create nothing (e.g. a bare `alias __MODULE__`) leave it unchanged.
@@ -243,8 +249,8 @@ defmodule AshCredo.Introspection.LexicalScopeWalker do
     {node, {on_enter.(node, scope, user), scope}}
   end
 
-  # Leave: callback runs with current scope, then we pop. Mirror the enter
-  # clauses so each push has a matching pop.
+  # Leave: the callback runs with the current scope, then we pop. Mirrors
+  # the enter clauses so each push has a matching pop.
 
   defp leave({directive, _, _} = node, {user, scope}, on_leave, _options)
        when directive in [:alias, :require, :import] do
@@ -313,7 +319,7 @@ defmodule AshCredo.Introspection.LexicalScopeWalker do
   end
 
   # A pushed frame starts as a copy of its parent env, so everything
-  # lexically visible stays visible; the pop discards additions made
+  # lexically visible stays visible; the pop discards the additions made
   # inside the scope.
   defp push_env_frame(%Scope{env_frames: frames} = scope) do
     %{scope | env_frames: [env(scope) | frames]}

--- a/lib/ash_credo/introspection/remote_bang_scanner.ex
+++ b/lib/ash_credo/introspection/remote_bang_scanner.ex
@@ -1,20 +1,20 @@
 defmodule AshCredo.Introspection.RemoteBangScanner do
   @moduledoc """
-  Scans a source file's AST for every literal remote bang call -
-  `Mod.fun!(args)` where `Mod` is a literal alias - and yields each as
+  Scans a source file's AST for every literal remote bang call, that is
+  `Mod.fun!(args)` where `Mod` is a literal alias, and yields each as
   `{call_ast, expanded_module_segments, fun_name}`.
 
   Used by `AshCredo.Check.Refactor.RaisingCall`'s compiled-introspection
   pass to find candidate code-interface bang calls.
 
   Aliases are resolved lexically via `LexicalScopeWalker`'s env. The
-  common `alias __MODULE__.Foo` pattern is substituted at declaration
-  time by the walker, and use-site `__MODULE__.Foo.bar!()` segments are
-  substituted here against the enclosing `defmodule`'s absolute segments,
-  so both resolve to the same module as the fully-qualified spelling.
-  Calls with a non-literal module (`apply/3`, variable references, bare
-  `__MODULE__.fun!()`) are skipped, since the call site cannot be
-  resolved to a concrete module at lint time.
+  walker substitutes the common `alias __MODULE__.Foo` pattern at
+  declaration time, and this module substitutes use-site
+  `__MODULE__.Foo.bar!()` segments against the enclosing `defmodule`'s
+  absolute segments, so both resolve to the same module as the fully
+  qualified spelling. Calls with a non-literal module (`apply/3`,
+  variable references, bare `__MODULE__.fun!()`) are skipped, since such
+  a call site cannot be resolved to a concrete module at lint time.
   """
 
   alias AshCredo.Introspection.{Aliases, LexicalScopeWalker}
@@ -47,8 +47,8 @@ defmodule AshCredo.Introspection.RemoteBangScanner do
       # Expand first, substitute second: `expand_alias/2` is a no-op on
       # `__MODULE__`-headed segments, and `resolve_module_self/2` drops
       # calls that cannot resolve to a concrete module (e.g. `__MODULE__`
-      # inside a non-literal `defmodule unquote(...)`) - `Module.concat/1`
-      # would raise on them.
+      # inside a non-literal `defmodule unquote(...)`), on which
+      # `Module.concat/1` would raise.
       resolved =
         segments
         |> Aliases.expand_alias(LexicalScopeWalker.env(scope))

--- a/lib/ash_credo/introspection/resource_context.ex
+++ b/lib/ash_credo/introspection/resource_context.ex
@@ -1,9 +1,9 @@
 defmodule AshCredo.Introspection.ResourceContext do
   @moduledoc """
-  Shared metadata for an Ash resource module discovered in a source file.
-  Produced by `AshCredo.Introspection.resource_contexts/1` and consumed by
-  every Design.* check that needs positional information about the
-  `defmodule` or its `use Ash.Resource` call.
+  Shared metadata for an Ash resource module discovered in a source
+  file. Produced by `AshCredo.Introspection.resource_contexts/1` and
+  consumed by every Design.* check that needs positional information
+  about the `defmodule` or its `use Ash.Resource` call.
 
   `:absolute_segments` is the full enclosing path of the resource's
   `defmodule` name (e.g. `[:MyApp, :Blog, :Post]`), or `nil` when the

--- a/lib/ash_credo/introspection/use_metadata.ex
+++ b/lib/ash_credo/introspection/use_metadata.ex
@@ -1,8 +1,9 @@
 defmodule AshCredo.Introspection.UseMetadata do
   @moduledoc """
-  Location and options of a `use SomeModule, opts` statement found inside a
-  `defmodule` body. Produced by `AshCredo.Introspection`'s `find_use/2`,
-  returned as `nil` when no matching `use` statement is found.
+  Location and options of a `use SomeModule, opts` statement found
+  inside a `defmodule` body. Produced by `AshCredo.Introspection`'s
+  `find_use/2`, which returns `nil` when no matching `use` statement is
+  found.
   """
 
   @enforce_keys [:line, :opts]

--- a/lib/ash_credo/name_filter.ex
+++ b/lib/ash_credo/name_filter.ex
@@ -4,10 +4,10 @@ defmodule AshCredo.NameFilter do
   @doc """
   Returns `true` when `name` matches any entry in `entries`.
 
-  Atom (or other literal) entries match by equality. `Regex` entries match
-  against the stringified name; a non-atom `name` never matches a regex, so
-  non-literal DSL values (e.g. an interpolated field name) fall through to
-  "not matched" instead of crashing.
+  Atom (or other literal) entries match by equality. `Regex` entries
+  match against the stringified name; a non-atom `name` never matches a
+  regex, so non-literal DSL values (e.g. an interpolated field name)
+  fall through to "not matched" instead of crashing.
   """
   def matches_any?(name, entries) do
     Enum.any?(entries, &matches?(name, &1))

--- a/lib/ash_credo/orchestration.ex
+++ b/lib/ash_credo/orchestration.ex
@@ -2,9 +2,10 @@ defmodule AshCredo.Orchestration do
   @moduledoc """
   Shared helpers for coordinating check execution.
 
-  This module holds Credo-facing plumbing that sits above AST introspection,
-  such as iterating resource contexts and building `IssueMeta` once per check
-  run before delegating into rule-specific logic.
+  This module holds Credo-facing plumbing that sits above AST
+  introspection, such as iterating resource contexts and building
+  `IssueMeta` once per check run before delegating into rule-specific
+  logic.
   """
 
   alias AshCredo.Introspection
@@ -40,11 +41,12 @@ defmodule AshCredo.Orchestration do
   end
 
   @doc """
-  Iterates resource contexts and invokes `fun.(resource, context, issue_meta)`
-  only for contexts that (a) have a literal `defmodule` name (so
-  `:absolute_segments` can resolve to a runtime module atom) and (b) declare a
-  non-embedded data layer in `use Ash.Resource`. Contexts failing either
-  filter contribute no issues.
+  Iterates resource contexts and invokes
+  `fun.(resource, context, issue_meta)` only for contexts that (a) have
+  a literal `defmodule` name, so `:absolute_segments` can resolve to a
+  runtime module atom, and (b) declare a non-embedded data layer in
+  `use Ash.Resource`. Contexts failing either filter contribute no
+  issues.
   """
   def flat_map_loadable_resource(%SourceFile{} = source_file, params, fun)
       when is_function(fun, 3) do
@@ -66,11 +68,11 @@ defmodule AshCredo.Orchestration do
   end
 
   @doc """
-  Iterates resource contexts and invokes `fun.(resource, context, issue_meta)`
-  for every context whose `defmodule` name is a literal (so
-  `:absolute_segments` resolves to a runtime module atom). Unlike
-  `flat_map_loadable_resource/3`, applies no data-layer filter - checks that
-  need one apply their own.
+  Iterates resource contexts and invokes
+  `fun.(resource, context, issue_meta)` for every context whose
+  `defmodule` name is a literal (so `:absolute_segments` resolves to a
+  runtime module atom). Unlike `flat_map_loadable_resource/3`, this
+  applies no data-layer filter; checks that need one apply their own.
   """
   def flat_map_named_resource(%SourceFile{} = source_file, params, fun)
       when is_function(fun, 3) do
@@ -84,10 +86,11 @@ defmodule AshCredo.Orchestration do
   end
 
   @doc """
-  Builds the standard "Ash is not loaded" diagnostic that compiled checks
-  emit from `Compiled.with_compiled_check/2`'s missing branch. `check` is
-  the emitting check module; its short name appears in the message and its
-  category/priority shape the issue via `Credo.Check.format_issue/3`.
+  Builds the standard "Ash is not loaded" diagnostic that compiled
+  checks emit from the missing branch of
+  `Compiled.with_compiled_check/2`. `check` is the emitting check
+  module; its short name appears in the message, and its category and
+  priority shape the issue via `Credo.Check.format_issue/3`.
   """
   def ash_missing_issue(issue_meta, check) do
     Check.format_issue(
@@ -103,10 +106,10 @@ defmodule AshCredo.Orchestration do
   end
 
   @doc """
-  Builds the standard "Could not load" diagnostic for `resource`, anchored
-  at the context's `use` line and deduplicated to one issue per module per
-  run via `Compiled.with_unique_not_loadable/2`. Returns a list of zero or
-  one issues.
+  Builds the standard "Could not load" diagnostic for `resource`,
+  anchored at the context's `use` line and deduplicated to one issue per
+  module per run via `Compiled.with_unique_not_loadable/2`. Returns a
+  list of zero or one issues.
   """
   def unique_not_loadable_issues(resource, context, issue_meta, check) do
     CompiledIntrospection.with_unique_not_loadable(resource, fn ->
@@ -124,14 +127,15 @@ defmodule AshCredo.Orchestration do
   end
 
   @doc """
-  Dispatches the result of a `Compiled.inspect_module/1`-style introspection
-  lookup (`inspect_module/1` itself or any accessor built on it, such as
-  `attributes/1` or `actions/1`). Invokes `on_ok.(info)` for `{:ok, info}`,
-  emits the deduplicated "could not load" diagnostic for
-  `{:error, :not_loadable}`, and contributes no issues for any other error.
+  Dispatches the result of a `Compiled.inspect_module/1`-style
+  introspection lookup (`inspect_module/1` itself or any accessor built
+  on it, such as `attributes/1` or `actions/1`). Invokes `on_ok.(info)`
+  for `{:ok, info}`, emits the deduplicated "could not load" diagnostic
+  for `{:error, :not_loadable}`, and contributes no issues for any other
+  error.
 
-  Every compiled resource check funnels its lookup result through here, so the
-  not-loadable handling lives in one place.
+  Every compiled resource check funnels its lookup result through here,
+  so the not-loadable handling lives in one place.
   """
   def with_resource_info(result, resource, context, issue_meta, check, on_ok)
       when is_function(on_ok, 1) do

--- a/lib/ash_credo/path_filter.ex
+++ b/lib/ash_credo/path_filter.ex
@@ -11,16 +11,16 @@ defmodule AshCredo.PathFilter do
   @doc """
   Returns `true` when `filename` matches any entry in `excluded_paths`.
 
-  Entries may be a `Regex` (matched against the full filename) or a binary.
-  Binary entries match as path segments: the filename is excluded when it
-  equals the entry, starts with `entry <> "/"`, or contains
-  `"/" <> entry <> "/"`. That lets `"test"` exclude `test/foo.exs` and
-  `/repo/test/foo.exs` without falsely catching `contest/foo.ex`, and lets
-  `"priv/seeds.exs"` exclude that exact file.
+  Entries may be a `Regex` (matched against the full filename) or a
+  binary. Binary entries match as path segments: the filename is
+  excluded when it equals the entry, starts with `entry <> "/"`, or
+  contains `"/" <> entry <> "/"`. That lets `"test"` exclude
+  `test/foo.exs` and `/repo/test/foo.exs` without falsely catching
+  `contest/foo.ex`, and lets `"priv/seeds.exs"` exclude that exact file.
 
-  Trailing slashes on binary entries are normalised away, so `"test"` and
-  `"test/"` behave identically - existing configs that wrote directory
-  names with a trailing slash continue to work.
+  Trailing slashes on binary entries are normalised away, so `"test"`
+  and `"test/"` behave identically; existing configs that wrote
+  directory names with a trailing slash continue to work.
   """
   def excluded?(filename, excluded_paths) do
     Enum.any?(excluded_paths, &matches?(filename, &1))

--- a/lib/mix/tasks/ash_credo.install.ex
+++ b/lib/mix/tasks/ash_credo.install.ex
@@ -6,7 +6,7 @@ if Code.ensure_loaded?(Igniter) do
     #{@shortdoc}
 
     Adds the `AshCredo` plugin to your `.credo.exs` configuration file.
-    If no `.credo.exs` exists, one will be created with sensible defaults.
+    If no `.credo.exs` exists, one is created with sensible defaults.
 
     ## Example
 
@@ -75,7 +75,7 @@ if Code.ensure_loaded?(Igniter) do
 
       # Each step returns `:error` when the config is not a literal it can
       # navigate. Igniter's updater contract has no clause for a bare
-      # `:error`, so without the `else` that crashes the whole install;
+      # `:error`, so without the `else` that would crash the whole install;
       # degrade to a warning with manual instructions instead.
       with {:ok, configs_zipper} <-
              Common.move_to_cursor(zipper, "%{configs: __cursor__()}"),

--- a/test/ash_credo_test.exs
+++ b/test/ash_credo_test.exs
@@ -36,7 +36,7 @@ defmodule AshCredoTest do
   # Inline annotation used in the main checks table in README.md. Matched
   # loosely because some rows end with `.**` and others continue with
   # ` and **configurable**`.
-  @compiled_annotation "**Requires compiled project"
+  @compiled_annotation "**Requires a compiled project"
 
   # Discovers all check modules from the filesystem. Returns a sorted list of
   # `{category_module, check_module_name, file_path}` tuples - e.g.
@@ -170,7 +170,7 @@ defmodule AshCredoTest do
 
       bullet_block =
         case Regex.run(
-               ~r/\*\*Note: only the following checks are enabled by default.*?\n((?:- `[\w.]+`\n)+)/s,
+               ~r/\*\*Only the following checks are enabled by default.*?\n((?:- `[\w.]+`\n)+)/s,
                readme_content,
                capture: :all_but_first
              ) do

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -4,9 +4,9 @@
 
 AshCredo is a Credo plugin providing static analysis checks for projects
 built with the Ash Framework. Checks cover Ash resources, domains, and the
-code that calls into them. Some checks analyse unexpanded source AST; others
-introspect compiled modules to see the fully-resolved DSL state, including
-anything Spark transformers and extensions contribute.
+code that calls into them. Some checks analyse the unexpanded source AST;
+others introspect compiled modules and see the fully resolved DSL state,
+including anything Spark transformers and extensions contribute.
 
 ## Setup
 
@@ -21,30 +21,30 @@ Register the plugin in `.credo.exs`:
       ]
     }
 
-Projects using Igniter can run `mix igniter.install ash_credo` instead, which
-adds the dependency and registers the plugin.
+Projects using Igniter can run `mix igniter.install ash_credo` instead,
+which adds the dependency and registers the plugin.
 
-Registering the plugin matters: it enables the default checks and sets up the
-run-scoped cache. Checks added directly to `checks:` without the plugin still
-work, but run uncached and without any defaults.
+Registering the plugin matters: it enables the default checks and sets up
+the run-scoped cache. Checks added directly to `checks:` without the
+plugin still work, but they run uncached and without any defaults.
 
 ## Enabling checks
 
 The plugin enables only a small, low-noise set of checks by default; most
-checks are opt-in. Do not guess check names. The authoritative list is the
+checks are opt-in. Don't guess check names. The authoritative list is the
 checks table in the README (<https://ash-credo.hexdocs.pm/readme.html#checks>,
-or `deps/ash_credo/README.md` inside a consuming project), which carries each
-check's category, default state, and configurable parameters, plus a
-ready-to-paste "enable all checks" block. Enable opt-in checks by adding them
-to `checks: %{extra: [...]}` in `.credo.exs`.
+or `deps/ash_credo/README.md` inside a consuming project), which carries
+each check's category, default state, and configurable parameters, plus a
+ready-to-paste "enable all checks" block. Enable opt-in checks by adding
+them to `checks: %{extra: [...]}` in `.credo.exs`.
 
 ## Compile before running
 
-Many checks introspect compiled BEAM modules rather than source AST. Run
-`mix compile` before `mix credo`, for example via an alias:
+Many checks introspect compiled BEAM modules rather than the source AST.
+Run `mix compile` before `mix credo`, for example via an alias:
 
     lint: ["compile", "credo --strict"]
 
 On an uncompiled project those checks emit "could not load" diagnostics
-instead of real results. The affected checks are listed in the README under
-"Checks that require a compiled project".
+instead of real results. The affected checks are listed in the README
+under "Checks that require a compiled project".


### PR DESCRIPTION
## Motivation

The prose across the project had grown uneven: dense multi-clause paragraphs in the README, table cells packed with parenthetical asides, and docstrings that mixed "should" and "must" without a clear rule for which checks are hard requirements and which are suggestions. This rewrite makes the documentation easier to scan and gives the wording a consistent voice.

## Changes

- Rewrite the README: split dense paragraphs, one idea per sentence, warning-first ordering for the compile requirement, and fuller sentences in the checks and parameters tables
- Rewrite `usage-rules.md` in the same style
- Rewrite check `explanations` (check and params) and `@moduledoc`/`@doc` prose across all checks, the introspection layer, cache, orchestration, and Mix tasks
- Apply consistent modality: "must" only for hard requirements (compile-before-credo, wrapper macros), "should"/"may" for recommendations and possibilities
- Rewrite `#` code comments in `lib/` to match
- Update the README consistency-test anchors to the new phrasings
