### PR TITLE
fix: reword AuthorizeFalse guidance to prefer the caller's actor

### DIFF
--- a/lib/ash_credo/check/warning/authorize_false.ex
+++ b/lib/ash_credo/check/warning/authorize_false.ex
@@ -10,13 +10,18 @@ defmodule AshCredo.Check.Warning.AuthorizeFalse do
     explanations: [
       check: """
       Passing `authorize?: false` bypasses Ash authorization entirely, which
-      makes it easy to skip policy checks by accident. Use system actors with
-      bypass policies instead, so authorization stays enforced and auditable.
+      makes it easy to skip policy checks by accident. Prefer passing the
+      caller's actor, so policies stay enforced. Only when no user is acting,
+      such as in background jobs or seeds, use a named system actor with a
+      bypass policy, which keeps the bypass explicit and auditable.
 
           # Bad - skips all authorization
           Ash.read!(query, authorize?: false)
 
-          # Good - uses a named system actor
+          # Good - authorizes as the logged-in user
+          Ash.read!(query, actor: current_user)
+
+          # Good when no user is acting - uses a named system actor
           Ash.read!(query, actor: %{system: :my_context})
 
           # In resource policies:
@@ -75,7 +80,7 @@ defmodule AshCredo.Check.Warning.AuthorizeFalse do
       Enum.map(lines, fn line ->
         format_issue(issue_meta,
           message:
-            "`authorize?: false` bypasses authorization. Use system actors with bypass policies instead.",
+            "`authorize?: false` bypasses authorization. Pass the caller's actor instead; use a system actor with a bypass policy only when no user is acting.",
           trigger: "authorize?: false",
           line_no: line
         )


### PR DESCRIPTION
## Motivation

The AuthorizeFalse issue message named exactly one remedy, "Use system actors with bypass policies instead.", which steers readers (and LLM agents auto-fixing Credo warnings) toward a system-actor bypass even when the call site has a logged-in user available. Passing the caller's actor is the better default because it keeps policies enforced; a system actor with a bypass policy is the fallback for actor-less contexts like background jobs and seeds. Closes #233.

## Changes

- Reword the issue message to recommend passing the caller's actor first and reserve system actors with bypass policies for cases where no user is acting
- Reorder the check explanation to match, adding an `actor: current_user` example ahead of the system-actor one and framing the bypass as the explicit, auditable fallback
