### PR TITLE
Emphasize using scope in calls

### DIFF
--- a/lib/ash_credo/check/warning/authorize_false.ex
+++ b/lib/ash_credo/check/warning/authorize_false.ex
@@ -80,7 +80,7 @@ defmodule AshCredo.Check.Warning.AuthorizeFalse do
       Enum.map(lines, fn line ->
         format_issue(issue_meta,
           message:
-            "`authorize?: false` bypasses authorization. Pass the caller's actor instead; use a system actor with a bypass policy only when no user is acting.",
+            "`authorize?: false` bypasses authorization. Pass the caller's scope or actor instead; use a system actor with a bypass policy only when no user is acting.",
           trigger: "authorize?: false",
           line_no: line
         )

--- a/lib/ash_credo/check/warning/authorize_false.ex
+++ b/lib/ash_credo/check/warning/authorize_false.ex
@@ -80,7 +80,7 @@ defmodule AshCredo.Check.Warning.AuthorizeFalse do
       Enum.map(lines, fn line ->
         format_issue(issue_meta,
           message:
-            "`authorize?: false` bypasses authorization. Pass the caller's scope or actor instead; use a system actor with a bypass policy only when no user is acting.",
+            "`authorize?: false` bypasses authorization. Pass the caller's scope instead; use a system actor with a bypass policy only when no user is acting.",
           trigger: "authorize?: false",
           line_no: line
         )


### PR DESCRIPTION
I try to pass down `scope` in Ash queries instead of actor because I'm using a multi-tenant database and so the `tenant` and `actor` go together (plus any other request-important values set on the scope can be passed down like the Phoenix scopes concept)

EDIT: I actually just changed the message to just say "scope" because that feels like best practice.

But otherwise perhaps it could be configurable. Too much to make the message configurable? Just trying to fight stupid LLM narrow-sightedness